### PR TITLE
chore: handle nil conversion in k8s scraper

### DIFF
--- a/scrapers/kubernetes/kubernetes.go
+++ b/scrapers/kubernetes/kubernetes.go
@@ -334,21 +334,22 @@ func extractResults(ctx context.Context, config v1.Kubernetes, objs []*unstructu
 
 		if obj.GetKind() == "Service" {
 			if spec, ok := obj.Object["spec"].(map[string]any); ok {
-				serviceType := spec["type"].(string)
-				tags["service-type"] = serviceType
+				if serviceType, ok := spec["type"].(string); ok {
+					tags["service-type"] = serviceType
 
-				if serviceType == "LoadBalancer" {
-					if status, ok := obj.Object["status"].(map[string]any); ok {
-						if lb, ok := status["loadBalancer"].(map[string]any); ok {
-							if ingresses, ok := lb["ingress"].([]any); ok {
-								for _, ing := range ingresses {
-									if ingress, ok := ing.(map[string]any); ok {
-										if hostname, ok := ingress["hostname"].(string); ok && hostname != "" {
-											tags["hostname"] = hostname
-										}
+					if serviceType == "LoadBalancer" {
+						if status, ok := obj.Object["status"].(map[string]any); ok {
+							if lb, ok := status["loadBalancer"].(map[string]any); ok {
+								if ingresses, ok := lb["ingress"].([]any); ok {
+									for _, ing := range ingresses {
+										if ingress, ok := ing.(map[string]any); ok {
+											if hostname, ok := ingress["hostname"].(string); ok && hostname != "" {
+												tags["hostname"] = hostname
+											}
 
-										if ip, ok := ingress["ip"].(string); ok && ip != "" {
-											tags["ip"] = ip
+											if ip, ok := ingress["ip"].(string); ok && ip != "" {
+												tags["ip"] = ip
+											}
 										}
 									}
 								}


### PR DESCRIPTION
@dabasvibhor Was facing this error in BCB

```log
 2024-03-05T09:45:10.547    DEBUG    excluding event object    {"name": "pg-test-app", "namespace": "mission-control", "reason": "Created"}
 panic: interface conversion: interface {} is nil, not string

goroutine 89 [running]:
github.com/flanksource/config-db/scrapers/kubernetes.extractResults({{{0x8f1ccf8, 0xc00ea3f5c0}, {0x8f51c20, 0xc0008ac630}, 0x0, 0x0, 0x85aeac8, 0x85aead0, {0x8effbd8, 0xc000451
740}}}, ...)
    /app/scrapers/kubernetes/kubernetes.go:337 +0x4c14
github.com/flanksource/config-db/scrapers/kubernetes.KubernetesScraper.Scrape({}, {0x8f554d0, 0xc00023f9f0})
    /app/scrapers/kubernetes/kubernetes.go:93 +0x315
github.com/flanksource/config-db/scrapers.Run({0x8f554d0, 0xc00023f9f0})
    /app/scrapers/runscrapers.go:44 +0x35d
github.com/flanksource/config-db/scrapers.RunScraper({0x8f554d0, 0xc00023f9a0})
    /app/scrapers/run.go:22 +0xb0
github.com/flanksource/config-db/scrapers.newScrapeJob.func1({{{{0x8f1ccf8, 0xc000c728a0}, {0x8f51c20, 0xc000c72810}, 0x0, 0x0, 0x85aeac8, 0x85aead0, {0x8effbd8, 0xc000451740}}}
, ...})
    /app/scrapers/cron.go:130 +0x45
github.com/flanksource/duty/job.(*Job).Run(0xc0005d2840)
    /go/pkg/mod/github.com/flanksource/duty@v1.0.356/job/job.go:352 +0x7d5
github.com/flanksource/duty/job.(*Job).AddToScheduler(0xc0005d2840, 0xc000c7fd60)
    /go/pkg/mod/github.com/flanksource/duty@v1.0.356/job/job.go:508 +0x52c
github.com/flanksource/config-db/scrapers.newScrapeJob({0x8f554d0, 0xc00023ef00})
    /app/scrapers/cron.go:140 +0x6b9
github.com/flanksource/config-db/scrapers.SyncScrapeJob({0x8f554d0, 0xc00023ef00})
    /app/scrapers/cron.go:103 +0x466
github.com/flanksource/config-db/scrapers.SyncScrapeConfigs.func1({{{{0x8f1ccf8, 0xc0001f47b0}, {0x8f51c20, 0xc0001f46f0}, 0x0, 0x0, 0x85aeac8, 0x85aead0, {0x8effbd8, 0xc0004517
40}}}, ...})
    /app/scrapers/cron.go:52 +0x48b
github.com/flanksource/duty/job.(*Job).Run(0xc0005d2160)
    /go/pkg/mod/github.com/flanksource/duty@v1.0.356/job/job.go:352 +0x7d5
github.com/flanksource/duty/job.(*Job).AddToScheduler(0xc0005d2160, 0xc000c7fd60)
    /go/pkg/mod/github.com/flanksource/duty@v1.0.356/job/job.go:508 +0x52c
github.com/flanksource/config-db/scrapers.SyncScrapeConfigs({0x8f554d0, 0xc0007e4960})
```