### PR TITLE
feat: added timeout flag to Trivy scraper

### DIFF
--- a/api/v1/trivy.go
+++ b/api/v1/trivy.go
@@ -13,6 +13,7 @@ type Trivy struct {
 	LicenseFull     bool     `json:"licenseFull,omitempty" yaml:"licenseFull,omitempty"`
 	Severity        string   `json:"severity,omitempty" yaml:"severity,omitempty"`
 	VulnType        string   `json:"vulnType,omitempty" yaml:"vulnType,omitempty"`
+	Timeout         string   `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 
 	Kubernetes *TrivyK8sOptions `json:"kubernetes,omitempty"`
 }
@@ -47,6 +48,9 @@ func (t Trivy) getCommonArgs() []string {
 	}
 	if t.VulnType != "" {
 		args = append(args, "--vuln-type", t.VulnType)
+	}
+	if t.Timeout != "" {
+		args = append(args, "--timeout", t.Timeout)
 	}
 
 	return args

--- a/fixtures/trivy.yaml
+++ b/fixtures/trivy.yaml
@@ -1,5 +1,6 @@
 trivy:
   - version: "0.40.0"
+    timeout: "10m" # Increased from the default 5m timeout
     kubernetes:
       namespace: default
       context: demo


### PR DESCRIPTION
The default scan timeout on Trivy is 5m which appears to be pretty low for large clusters.
It's failing to scan on our cluster for instance

`k8s scan error: context deadline exceeded`

https://github.com/aquasecurity/trivy/issues/2169#issuecomment-1134766285