### PR TITLE
fix: changes from cloudtrail

### DIFF
--- a/api/v1/interface.go
+++ b/api/v1/interface.go
@@ -200,9 +200,10 @@ func (r RelationshipResult) String() string {
 
 type RelationshipResults []RelationshipResult
 
-func (s *ScrapeResults) AddChange(change ChangeResult) *ScrapeResults {
+func (s *ScrapeResults) AddChange(base BaseScraper, change ChangeResult) *ScrapeResults {
 	*s = append(*s, ScrapeResult{
-		Changes: []ChangeResult{change},
+		BaseScraper: base,
+		Changes:     []ChangeResult{change},
 	})
 	return s
 }

--- a/scrapers/aws/cloudtrail.go
+++ b/scrapers/aws/cloudtrail.go
@@ -119,9 +119,10 @@ func (aws Scraper) cloudtrail(ctx *AWSContext, config v1.AWS, results *v1.Scrape
 					change.ConfigType = *resource.ResourceType
 				}
 
-				results.AddChange(change)
+				results.AddChange(config.BaseScraper, change)
 			}
 		}
+
 		LastEventTime.Store(lastEventKey, maxTime)
 		logger.Infof("Processed %d events, changes=%d ignored=%d", count, len(*results), ignored)
 		wg.Done()


### PR DESCRIPTION
exclusions in changes from Cloudtrail were not working because the change didn't have the base scraper from which we were reading the exclusions.