### PR TITLE
fix: parent & path of configs & batch saving

### DIFF
--- a/db/config.go
+++ b/db/config.go
@@ -180,16 +180,6 @@ func NewConfigItemFromResult(ctx api.ScrapeContext, result v1.ScrapeResult) (*mo
 		ci.DeleteReason = result.DeleteReason
 	}
 
-	if result.ParentExternalID != "" && result.ParentType != "" {
-		if found, err := ctx.TempCache().Find(result.ParentType, result.ParentExternalID); err != nil {
-			return nil, err
-		} else if found != nil {
-			ci.ParentID = &found.ID
-		} else {
-			ctx.DutyContext().Infof("[%s] parent %s/%s not found", ci, result.ParentType, result.ParentExternalID)
-		}
-	}
-
 	return ci, nil
 }
 

--- a/db/config.go
+++ b/db/config.go
@@ -137,6 +137,9 @@ func NewConfigItemFromResult(ctx api.ScrapeContext, result v1.ScrapeResult) (*mo
 		Config:          &dataStr,
 		Ready:           result.Ready,
 		LastScrapedTime: result.LastScrapedTime,
+
+		ParentExternalID: result.ParentExternalID,
+		ParentType:       result.ParentType,
 	}
 
 	if parsed, err := result.Tags.AsMap(); err != nil {

--- a/db/models/config_item.go
+++ b/db/models/config_item.go
@@ -41,7 +41,10 @@ type ConfigItem struct {
 	DeletedAt       *time.Time            `gorm:"column:deleted_at" json:"deleted_at"`
 	LastScrapedTime *time.Time            `gorm:"column:last_scraped_time" json:"last_scraped_time"`
 	DeleteReason    v1.ConfigDeleteReason `gorm:"column:delete_reason" json:"delete_reason"`
-	TouchDeletedAt  bool                  `gorm:"-" json:"-"`
+
+	ParentExternalID string `gorm:"-" json:"-"`
+	ParentType       string `gorm:"-" json:"-"`
+	TouchDeletedAt   bool   `gorm:"-" json:"-"`
 }
 
 func (ci ConfigItem) String() string {

--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/distribution/reference v0.5.0 // indirect
+	github.com/dominikbraun/graph v0.23.0 // indirect
 	github.com/eko/gocache/lib/v4 v4.1.5 // indirect
 	github.com/eko/gocache/store/go_cache/v4 v4.2.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -817,6 +817,8 @@ github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/dominikbraun/graph v0.23.0 h1:TdZB4pPqCLFxYhdyMFb1TBdFxp8XLcJfTTBQucVPgCo=
+github.com/dominikbraun/graph v0.23.0/go.mod h1:yOjYyogZLY1LSG9E33JWZJiq5k83Qy2C6POAuiViluc=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eko/gocache/lib/v4 v4.1.5 h1:CeMQmdIzwBKKLRjk3FCDXzNFsQTyqJ01JLI7Ib0C9r8=
 github.com/eko/gocache/lib/v4 v4.1.5/go.mod h1:XaNfCwW8KYW1bRZ/KoHA1TugnnkMz0/gT51NDIu7LSY=


### PR DESCRIPTION
- optimize setting the parent & the config path on the first run. 
  - This fixes having to run the scraper at least twice to setup the parent_id properly. 
  - fixes incorrect evaluation of config path
- Bulk saving of new config items, new config changes & updates to config changes.