### PR TITLE
fix: generate id for kubernetes components which dont have one

### DIFF
--- a/scrapers/kubernetes/kubernetes.go
+++ b/scrapers/kubernetes/kubernetes.go
@@ -56,6 +56,11 @@ func (kubernetes KubernetesScraper) Scrape(ctx *v1.ScrapeContext, configs v1.Con
 		resourceIDMap[""]["Cluster"]["selfRef"] = clusterID // For shorthand
 
 		for _, obj := range objs {
+			if string(obj.GetUID()) == "" {
+				logger.Warnf("Found kubernetes object with no resource ID: %s/%s/%s", obj.GetKind(), obj.GetNamespace(), obj.GetName())
+				continue
+			}
+
 			if obj.GetKind() == "Event" {
 				reason, _ := obj.Object["reason"].(string)
 				if utils.MatchItems(reason, config.Event.Exclusions...) {


### PR DESCRIPTION
Fix errors like these:
```
2023-06-16T08:32:48.465+0530	ERROR	Error scraping : failed to extract attributes: no id defined for: ComponentStatus/etcd-0 (): id= name= type= transform= exclude=[{$.status.lastCheck} {$.status.lastTransitionedTime} {$.status.checkStatus.*.lastTransitionedTime}]
2023-06-16T08:32:48.466+0530	ERROR	Error scraping : failed to extract attributes: no id defined for: ComponentStatus/controller-manager (): id= name= type= transform= exclude=[{$.status.lastCheck} {$.status.lastTransitionedTime} {$.status.checkStatus.*.lastTransitionedTime}]
2023-06-16T08:32:48.466+0530	ERROR	Error scraping : failed to extract attributes: no id defined for: ComponentStatus/scheduler (): id= name= type= transform= exclude=[{$.status.lastCheck} {$.status.lastTransitionedTime} {$.status.checkStatus.*.lastTransitionedTime}]
```