### PR TITLE
fix: add -sa suffix in default service account name

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -14,7 +14,7 @@ Create chart name and version as used by the chart label.
 
 {{/* Create the name of config-db service account */}}
 {{- define "config-db.serviceAccountName" -}}
-{{ .Values.serviceAccount.name | default (include "config-db.name" .) }}
+{{ .Values.serviceAccount.name | default ( printf "%s-sa" (include "config-db.name" .)) }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Chart upgradation failing
```
Helm upgrade failed: error while running post render on files: no matches for Id ServiceAccount.v1.[noGrp]/config-db-sa.[noNs]; failed to find unique target for patch ServiceAccount.v1.[noGrp]/config-db-sa.[noNs]

```