### PR TITLE
fix: incorrect tags 

### DIFF
--- a/scrapers/kubernetes/events_watch.go
+++ b/scrapers/kubernetes/events_watch.go
@@ -2,11 +2,18 @@ package kubernetes
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/flanksource/commons/logger"
+	"github.com/flanksource/duty/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
 	"github.com/flanksource/config-db/api"
 	v1 "github.com/flanksource/config-db/api/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -20,10 +27,16 @@ var (
 // WatchEvents watches Kubernetes events for any config changes & fetches
 // the referenced config items in batches.
 func WatchEvents(ctx api.ScrapeContext, config v1.Kubernetes) error {
-	ctx.Logger.V(1).Infof("Watching kubernetes events. namespace=%s cluster=%s", config.Namespace, config.ClusterName)
-
 	buffer := make(chan v1.KubernetesEvent, ctx.DutyContext().Properties().Int("kubernetes.watch.events.bufferSize", BufferSize))
 	WatchEventBuffers[config.Hash()] = buffer
+
+	if config.Kubeconfig != nil {
+		var err error
+		ctx, err = applyKubeconfig(ctx, *config.Kubeconfig)
+		if err != nil {
+			return fmt.Errorf("failed to apply kube config")
+		}
+	}
 
 	watcher, err := ctx.Kubernetes().CoreV1().Events(config.Namespace).Watch(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -50,4 +63,61 @@ func WatchEvents(ctx api.ScrapeContext, config v1.Kubernetes) error {
 	}
 
 	return nil
+}
+
+func applyKubeconfig(ctx api.ScrapeContext, kubeConfig types.EnvVar) (api.ScrapeContext, error) {
+	val, err := ctx.GetEnvValueFromCache(kubeConfig)
+	if err != nil {
+		return ctx, fmt.Errorf("failed to get kubeconfig from env: %w", err)
+	}
+
+	if strings.HasPrefix(val, "/") {
+		kube, err := newKubeClientWithConfigPath(val)
+		if err != nil {
+			return ctx, fmt.Errorf("failed to initialize kubernetes client from the provided kubeconfig: %w", err)
+		}
+
+		ctx.Context = ctx.WithKubernetes(kube)
+	} else {
+		kube, err := newKubeClientWithConfig(val)
+		if err != nil {
+			return ctx, fmt.Errorf("failed to initialize kubernetes client from the provided kubeconfig: %w", err)
+		}
+
+		ctx.Context = ctx.WithKubernetes(kube)
+	}
+
+	return ctx, nil
+}
+
+func newKubeClientWithConfigPath(kubeConfigPath string) (kubernetes.Interface, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	if err != nil {
+		return fake.NewSimpleClientset(), err
+	}
+
+	return kubernetes.NewForConfig(config)
+}
+
+func newKubeClientWithConfig(kubeConfig string) (kubernetes.Interface, error) {
+	getter := func() (*clientcmdapi.Config, error) {
+		clientCfg, err := clientcmd.NewClientConfigFromBytes([]byte(kubeConfig))
+		if err != nil {
+			return nil, err
+		}
+
+		apiCfg, err := clientCfg.RawConfig()
+		if err != nil {
+			return nil, err
+		}
+
+		return &apiCfg, nil
+	}
+
+	config, err := clientcmd.BuildConfigFromKubeconfigGetter("", getter)
+	if err != nil {
+		return fake.NewSimpleClientset(), err
+	}
+
+	return kubernetes.NewForConfig(config)
 }

--- a/scrapers/processors/json.go
+++ b/scrapers/processors/json.go
@@ -400,7 +400,7 @@ func (e Extract) Extract(ctx context.Context, inputs ...v1.ScrapeResult) ([]v1.S
 			if extracted, err := e.extractAttributes(result); err != nil {
 				return results, fmt.Errorf("failed to extract attributes: %v", err)
 			} else {
-				ctx.Logger.V(3).Infof("Scraped %s", extracted)
+				ctx.Logger.V(1).Infof("Scraped %s", extracted)
 				results = append(results, extracted)
 			}
 		}


### PR DESCRIPTION
resolves: https://github.com/flanksource/config-db/issues/480

configs were incorrectly tagged because watch kubernetes event job wasn't using the custom kubeconfig at all. So it would always watch events on the default kubeconfig cluster and then tag the scraped configs with a different cluster.