### PR TITLE
fix: set max results to 50 in SSM describeInstancesPatches

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,4 +13,6 @@ jobs:
         with:
           go-version: 1.17.x
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
+        with:
+          args: --timeout 10m

--- a/scrapers/aws/aws.go
+++ b/scrapers/aws/aws.go
@@ -193,7 +193,7 @@ func listPatches(SSM *ssm.Client, ctx v1.ScrapeContext, instanceId string, token
 
 	patches, err := SSM.DescribeInstancePatches(ctx, &ssm.DescribeInstancePatchesInput{
 		InstanceId: &instanceId,
-		MaxResults: 100,
+		MaxResults: 50,
 		NextToken:  token,
 	})
 


### PR DESCRIPTION
Needed to set the MaxResults 50 since we are getting the following error:

```
api error ValidationException: 1 validation error detected: Value '100' at 'maxResults' failed to satisfy constraint: Member must have value less than or equal to 50
```