### PR TITLE
fix: remove running the same job twice

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -64,33 +64,28 @@ func startScraperCron(configFiles []string) {
 	if err != nil {
 		logger.Fatalf(err.Error())
 	}
+
+	logger.Infof("Persisting %d config files", len(scraperConfigsFiles))
 	for _, scraper := range scraperConfigsFiles {
-		scraperDB, err := db.PersistScrapeConfigFromFile(scraper)
+		_, err := db.PersistScrapeConfigFromFile(scraper)
 		if err != nil {
 			logger.Fatalf("Error persisting scrape config to db: %v", err)
-			continue
 		}
-		_scraper := scraper
-		_scraper.ID = scraperDB.ID.String()
-		scrapers.AddToCron(_scraper, "")
-		fn := func() {
-			if _, err := scrapers.RunScraper(_scraper); err != nil {
-				logger.Errorf("Error running scraper: %v", err)
-			}
-		}
-		defer fn()
 	}
 
 	scraperConfigsDB, err := db.GetScrapeConfigs()
 	if err != nil {
 		logger.Fatalf(err.Error())
 	}
+
+	logger.Infof("Starting %d scrapers", len(scraperConfigsDB))
 	for _, scraper := range scraperConfigsDB {
 		_scraper, err := models.V1ConfigScraper(scraper)
 		if err != nil {
 			logger.Fatalf("Error parsing config scraper: %v", err)
 		}
 		scrapers.AddToCron(_scraper, scraper.ID.String())
+
 		fn := func() {
 			if _, err := scrapers.RunScraper(_scraper); err != nil {
 				logger.Errorf("Error running scraper: %v", err)

--- a/db/config_scraper.go
+++ b/db/config_scraper.go
@@ -50,7 +50,10 @@ func GetScrapeConfigs() ([]models.ConfigScraper, error) {
 
 func PersistScrapeConfigFromFile(configScraperSpec v1.ConfigScraper) (models.ConfigScraper, error) {
 	var configScraper models.ConfigScraper
-	spec, _ := utils.StructToJSON(configScraperSpec)
+	spec, err := utils.StructToJSON(configScraperSpec)
+	if err != nil {
+		return configScraper, fmt.Errorf("error converting scraper spec to JSON: %w", err)
+	}
 
 	// Check if exists
 	tx := db.Table("config_scrapers").Where("spec = ?", spec).Find(&configScraper)
@@ -62,7 +65,6 @@ func PersistScrapeConfigFromFile(configScraperSpec v1.ConfigScraper) (models.Con
 	}
 
 	// Create if not exists
-	var err error
 	configScraper.Spec = spec
 	configScraper.Name, err = configScraperSpec.GenerateName()
 	if err != nil {


### PR DESCRIPTION
Prevent the same config being scraped twice