### PR TITLE
chore: update labels key in kubernetes fixture

### DIFF
--- a/fixtures/kubernetes.yaml
+++ b/fixtures/kubernetes.yaml
@@ -106,7 +106,7 @@ spec:
           - controllerrevision
           - certificaterequest
           - orders.acme.cert-manager.io
-        label:
+        labels:
           canary-checker.flanksource.com/generated: 'true'
       relationships:
         - kind:


### PR DESCRIPTION
```
Error from server (BadRequest): error when creating "fixtures/kubernetes.yaml": ScrapeConfig in version "v1" cannot be handled as a ScrapeConfig: strict decoding error: unknown field "spec.kubernetes[0].exclusions.label"
```