### PR TITLE
fix: config_relationship & kubernetes pod parent

### DIFF
--- a/db/config.go
+++ b/db/config.go
@@ -196,7 +196,7 @@ func GetJSON(ci models.ConfigItem) []byte {
 
 func UpdateConfigRelatonships(ctx api.ScrapeContext, relationships []models.ConfigRelationship) error {
 	return ctx.DB().Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "config_id"}, {Name: "related_id"}, {Name: "selector_id"}},
+		Columns:   []clause.Column{{Name: "config_id"}, {Name: "related_id"}, {Name: "relation"}},
 		DoNothing: true,
 	}).CreateInBatches(relationships, 200).Error
 }

--- a/db/update.go
+++ b/db/update.go
@@ -361,6 +361,7 @@ func SaveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) error {
 		// once the all the scraped results are saved.
 		resultsWithRelationshipSelectors []v1.ScrapeResult
 	)
+
 	for _, result := range results {
 		if result.AnalysisResult != nil {
 			if err := upsertAnalysis(ctx, &result); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -38,10 +38,11 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.19.0
 	github.com/aws/aws-sdk-go-v2/service/support v1.14.7
 	github.com/aws/smithy-go v1.13.5
+	github.com/dominikbraun/graph v0.23.0
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/fergusstrange/embedded-postgres v1.25.0
 	github.com/flanksource/commons v1.22.1
-	github.com/flanksource/duty v1.0.452
+	github.com/flanksource/duty v1.0.459
 	github.com/flanksource/is-healthy v1.0.4
 	github.com/flanksource/ketall v1.1.6
 	github.com/flanksource/mapstructure v1.6.0
@@ -99,7 +100,6 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/distribution/reference v0.5.0 // indirect
-	github.com/dominikbraun/graph v0.23.0 // indirect
 	github.com/eko/gocache/lib/v4 v4.1.5 // indirect
 	github.com/eko/gocache/store/go_cache/v4 v4.2.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -858,8 +858,8 @@ github.com/fergusstrange/embedded-postgres v1.25.0 h1:sa+k2Ycrtz40eCRPOzI7Ry7Ttk
 github.com/fergusstrange/embedded-postgres v1.25.0/go.mod h1:t/MLs0h9ukYM6FSt99R7InCHs1nW0ordoVCcnzmpTYw=
 github.com/flanksource/commons v1.22.1 h1:Ycg8r26bx537UTdAEFgngDW1r2j5bX6Lr3NGxLICpiw=
 github.com/flanksource/commons v1.22.1/go.mod h1:GD5+yGvmYFPIW3WMNN+y1JkeDMJY74e05pQAsRbrvwY=
-github.com/flanksource/duty v1.0.452 h1:LCnKLk5e4XKI9QX5Myr+K/kO5NKgZsRiHAwveZzAztg=
-github.com/flanksource/duty v1.0.452/go.mod h1:eF0Z6vZ2vSO1vy8HDYMc+OkhGWx4Pg5+P16gUuL8+oI=
+github.com/flanksource/duty v1.0.459 h1:OZVwMMsBaN8CUqXoqYI8kl42B4pqEc/gVpkvfxM8CT4=
+github.com/flanksource/duty v1.0.459/go.mod h1:eF0Z6vZ2vSO1vy8HDYMc+OkhGWx4Pg5+P16gUuL8+oI=
 github.com/flanksource/gomplate/v3 v3.20.4/go.mod h1:27BNWhzzSjDed1z8YShO6W+z6G9oZXuxfNFGd/iGSdc=
 github.com/flanksource/gomplate/v3 v3.24.2 h1:WZSriw1MaBhzrDV1IOP9eNsupIPxIHy0yTaMOVhCvsk=
 github.com/flanksource/gomplate/v3 v3.24.2/go.mod h1:94BxYobZqouGdVezuz6LNto5C+yLMG0LnNnM9CUPyoo=

--- a/hack/generate-schemas/go.mod
+++ b/hack/generate-schemas/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/flanksource/duty v1.0.452 // indirect
+	github.com/flanksource/duty v1.0.459 // indirect
 	github.com/flanksource/gomplate/v3 v3.24.2 // indirect
 	github.com/flanksource/is-healthy v1.0.4 // indirect
 	github.com/flanksource/kubectl-neat v1.0.4 // indirect

--- a/hack/generate-schemas/go.sum
+++ b/hack/generate-schemas/go.sum
@@ -245,8 +245,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flanksource/commons v1.22.1 h1:Ycg8r26bx537UTdAEFgngDW1r2j5bX6Lr3NGxLICpiw=
 github.com/flanksource/commons v1.22.1/go.mod h1:GD5+yGvmYFPIW3WMNN+y1JkeDMJY74e05pQAsRbrvwY=
-github.com/flanksource/duty v1.0.452 h1:LCnKLk5e4XKI9QX5Myr+K/kO5NKgZsRiHAwveZzAztg=
-github.com/flanksource/duty v1.0.452/go.mod h1:eF0Z6vZ2vSO1vy8HDYMc+OkhGWx4Pg5+P16gUuL8+oI=
+github.com/flanksource/duty v1.0.459 h1:OZVwMMsBaN8CUqXoqYI8kl42B4pqEc/gVpkvfxM8CT4=
+github.com/flanksource/duty v1.0.459/go.mod h1:eF0Z6vZ2vSO1vy8HDYMc+OkhGWx4Pg5+P16gUuL8+oI=
 github.com/flanksource/gomplate/v3 v3.24.2 h1:WZSriw1MaBhzrDV1IOP9eNsupIPxIHy0yTaMOVhCvsk=
 github.com/flanksource/gomplate/v3 v3.24.2/go.mod h1:94BxYobZqouGdVezuz6LNto5C+yLMG0LnNnM9CUPyoo=
 github.com/flanksource/is-healthy v1.0.4 h1:r/dVsi7keR5NGLCTpgO/M6Hah2jRtYNfMh/XJNnxacc=


### PR DESCRIPTION
merge after: https://github.com/flanksource/duty/pull/761

- changes related to the change in unique constraint in the `config_relationships` table
- set the deployment/replicaset as the parent of a pod depending on exclusion