### PR TITLE
feat: prevent concurrent execution of config scraper jobs

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -62,7 +62,7 @@ func serve(configFiles []string) {
 func startScraperCron(configFiles []string) {
 	scraperConfigsFiles, err := v1.ParseConfigs(configFiles...)
 	if err != nil {
-		logger.Fatalf(err.Error())
+		logger.Fatalf("error parsing config files: %v", err)
 	}
 
 	logger.Infof("Persisting %d config files", len(scraperConfigsFiles))
@@ -75,7 +75,7 @@ func startScraperCron(configFiles []string) {
 
 	scraperConfigsDB, err := db.GetScrapeConfigs()
 	if err != nil {
-		logger.Fatalf(err.Error())
+		logger.Fatalf("error getting configs from database: %v", err)
 	}
 
 	logger.Infof("Starting %d scrapers", len(scraperConfigsDB))
@@ -88,10 +88,10 @@ func startScraperCron(configFiles []string) {
 
 		fn := func() {
 			if _, err := scrapers.RunScraper(_scraper); err != nil {
-				logger.Errorf("Error running scraper: %v", err)
+				logger.Errorf("Error running scraper(id=%s): %v", _scraper.ID, err)
 			}
 		}
-		defer fn()
+		go scrapers.AtomicRunner(_scraper.ID, fn)
 	}
 }
 

--- a/scrapers/cron_test.go
+++ b/scrapers/cron_test.go
@@ -1,0 +1,34 @@
+package scrapers
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAtomicRunner(t *testing.T) {
+	var (
+		id               = "test-id"
+		counter          = 0
+		incrementCounter = func() {
+			time.Sleep(1 * time.Second)
+			counter++
+		}
+	)
+
+	// Execute atomicRunner in multiple goroutines to check if it behaves as expected
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			AtomicRunner(id, incrementCounter)()
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	// If AtomicRunner behaves correctly, counter should be equal to 1, because other goroutines should be blocked
+	if counter != 1 {
+		t.Errorf("AtomicRunner did not behave as expected, expected counter to be 1, got %d", counter)
+	}
+}


### PR DESCRIPTION
Resolves: https://github.com/flanksource/config-db/issues/224

Tested locally with Trivy. Made sure only one instance of Trivy was running

