### PR TITLE
feat: map cloudtrail events' username to a person

### DIFF
--- a/api/v1/interface.go
+++ b/api/v1/interface.go
@@ -100,6 +100,7 @@ type ChangeResult struct {
 	Summary          string
 	Severity         string
 	Source           string
+	CreatedBy        *string
 	CreatedAt        *time.Time
 	Details          map[string]interface{}
 }

--- a/db/models/config_change.go
+++ b/db/models/config_change.go
@@ -12,18 +12,20 @@ import (
 
 // ConfigChange represents the config change database table
 type ConfigChange struct {
-	ExternalID       string     `gorm:"-"`
-	ConfigType       string     `gorm:"-"`
-	ExternalChangeId string     `gorm:"column:external_change_id" json:"external_change_id"`
-	ID               string     `gorm:"primaryKey;unique_index;not null;column:id" json:"id"`
-	ConfigID         string     `gorm:"column:config_id;default:''" json:"config_id"`
-	ChangeType       string     `gorm:"column:change_type" json:"change_type"`
-	Severity         string     `gorm:"column:severity" json:"severity"`
-	Source           string     `gorm:"column:source" json:"source"`
-	Summary          string     `gorm:"column:summary;default:null" json:"summary,omitempty"`
-	Patches          string     `gorm:"column:patches;default:null" json:"patches,omitempty"`
-	Details          v1.JSON    `gorm:"column:details" json:"details,omitempty"`
-	CreatedAt        *time.Time `gorm:"column:created_at" json:"created_at"`
+	ExternalID        string     `gorm:"-"`
+	ConfigType        string     `gorm:"-"`
+	ExternalChangeId  string     `gorm:"column:external_change_id" json:"external_change_id"`
+	ID                string     `gorm:"primaryKey;unique_index;not null;column:id" json:"id"`
+	ConfigID          string     `gorm:"column:config_id;default:''" json:"config_id"`
+	ChangeType        string     `gorm:"column:change_type" json:"change_type"`
+	Severity          string     `gorm:"column:severity" json:"severity"`
+	Source            string     `gorm:"column:source" json:"source"`
+	Summary           string     `gorm:"column:summary;default:null" json:"summary,omitempty"`
+	Patches           string     `gorm:"column:patches;default:null" json:"patches,omitempty"`
+	Details           v1.JSON    `gorm:"column:details" json:"details,omitempty"`
+	CreatedAt         *time.Time `gorm:"column:created_at" json:"created_at"`
+	CreatedBy         *string    `json:"created_by"`
+	ExternalCreatedBy *string    `json:"external_created_by"`
 }
 
 func (c ConfigChange) GetExternalID() v1.ExternalID {
@@ -49,6 +51,7 @@ func NewConfigChangeFromV1(result v1.ScrapeResult, change v1.ChangeResult) *Conf
 		Summary:          change.Summary,
 		Patches:          change.Patches,
 		CreatedAt:        change.CreatedAt,
+		CreatedBy:        change.CreatedBy,
 	}
 	if _change.ExternalID == "" {
 		_change.ExternalID = result.ID

--- a/db/people.go
+++ b/db/people.go
@@ -1,0 +1,23 @@
+package db
+
+import (
+	"context"
+	"errors"
+
+	"github.com/flanksource/duty/models"
+	"gorm.io/gorm"
+)
+
+func FindPersonByEmail(ctx context.Context, email string) (*models.Person, error) {
+	var person models.Person
+	err := db.WithContext(ctx).Where("email = ?", email).First(&person).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return &person, err
+}

--- a/scrapers/aws/aws.go
+++ b/scrapers/aws/aws.go
@@ -967,9 +967,9 @@ func (aws Scraper) Scrape(ctx *v1.ScrapeContext, config v1.ConfigScraper) v1.Scr
 			aws.efs(awsCtx, awsConfig, results)
 			aws.rds(awsCtx, awsConfig, results)
 			aws.config(awsCtx, awsConfig, results)
-			aws.cloudtrail(awsCtx, awsConfig, results)
 			aws.loadBalancers(awsCtx, awsConfig, results)
 			aws.containerImages(awsCtx, awsConfig, results)
+			aws.cloudtrail(awsCtx, awsConfig, results)
 			// We are querying half a million amis, need to optimize for this
 			// aws.ami(awsCtx, awsConfig, results)
 		}

--- a/scrapers/aws/cloudtrail.go
+++ b/scrapers/aws/cloudtrail.go
@@ -48,9 +48,10 @@ var LastEventTime = sync.Map{}
 type CloudTrailEvent struct {
 	UserIdentity struct {
 		Arn            string `json:"arn"`
+		Username       string `json:"userName"`
 		SessionContext struct {
 			SessionIssuer struct {
-				Username string `json:"username"`
+				Username string `json:"userName"`
 			} `json:"sessionIssuer"`
 		} `json:"sessionContext"`
 	} `json:"userIdentity"`
@@ -102,9 +103,12 @@ func (aws Scraper) cloudtrail(ctx *AWSContext, config v1.AWS, results *v1.Scrape
 					continue
 				}
 
-				username := cloudtrailEvent.UserIdentity.SessionContext.SessionIssuer.Username
-				if username != "" {
-					change.CreatedBy = &username
+				if cloudtrailEvent.UserIdentity.Username != "" {
+					change.CreatedBy = &cloudtrailEvent.UserIdentity.Username
+				} else if cloudtrailEvent.UserIdentity.SessionContext.SessionIssuer.Username != "" {
+					change.CreatedBy = &cloudtrailEvent.UserIdentity.SessionContext.SessionIssuer.Username
+				} else if event.Username != nil {
+					change.CreatedBy = event.Username
 				}
 
 				change.Details["Event"] = *event.CloudTrailEvent

--- a/scrapers/aws/cloudtrail.go
+++ b/scrapers/aws/cloudtrail.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -13,33 +14,51 @@ import (
 	v1 "github.com/flanksource/config-db/api/v1"
 )
 
-func lookupEvents(ctx *AWSContext, input *cloudtrail.LookupEventsInput, c chan types.Event) error {
-	logger.Debugf("Looking up events from %s", input.StartTime)
+func lookupEvents(ctx *AWSContext, input *cloudtrail.LookupEventsInput, c chan<- types.Event) error {
+	defer close(c)
+
+	logger.Debugf("Looking up events from %v", input.StartTime)
 	CloudTrail := cloudtrail.NewFromConfig(*ctx.Session)
-	defer func() {
-		close(c)
-	}()
 	events, err := CloudTrail.LookupEvents(ctx, input)
 	if err != nil {
 		return err
 	}
+
 	for _, event := range events.Events {
 		c <- event
 	}
+
 	for events.NextToken != nil {
 		input.NextToken = events.NextToken
 		events, err = CloudTrail.LookupEvents(ctx, input)
 		if err != nil {
 			return err
 		}
+
 		for _, event := range events.Events {
 			c <- event
 		}
 	}
+
 	return nil
 }
 
 var LastEventTime = sync.Map{}
+
+type CloudTrailEvent struct {
+	UserIdentity struct {
+		Arn            string `json:"arn"`
+		SessionContext struct {
+			SessionIssuer struct {
+				Username string `json:"username"`
+			} `json:"sessionIssuer"`
+		} `json:"sessionContext"`
+	} `json:"userIdentity"`
+}
+
+func (t *CloudTrailEvent) FromJSON(j string) error {
+	return json.Unmarshal([]byte(j), t)
+}
 
 func (aws Scraper) cloudtrail(ctx *AWSContext, config v1.AWS, results *v1.ScrapeResults) {
 	if config.Excludes("cloudtrail") {
@@ -74,6 +93,18 @@ func (aws Scraper) cloudtrail(ctx *AWSContext, config v1.AWS, results *v1.Scrape
 					ChangeType:       *event.EventName,
 					Details:          v1.NewJSON(*event.CloudTrailEvent),
 					Source:           fmt.Sprintf("AWS::CloudTrail::%s:%s", ctx.Session.Region, *ctx.Caller.Account),
+				}
+
+				var cloudtrailEvent CloudTrailEvent
+				if err := cloudtrailEvent.FromJSON(ptr.ToString(event.CloudTrailEvent)); err != nil {
+					logger.Warnf("error parsing cloudtrail event: %v", err)
+					ignored++
+					continue
+				}
+
+				username := cloudtrailEvent.UserIdentity.SessionContext.SessionIssuer.Username
+				if username != "" {
+					change.CreatedBy = &username
 				}
 
 				change.Details["Event"] = *event.CloudTrailEvent


### PR DESCRIPTION
Resolves: https://github.com/flanksource/config-db/issues/216

Didn't find any events that actually mapped to a user.

```
select distinct external_created_by from config_changes
+------------------------------------------------------------------+
| external_created_by                                              |
|------------------------------------------------------------------|
| AWSServiceRoleForAmazonEKS                                       |
| eksctl-flanksource-canary-cluster-clus-ServiceRole-1UJQ53DFHT859 |
| spotinst-iam-stack-d5xzp-SpotinstRole-117P4HAZYZJD0              |
| eksctl-flanksource-canary-cluster-NodeInstanceRole-79QOSKKDW3PB  |
+------------------------------------------------------------------+
```