### PR TITLE
feat: group trivy analysis by package names

### DIFF
--- a/api/v1/interface.go
+++ b/api/v1/interface.go
@@ -32,14 +32,15 @@ type Analyzer func(configs []ScrapeResult) AnalysisResult
 type AnalysisType string
 
 const (
-	AnalysisTypeAvailability   AnalysisType = "availability"
-	AnalysisTypeCompliance     AnalysisType = "compliance"
-	AnalysisTypeCost           AnalysisType = "cost"
-	AnalysisTypeOther          AnalysisType = "other"
-	AnalysisTypePerformance    AnalysisType = "performance"
-	AnalysisTypeRecommendation AnalysisType = "recommendation"
-	AnalysisTypeReliability    AnalysisType = "reliability"
-	AnalysisTypeSecurity       AnalysisType = "security"
+	AnalysisTypeAvailability     AnalysisType = "availability"
+	AnalysisTypeCompliance       AnalysisType = "compliance"
+	AnalysisTypeCost             AnalysisType = "cost"
+	AnalysisTypeOther            AnalysisType = "other"
+	AnalysisTypePerformance      AnalysisType = "performance"
+	AnalysisTypeRecommendation   AnalysisType = "recommendation"
+	AnalysisTypeReliability      AnalysisType = "reliability"
+	AnalysisTypeSecurity         AnalysisType = "security"
+	AnalysisTypeMisconfiguration AnalysisType = "misconfiguration"
 )
 
 type Severity string
@@ -51,6 +52,19 @@ const (
 	SeverityLow      Severity = "low"
 	SeverityInfo     Severity = "info"
 )
+
+var severityRank = map[Severity]int{
+	SeverityCritical: 5,
+	SeverityHigh:     4,
+	SeverityMedium:   3,
+	SeverityLow:      2,
+	SeverityInfo:     1,
+}
+
+// IsMoreSevere compares whether s1 is more severe than s2.
+func IsMoreSevere(s1, s2 Severity) bool {
+	return severityRank[s1] > severityRank[s2]
+}
 
 // AnalysisResult ...
 // +kubebuilder:object:generate=false
@@ -147,8 +161,8 @@ func (t ScrapeResults) Errors() []string {
 	return errs
 }
 
-func (t *ScrapeResults) Add(r ScrapeResult) {
-	*t = append(*t, r)
+func (t *ScrapeResults) Add(r ...ScrapeResult) {
+	*t = append(*t, r...)
 }
 
 type RelationshipResult struct {

--- a/api/v1/interface.go
+++ b/api/v1/interface.go
@@ -32,15 +32,14 @@ type Analyzer func(configs []ScrapeResult) AnalysisResult
 type AnalysisType string
 
 const (
-	AnalysisTypeAvailability     AnalysisType = "availability"
-	AnalysisTypeCompliance       AnalysisType = "compliance"
-	AnalysisTypeCost             AnalysisType = "cost"
-	AnalysisTypeOther            AnalysisType = "other"
-	AnalysisTypePerformance      AnalysisType = "performance"
-	AnalysisTypeRecommendation   AnalysisType = "recommendation"
-	AnalysisTypeReliability      AnalysisType = "reliability"
-	AnalysisTypeSecurity         AnalysisType = "security"
-	AnalysisTypeMisconfiguration AnalysisType = "misconfiguration"
+	AnalysisTypeAvailability   AnalysisType = "availability"
+	AnalysisTypeCompliance     AnalysisType = "compliance"
+	AnalysisTypeCost           AnalysisType = "cost"
+	AnalysisTypeOther          AnalysisType = "other"
+	AnalysisTypePerformance    AnalysisType = "performance"
+	AnalysisTypeRecommendation AnalysisType = "recommendation"
+	AnalysisTypeReliability    AnalysisType = "reliability"
+	AnalysisTypeSecurity       AnalysisType = "security"
 )
 
 type Severity string

--- a/db/update.go
+++ b/db/update.go
@@ -143,7 +143,7 @@ func updateChange(ctx *v1.ScrapeContext, result *v1.ScrapeResult) error {
 
 		id, err := FindConfigItemID(change.GetExternalID())
 		if id == nil {
-			logger.Warnf("[%s/%s] unable to find config item for change: %v", change.ConfigType, change.ExternalID, change.ChangeType)
+			logger.Warnf("[Source=%s] [%s/%s] unable to find config item for change: %v", change.Source, change.ConfigType, change.ExternalID, change.ChangeType)
 			return nil
 		} else if err != nil {
 			return err

--- a/db/update.go
+++ b/db/update.go
@@ -163,7 +163,7 @@ func updateAnalysis(ctx *v1.ScrapeContext, result *v1.ScrapeResult) error {
 	analysis := result.AnalysisResult.ToConfigAnalysis()
 	ci, err := GetConfigItem(analysis.ConfigType, analysis.ExternalID)
 	if ci == nil {
-		logger.Warnf("[%s/%s] unable to find config item for analysis: %+v", analysis.ConfigType, analysis.ExternalID, analysis)
+		logger.Warnf("[Source=%s] [%s/%s] unable to find config item for analysis: %+v", analysis.Source, analysis.ConfigType, analysis.ExternalID, analysis)
 		return nil
 	} else if err != nil {
 		return err

--- a/scrapers/trivy/models.go
+++ b/scrapers/trivy/models.go
@@ -1,6 +1,8 @@
 package trivy
 
-import "time"
+import (
+	"time"
+)
 
 type TrivyResponse struct {
 	ClusterName       string     `json:"ClusterName"`
@@ -19,7 +21,7 @@ type Result struct {
 	Target            string                  `json:"Target"`
 	Class             string                  `json:"Class"`
 	Type              string                  `json:"Type"`
-	Vulnerabilities   []DetectedVulnerability `json:"Vulnerabilities"`
+	Vulnerabilities   DetectedVulnerabilities `json:"Vulnerabilities"`
 	MisconfSummary    *MisconfSummary         `json:"MisconfSummary"`
 	Misconfigurations []Misconfiguration      `json:"Misconfigurations"`
 }
@@ -77,6 +79,18 @@ type DetectedVulnerability struct {
 	// Embed vulnerability details
 	Vulnerability
 }
+
+type DetectedVulnerabilities []DetectedVulnerability
+
+func (t DetectedVulnerabilities) GroupByPkg() map[string][]DetectedVulnerability {
+	output := make(map[string][]DetectedVulnerability)
+	for _, v := range t {
+		output[v.PkgName] = append(output[v.PkgName], v)
+	}
+
+	return output
+}
+
 type Layer struct {
 	Digest string `json:"Digest"`
 	DiffID string `json:"DiffID"`

--- a/scrapers/trivy/trivy.go
+++ b/scrapers/trivy/trivy.go
@@ -111,7 +111,7 @@ func getAnalysis(trivyResponse TrivyResponse) v1.ScrapeResults {
 						ConfigType:   fmt.Sprintf("Kubernetes::%s", resource.Kind),
 						ExternalID:   fmt.Sprintf("Kubernetes/%s/%s/%s", resource.Kind, resource.Namespace, resource.Name),
 						Analysis:     misconfigurationJSON,
-						AnalysisType: v1.AnalysisTypeMisconfiguration,
+						AnalysisType: v1.AnalysisTypeSecurity,
 						Analyzer:     misconfiguration.Title,
 						Messages:     []string{misconfiguration.Description, misconfiguration.Message},
 						Severity:     mapSeverity(misconfiguration.Severity),

--- a/scrapers/trivy/trivy.go
+++ b/scrapers/trivy/trivy.go
@@ -55,32 +55,77 @@ func (t Scanner) Scrape(ctx *v1.ScrapeContext, configs v1.ConfigScraper) v1.Scra
 				continue
 			}
 
-			for _, resource := range trivyResponse.Vulnerabilities {
-				for _, result := range resource.Results {
-					for _, vulnerability := range result.Vulnerabilities {
-						analysis, err := utils.ToJSONMap(vulnerability)
-						if err != nil {
-							logger.Errorf("failed to extract analysis: %v", err)
-						}
+			results.Add(getAnalysis(trivyResponse)...)
+		}
+	}
 
-						results.Add(v1.ScrapeResult{
-							AnalysisResult: &v1.AnalysisResult{
-								ConfigType:   fmt.Sprintf("Kubernetes::%s", resource.Kind),
-								ExternalID:   fmt.Sprintf("Kubernetes/%s/%s/%s", resource.Kind, resource.Namespace, resource.Name),
-								Analysis:     analysis,
-								AnalysisType: v1.AnalysisTypeSecurity, // It's always security related.
-								Analyzer:     fmt.Sprintf("%s [%s]", vulnerability.PkgName, vulnerability.VulnerabilityID),
-								Messages:     []string{vulnerability.Description},
-								Severity:     mapSeverity(vulnerability.Severity),
-								Source:       "Trivy",
-								Summary:      vulnerability.Title,
-							},
-						})
-					}
+	return results
+}
+
+// getAnalysis returns the ScrapeResults obtained by extracting the analysis from the TrivyResponse vulnerabilities.
+func getAnalysis(trivyResponse TrivyResponse) v1.ScrapeResults {
+	var results v1.ScrapeResults
+	for _, resource := range trivyResponse.Vulnerabilities {
+		for _, result := range resource.Results {
+			for pkg, vulnerabilities := range result.Vulnerabilities.GroupByPkg() {
+				groupedResult := v1.ScrapeResult{
+					AnalysisResult: &v1.AnalysisResult{
+						AnalysisType: v1.AnalysisTypeSecurity,
+						Analyzer:     pkg,
+						ConfigType:   fmt.Sprintf("Kubernetes::%s", resource.Kind),
+						ExternalID:   fmt.Sprintf("Kubernetes/%s/%s/%s", resource.Kind, resource.Namespace, resource.Name),
+						Severity:     mapSeverity(vulnerabilities[0].Severity),
+						Source:       "Trivy",
+						Summary:      pkg,
+					},
 				}
+
+				groupedResult.AnalysisResult.Analysis = make(map[string]any)
+				for _, vulnerability := range vulnerabilities {
+					analysis, err := utils.ToJSONMap(vulnerability)
+					if err != nil {
+						logger.Errorf("failed to extract analysis: %v", err)
+					} else {
+						groupedResult.AnalysisResult.Analysis[vulnerability.Title] = analysis
+					}
+
+					if v1.IsMoreSevere(mapSeverity(vulnerability.Severity), groupedResult.AnalysisResult.Severity) {
+						groupedResult.AnalysisResult.Severity = mapSeverity(vulnerability.Severity)
+					}
+
+					groupedResult.AnalysisResult.Messages = append(groupedResult.AnalysisResult.Messages, vulnerability.Description)
+				}
+
+				results.Add(groupedResult)
 			}
 		}
 	}
+
+	// TODO: This should be parsed in a different manner.
+	// for _, resource := range trivyResponse.Misconfigurations {
+	// 	for _, result := range resource.Results {
+	// 		for _, vulnerability := range result.Vulnerabilities {
+	// 			analysis, err := utils.ToJSONMap(vulnerability)
+	// 			if err != nil {
+	// 				logger.Errorf("failed to extract analysis: %v", err)
+	// 			}
+
+	// 			results.Add(v1.ScrapeResult{
+	// 				AnalysisResult: &v1.AnalysisResult{
+	// 					ConfigType:   fmt.Sprintf("Kubernetes::%s", resource.Kind),
+	// 					ExternalID:   fmt.Sprintf("Kubernetes/%s/%s/%s", resource.Kind, resource.Namespace, resource.Name),
+	// 					Analysis:     analysis,
+	// 					AnalysisType: v1.AnalysisTypeMisconfiguration,
+	// 					Analyzer:     fmt.Sprintf("%s [%s]", vulnerability.PkgName, vulnerability.VulnerabilityID),
+	// 					Messages:     []string{vulnerability.Description},
+	// 					Severity:     mapSeverity(vulnerability.Severity),
+	// 					Source:       "Trivy",
+	// 					Summary:      vulnerability.Title,
+	// 				},
+	// 			})
+	// 		}
+	// 	}
+	// }
 
 	return results
 }


### PR DESCRIPTION
Resolves: https://github.com/flanksource/config-db/issues/238

* Grouping by pkg name. Reduced from ~470 analysis reports to just ~90 reports
* Store misconfigurations as well in addition to vulnerabilities.