### PR TITLE
fix: nil pointer error in sql scraper

### DIFF
--- a/scrapers/sql/sql.go
+++ b/scrapers/sql/sql.go
@@ -30,7 +30,7 @@ func (s SqlScraper) Scrape(ctx *v1.ScrapeContext, configs v1.ConfigScraper) v1.S
 		connection := config.GetModel()
 		connection, err := duty.HydrateConnection(ctx, ctx.Kubernetes, db.DefaultDB(), connection, ctx.Namespace)
 		if err != nil {
-			results.Errorf(err, "failed to hydrate connection for %s", *connection)
+			results.Errorf(err, "failed to hydrate connection for %s", config.Connection)
 		}
 		db, err := dburl.Open(connection.URL)
 		if err != nil {


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6f1a494]

goroutine 68 [running]:
github.com/flanksource/config-db/scrapers/sql.SqlScraper.Scrape({}, _, {{0xc0003acc30, 0x24}, {0x0, 0x0}, {0xc000b71038, 0x3}, {0x0, 0x0, ...}, ...})
        /app/scrapers/sql/sql.go:33 +0x1b4
github.com/flanksource/config-db/scrapers.Run(0xc00094d2c0, {0xc0024a75b0, 0x1, 0x0?})
        /app/scrapers/runscrapers.go:42 +0x551
github.com/flanksource/config-db/scrapers.RunScraper({{0xc0003acc30, 0x24}, {0x0, 0x0}, {0xc000b71038, 0x3}, {0x0, 0x0, 0x0}, {0x0, ...}, ...})
        /app/scrapers/run.go:21 +0x2e8
github.com/flanksource/config-db/cmd.startScraperCron.func2()
        /app/cmd/server.go:92 +0x58
github.com/flanksource/config-db/cmd.startScraperCron({0xc0005dce60?, 0x0?, 0x2?})
        /app/cmd/server.go:98 +0x165
created by github.com/flanksource/config-db/cmd.serve
        /app/cmd/server.go:52 +0x445

```