### PR TITLE
fix: duplicate watch jobs for kubernetes scraper

### DIFF
--- a/db/config_scraper.go
+++ b/db/config_scraper.go
@@ -81,7 +81,7 @@ func PersistScrapeConfigFromCRD(ctx context.Context, scrapeConfig *v1.ScrapeConf
 
 func GetScrapeConfigsOfAgent(ctx api.ScrapeContext, agentID uuid.UUID) ([]models.ConfigScraper, error) {
 	var configScrapers []models.ConfigScraper
-	err := ctx.DB().Find(&configScrapers, "agent_id = ?", agentID).Error
+	err := ctx.DB().Where("deleted_at IS NULL").Find(&configScrapers, "agent_id = ?", agentID).Error
 	return configScrapers, err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -295,7 +295,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
-// replace github.com/flanksource/duty => ../duty
+replace github.com/flanksource/duty => ../duty
 
 // replace github.com/flanksource/postq => ../postq
 

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/fergusstrange/embedded-postgres v1.25.0
 	github.com/flanksource/commons v1.22.1
-	github.com/flanksource/duty v1.0.415
+	github.com/flanksource/duty v1.0.418
 	github.com/flanksource/is-healthy v1.0.1
 	github.com/flanksource/ketall v1.1.5
 	github.com/flanksource/mapstructure v1.6.0
@@ -295,7 +295,9 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
-replace github.com/flanksource/duty => ../duty
+// replace github.com/flanksource/duty => ../duty
+
+// replace github.com/flanksource/ketall => ../ketall
 
 // replace github.com/flanksource/postq => ../postq
 

--- a/go.sum
+++ b/go.sum
@@ -845,8 +845,6 @@ github.com/fergusstrange/embedded-postgres v1.25.0 h1:sa+k2Ycrtz40eCRPOzI7Ry7Ttk
 github.com/fergusstrange/embedded-postgres v1.25.0/go.mod h1:t/MLs0h9ukYM6FSt99R7InCHs1nW0ordoVCcnzmpTYw=
 github.com/flanksource/commons v1.22.1 h1:Ycg8r26bx537UTdAEFgngDW1r2j5bX6Lr3NGxLICpiw=
 github.com/flanksource/commons v1.22.1/go.mod h1:GD5+yGvmYFPIW3WMNN+y1JkeDMJY74e05pQAsRbrvwY=
-github.com/flanksource/duty v1.0.415 h1:pwEfYQoPXNW4SGfev90lIIGaaU7wJKYFgWfI7tdc2ic=
-github.com/flanksource/duty v1.0.415/go.mod h1:qQm7wt7TlqV6TFn+PU98bQIYCCau5/3baepXGTQRtV4=
 github.com/flanksource/gomplate/v3 v3.20.4/go.mod h1:27BNWhzzSjDed1z8YShO6W+z6G9oZXuxfNFGd/iGSdc=
 github.com/flanksource/gomplate/v3 v3.24.2 h1:WZSriw1MaBhzrDV1IOP9eNsupIPxIHy0yTaMOVhCvsk=
 github.com/flanksource/gomplate/v3 v3.24.2/go.mod h1:94BxYobZqouGdVezuz6LNto5C+yLMG0LnNnM9CUPyoo=

--- a/go.sum
+++ b/go.sum
@@ -845,6 +845,8 @@ github.com/fergusstrange/embedded-postgres v1.25.0 h1:sa+k2Ycrtz40eCRPOzI7Ry7Ttk
 github.com/fergusstrange/embedded-postgres v1.25.0/go.mod h1:t/MLs0h9ukYM6FSt99R7InCHs1nW0ordoVCcnzmpTYw=
 github.com/flanksource/commons v1.22.1 h1:Ycg8r26bx537UTdAEFgngDW1r2j5bX6Lr3NGxLICpiw=
 github.com/flanksource/commons v1.22.1/go.mod h1:GD5+yGvmYFPIW3WMNN+y1JkeDMJY74e05pQAsRbrvwY=
+github.com/flanksource/duty v1.0.418 h1:eqff2Xn3KMhWIBBvED+U3CohE3OAiDTmEo+le7cB/UQ=
+github.com/flanksource/duty v1.0.418/go.mod h1:qQm7wt7TlqV6TFn+PU98bQIYCCau5/3baepXGTQRtV4=
 github.com/flanksource/gomplate/v3 v3.20.4/go.mod h1:27BNWhzzSjDed1z8YShO6W+z6G9oZXuxfNFGd/iGSdc=
 github.com/flanksource/gomplate/v3 v3.24.2 h1:WZSriw1MaBhzrDV1IOP9eNsupIPxIHy0yTaMOVhCvsk=
 github.com/flanksource/gomplate/v3 v3.24.2/go.mod h1:94BxYobZqouGdVezuz6LNto5C+yLMG0LnNnM9CUPyoo=

--- a/hack/generate-schemas/go.mod
+++ b/hack/generate-schemas/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/flanksource/duty v1.0.415 // indirect
+	github.com/flanksource/duty v1.0.418 // indirect
 	github.com/flanksource/gomplate/v3 v3.24.2 // indirect
 	github.com/flanksource/is-healthy v1.0.1 // indirect
 	github.com/flanksource/kubectl-neat v1.0.4 // indirect

--- a/hack/generate-schemas/go.sum
+++ b/hack/generate-schemas/go.sum
@@ -243,8 +243,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flanksource/commons v1.22.1 h1:Ycg8r26bx537UTdAEFgngDW1r2j5bX6Lr3NGxLICpiw=
 github.com/flanksource/commons v1.22.1/go.mod h1:GD5+yGvmYFPIW3WMNN+y1JkeDMJY74e05pQAsRbrvwY=
-github.com/flanksource/duty v1.0.415 h1:pwEfYQoPXNW4SGfev90lIIGaaU7wJKYFgWfI7tdc2ic=
-github.com/flanksource/duty v1.0.415/go.mod h1:qQm7wt7TlqV6TFn+PU98bQIYCCau5/3baepXGTQRtV4=
+github.com/flanksource/duty v1.0.418 h1:eqff2Xn3KMhWIBBvED+U3CohE3OAiDTmEo+le7cB/UQ=
+github.com/flanksource/duty v1.0.418/go.mod h1:qQm7wt7TlqV6TFn+PU98bQIYCCau5/3baepXGTQRtV4=
 github.com/flanksource/gomplate/v3 v3.24.2 h1:WZSriw1MaBhzrDV1IOP9eNsupIPxIHy0yTaMOVhCvsk=
 github.com/flanksource/gomplate/v3 v3.24.2/go.mod h1:94BxYobZqouGdVezuz6LNto5C+yLMG0LnNnM9CUPyoo=
 github.com/flanksource/is-healthy v1.0.1 h1:cr36GHndzge4rb6GDw+kSh5M6bUpglcZNbqqaTDAZeE=


### PR DESCRIPTION
* don't run deleted scrapers

The cron job for `consumeKubernetesWatchEvents` was not being cleared before another one of it was run. With 5 spec update, we would have had 5 of those jobs running. 

merge after: https://github.com/flanksource/duty/pull/670