### PR TITLE
fix: nil pointer panic on error logging for job history ctx

### DIFF
--- a/scrapers/runscrapers.go
+++ b/scrapers/runscrapers.go
@@ -70,14 +70,15 @@ func Run(ctx api.ScrapeContext) ([]v1.ScrapeResult, error) {
 			continue
 		}
 
-		jobHistory := models.JobHistory{
-			Name:         fmt.Sprintf("scraper:%T", scraper),
-			ResourceType: "config_scraper",
-			ResourceID:   string(ctx.ScrapeConfig().GetUID()),
-		}
+		jobHistory := models.NewJobHistory(
+			ctx.DutyContext().Logger,
+			fmt.Sprintf("scraper:%T", scraper),
+			"config_scraper",
+			string(ctx.ScrapeConfig().GetUID()),
+		)
 
 		jobHistory.Start()
-		if err := db.PersistJobHistory(&jobHistory); err != nil {
+		if err := db.PersistJobHistory(jobHistory); err != nil {
 			logger.Errorf("Error persisting job history: %v", err)
 		}
 
@@ -100,7 +101,7 @@ func Run(ctx api.ScrapeContext) ([]v1.ScrapeResult, error) {
 		}
 
 		jobHistory.End()
-		if err := db.PersistJobHistory(&jobHistory); err != nil {
+		if err := db.PersistJobHistory(jobHistory); err != nil {
 			logger.Errorf("Error persisting job history: %v", err)
 		}
 	}


### PR DESCRIPTION
```
Error scraping : operation error CloudTrail: LookupEvents, exceeded maximum number of attempts, 3, https response error StatusCode: 400, RequestID: 7d6808be-63c3-4b2c-904b-a8ac539007bf, api error ThrottlingException: Rate exceeded
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x88 pc=0x32cdfec]

goroutine 108 [running]:
github.com/flanksource/duty/models.(*JobHistory).AddError(0xc000d5b450, {0xc004448540, 0xd5})
	/go/pkg/mod/github.com/flanksource/duty@v1.0.321/models/job_history.go:101 +0xec
github.com/flanksource/config-db/scrapers.Run({0x8d9f890, 0xc000d23310})
	/app/scrapers/runscrapers.go:91 +0xa6d
github.com/flanksource/config-db/scrapers.RunScraper({0x8d9f890, 0xc000d23310})
	/app/scrapers/run.go:12 +0x3b
github.com/flanksource/config-db/cmd.startScraperCron.func1()
	/app/cmd/server.go:115 +0x45
github.com/flanksource/config-db/scrapers.AtomicRunner.func1()
	/app/scrapers/cron.go:38 +0x1a5
created by github.com/flanksource/config-db/cmd.startScraperCron
	/app/cmd/server.go:119 +0x86b
	```