### PR TITLE
fix: copy namespace from scrape result to config item

### DIFF
--- a/db/config.go
+++ b/db/config.go
@@ -147,6 +147,7 @@ func NewConfigItemFromResult(result v1.ScrapeResult) (*models.ConfigItem, error)
 		ConfigClass: result.ConfigClass,
 		Type:        &result.Type,
 		Name:        &result.Name,
+		Namespace:   &result.Namespace,
 		Source:      &result.Source,
 		Tags:        &result.Tags,
 		Config:      &dataStr,

--- a/fixtures/expected/file-git.json
+++ b/fixtures/expected/file-git.json
@@ -61,6 +61,13 @@
             "display": {
               "template": "code={{.code}}, age={{.sslAge}}"
             }
+          },
+          {
+            "name": "http-headers",
+            "test": {
+              "expr": "json.headers[\"User-Agent\"].startsWith(\"canary-checker/\")"
+            },
+            "url": "https://httpbin.demo.aws.flanksource.com/headers"
           }
         ]
       }


### PR DESCRIPTION
Right now, namespace for all kubernetes objects is empty