### PR TITLE
feat: Add GitHub action scraper

### DIFF
--- a/api/v1/github.go
+++ b/api/v1/github.go
@@ -1,0 +1,11 @@
+package v1
+
+import "github.com/flanksource/kommons"
+
+type GitHubActions struct {
+	BaseScraper         `json:",inline"`
+	Owner               string         `yaml:"owner" json:"owner"`
+	Repository          string         `yaml:"repository" json:"repository"`
+	PersonalAccessToken kommons.EnvVar `yaml:"personalAccessToken" json:"personalAccessToken"`
+	Workflows           []string       `yaml:"workflows" json:"workflows"`
+}

--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -18,6 +18,7 @@ type ConfigScraper struct {
 	Kubernetes     []Kubernetes     `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty"`
 	KubernetesFile []KubernetesFile `json:"kubernetesFile,omitempty" yaml:"kubernetesFile,omitempty"`
 	AzureDevops    []AzureDevops    `json:"azureDevops,omitempty" yaml:"azureDevops,omitempty"`
+	GithubActions  []GitHubActions  `json:"githubActions,omitempty" yaml:"githubActions,omitempty"`
 	SQL            []SQL            `json:"sql,omitempty" yaml:"sql,omitempty"`
 }
 

--- a/scrapers/common.go
+++ b/scrapers/common.go
@@ -7,6 +7,7 @@ import (
 	"github.com/flanksource/config-db/scrapers/aws"
 	"github.com/flanksource/config-db/scrapers/azure/devops"
 	"github.com/flanksource/config-db/scrapers/file"
+	"github.com/flanksource/config-db/scrapers/github"
 	"github.com/flanksource/config-db/scrapers/kubernetes"
 	"github.com/flanksource/config-db/scrapers/sql"
 	"github.com/flanksource/kommons"
@@ -21,6 +22,7 @@ var All = []v1.Scraper{
 	kubernetes.KubernetesScraper{},
 	kubernetes.KubernetesFileScraper{},
 	devops.AzureDevopsScraper{},
+	github.GithubActionsScraper{},
 	sql.SqlScraper{},
 }
 

--- a/scrapers/github/client.go
+++ b/scrapers/github/client.go
@@ -1,0 +1,102 @@
+package github
+
+import (
+	"fmt"
+
+	v1 "github.com/flanksource/config-db/api/v1"
+	"github.com/go-resty/resty/v2"
+)
+
+// Workflow represents a gitHub actions workflow object.
+// see https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#get-a-workflow
+type Workflow struct {
+	ID        int    `json:"id"`
+	NodeID    string `json:"node_id"`
+	Name      string `json:"name"`
+	Path      string `json:"path"`
+	State     string `json:"state"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+	Url       string `json:"url"`
+	HtmlURL   string `json:"html_url"`
+	BadgeURL  string `json:"badge_url"`
+}
+
+// Workflows is a list of gitHub actions workflows
+type Workflows struct {
+	Count int        `json:"total_count"`
+	Value []Workflow `json:"value"`
+}
+
+// Run is a gitHub actions workflow runs for a repository.
+// see https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository
+type Run struct {
+	ID                  int               `json:"id"`
+	Name                string            `json:"name"`
+	NodeID              string            `json:"node_id"`
+	CheckSuiteID        int               `json:"check_suite_id"`
+	CheckSuiteNodeID    string            `json:"check_suite_node_id"`
+	HeadBranch          string            `json:"head_branch"`
+	HeadSHA             string            `json:"head_sha"`
+	Path                string            `json:"path"`
+	RunNumber           int               `json:"run_number"`
+	Event               string            `json:"event"`
+	DisplayTitle        string            `json:"display_title"`
+	Status              string            `json:"status"`
+	Conclusion          any               `json:"conclusion"`
+	WorkflowID          int               `json:"workflow_id"`
+	URL                 string            `json:"url"`
+	HtmlURL             string            `json:"html_url"`
+	PullRequests        any               `json:"pull_requests"`
+	CreatedAt           string            `json:"created_at"`
+	UpdatedAt           string            `json:"updated_at"`
+	Actor               map[string]string `json:"actor"`
+	RunAttempt          int               `json:"run_attempt"`
+	ReferencedWorkflows any               `json:"referenced_workflows"`
+	RunStartedAt        string            `json:"run_started_at"`
+	TriggeringActor     map[string]string `json:"triggering_actor"`
+	HeadCommit          map[string]string `json:"head_commit"`
+	Repository          map[string]string `json:"repository"`
+	HeadRepository      map[string]string `json:"head_repository"`
+}
+
+type Runs struct {
+	Count int   `json:"total_count"`
+	Value []Run `json:"value"`
+}
+
+type GitHubActionsClient struct {
+	*resty.Client
+	*v1.ScrapeContext
+}
+
+func NewGitHubActionsClient(ctx *v1.ScrapeContext, gha v1.GitHubActions) (*GitHubActionsClient, error) {
+	client := resty.New().
+		SetBaseURL(fmt.Sprintf("https://api.github.com/repos/%s/%s", gha.Owner, gha.Repository)).
+		SetBasicAuth(gha.Owner, gha.PersonalAccessToken.Value)
+
+	return &GitHubActionsClient{
+		ScrapeContext: ctx,
+		Client:        client,
+	}, nil
+}
+
+func (gh *GitHubActionsClient) GetWorkflows() ([]Workflow, error) {
+	var response Workflows
+	_, err := gh.R().SetResult(&response).Get("/actions/workflows")
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Value, nil
+}
+
+func (gh *GitHubActionsClient) GetWorkflowRuns() ([]Run, error) {
+	var response Runs
+	_, err := gh.R().SetResult(&response).Get("/actions/runs")
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Value, nil
+}

--- a/scrapers/github/client.go
+++ b/scrapers/github/client.go
@@ -30,7 +30,7 @@ func (w Workflow) GetID() string { return fmt.Sprintf("%d/%s", w.ID, w.Name) }
 // Workflows is a list of gitHub actions workflows
 type Workflows struct {
 	Count int        `json:"total_count"`
-	Value []Workflow `json:"value"`
+	Value []Workflow `json:"workflows"`
 }
 
 // Run is a gitHub actions workflow runs for a repository.
@@ -67,7 +67,7 @@ type Run struct {
 
 type Runs struct {
 	Count int   `json:"total_count"`
-	Value []Run `json:"value"`
+	Value []Run `json:"workflow_runs"`
 }
 
 type GitHubActionsClient struct {
@@ -77,6 +77,7 @@ type GitHubActionsClient struct {
 
 func NewGitHubActionsClient(ctx *v1.ScrapeContext, gha v1.GitHubActions) (*GitHubActionsClient, error) {
 	client := resty.New().
+	 	SetHeader("Accept", "application/vnd.github+json").
 		SetBaseURL(fmt.Sprintf("https://api.github.com/repos/%s/%s", gha.Owner, gha.Repository)).
 		SetBasicAuth(gha.Owner, gha.PersonalAccessToken.Value)
 

--- a/scrapers/github/client_test.go
+++ b/scrapers/github/client_test.go
@@ -25,6 +25,7 @@ var testGithubApiClient = func() (*GitHubActionsClient, error) {
 }
 
 var client *GitHubActionsClient
+var workflows []Workflow
 
 func init() {
 	var err error
@@ -35,7 +36,8 @@ func init() {
 }
 
 func TestGetWorkFlows(t *testing.T) {
-	_, err := client.GetWorkflows()
+	var err error
+	workflows, err = client.GetWorkflows()
 	if err != nil {
 		t.Fatalf("error was not expected %v", err)
 	}
@@ -43,11 +45,13 @@ func TestGetWorkFlows(t *testing.T) {
 }
 
 func TestGetWorkFlowRuns(t *testing.T) {
-	_, err := client.GetWorkflowRuns()
-	if err != nil {
-		t.Fatalf("error was not expected %v", err)
+	for _, workflow := range workflows {
+		_, err := client.GetWorkflowRuns(workflow.ID)
+		if err != nil {
+			t.Fatalf("error was not expected %v", err)
+		}
+
+		// (TODO: basebandit) we could probably assert that there is something in the returned runs slice
+
 	}
-
-	// (TODO: basebandit) we could probably assert that there is something in the returned runs slice
-
 }

--- a/scrapers/github/client_test.go
+++ b/scrapers/github/client_test.go
@@ -1,0 +1,53 @@
+package github
+
+import (
+	"os"
+	"testing"
+
+	v1 "github.com/flanksource/config-db/api/v1"
+	"github.com/flanksource/kommons"
+)
+
+var testGithubApiClient = func() (*GitHubActionsClient, error) {
+	textCtx := new(v1.ScrapeContext)
+	ghToken := os.Getenv("GH_ACCESS_TOKEN")
+	testGh := v1.GitHubActions{
+		Owner:               "basebandit",
+		Repository:          "config-db",
+		PersonalAccessToken: kommons.EnvVar{Value: ghToken},
+	}
+	client, err := NewGitHubActionsClient(textCtx, testGh)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+var client *GitHubActionsClient
+
+func init() {
+	var err error
+	client, err = testGithubApiClient()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestGetWorkFlows(t *testing.T) {
+	_, err := client.GetWorkflows()
+	if err != nil {
+		t.Fatalf("error was not expected %v", err)
+	}
+	// (TODO: basebandit) we could probably assert that there is something in the returned workflows slice
+}
+
+func TestGetWorkFlowRuns(t *testing.T) {
+	_, err := client.GetWorkflowRuns()
+	if err != nil {
+		t.Fatalf("error was not expected %v", err)
+	}
+
+	// (TODO: basebandit) we could probably assert that there is something in the returned runs slice
+
+}

--- a/scrapers/github/workflows.go
+++ b/scrapers/github/workflows.go
@@ -1,0 +1,80 @@
+package github
+
+import (
+	"fmt"
+
+	v1 "github.com/flanksource/config-db/api/v1"
+	"github.com/flanksource/config-db/utils"
+)
+
+const WorkflowRun = "GitHubActions::WorkflowRun"
+
+type GithubActionsScraper struct {
+}
+
+// Scrape fetches github workflows and workflow runs from github API and converts the action executions (workflow runs) to change events.
+func (gh GithubActionsScraper) Scrape(ctx *v1.ScrapeContext, configs v1.ConfigScraper) v1.ScrapeResults {
+	results := v1.ScrapeResults{}
+	for _, config := range configs.GithubActions {
+		client, err := NewGitHubActionsClient(ctx, config)
+		if err != nil {
+			results.Errorf(err, "failed to create github actions client for owner %s with repository %v", config.Owner, config.Repository)
+			continue
+		}
+
+		workflows, err := client.GetWorkflows()
+		if err != nil {
+			results.Errorf(err, "failed to get projects for %s", config.Repository)
+			continue
+		}
+
+		for _, workflow := range workflows {
+			if !utils.MatchItems(workflow.Name, config.Workflows...) {
+				continue
+			}
+			fmt.Printf("%v\n", workflow.Name)
+			var uniqueWorkflows = make(map[string]Workflow)
+			fmt.Printf("\t->%v\n", workflow.Name)
+
+			runs, err := client.GetWorkflowRuns(workflow.ID)
+			if err != nil {
+				results.Errorf(err, "failed to get workflow runs for %d/%s", workflow.ID, workflow.Name)
+				continue
+			}
+			var id string
+			var _workflow Workflow
+			for _, run := range runs {
+				id = workflow.GetID()
+				if _, ok := uniqueWorkflows[id]; !ok {
+					uniqueWorkflows[id] = workflow
+				} else {
+					_workflow = uniqueWorkflows[id]
+				}
+				workflow.Runs = append(workflow.Runs, v1.ChangeResult{
+					ChangeType:       "Dispatch",
+					CreatedAt:        &run.CreatedAt,
+					Severity:         run.Conclusion.(string),
+					ExternalID:       id,
+					ExternalType:     WorkflowRun,
+					Source:           run.Event,
+					Details:          v1.NewJSON(run),
+					ExternalChangeID: fmt.Sprintf("%s/%d/%d", workflow.Name, workflow.ID, run.ID),
+				})
+				uniqueWorkflows[id] = _workflow
+			}
+
+			for id, workflow := range uniqueWorkflows {
+				results = append(results, v1.ScrapeResult{
+					Type:         "Deployment",
+					Config:       workflow,
+					ExternalType: WorkflowRun,
+					ID:           id,
+					Name:         workflow.Name,
+					Changes:      workflow.Runs,
+					Aliases:      []string{fmt.Sprintf("%s/%d", workflow.Name, workflow.ID)},
+				})
+			}
+		}
+	}
+	return results
+}


### PR DESCRIPTION
This PR addresses [issue](https://github.com/flanksource/config-db/issues/47) introduces a Github Scraper that retrieves all workflows and their runs using the Github API and creates a new config item per workflow run and record workflow run executions as change events.

## QA Steps
- Unit Tests should pass
- Other steps TBD

