### PR TITLE
fix: addition of vertices for changes only results

### DIFF
--- a/db/models/config_item.go
+++ b/db/models/config_item.go
@@ -49,9 +49,10 @@ type ConfigItem struct {
 
 func (ci ConfigItem) String() string {
 	if len(ci.ExternalID) == 0 {
-		return fmt.Sprintf("%s/%s", *ci.Type, *ci.Name)
+		return fmt.Sprintf("id=%s name=%s type=%s", ci.ID, *ci.Type, *ci.Name)
 	}
-	return fmt.Sprintf("%s/%s id=%s", *ci.Type, *ci.Name, ci.ExternalID[0])
+
+	return fmt.Sprintf("id=%s name=%s type=%s external_id=%s", ci.ID, *ci.Type, *ci.Name, ci.ExternalID[0])
 }
 
 func (ci ConfigItem) ConfigJSONStringMap() (map[string]interface{}, error) {

--- a/db/update.go
+++ b/db/update.go
@@ -589,10 +589,6 @@ func extractConfigsAndChangesFromResults(ctx api.ScrapeContext, scrapeStartTime 
 			root = ci.ID
 		}
 
-		if err := tree.AddVertex(ci.ID); err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("unable to add vertex(%s): %w", ci, err)
-		}
-
 		parentExternalKey := configExternalKey{externalID: ci.ExternalID[0], parentType: lo.FromPtr(ci.Type)}
 		parentTypeToConfigMap[parentExternalKey] = ci.ID
 
@@ -609,6 +605,10 @@ func extractConfigsAndChangesFromResults(ctx api.ScrapeContext, scrapeStartTime 
 
 		allConfigs = append(allConfigs, ci)
 		if result.Config != nil {
+			if err := tree.AddVertex(ci.ID); err != nil {
+				return nil, nil, nil, nil, fmt.Errorf("unable to add vertex(%s): %w", ci, err)
+			}
+
 			if existing == nil || existing.ID == "" {
 				newConfigs = append(newConfigs, ci)
 			} else {


### PR DESCRIPTION
results that only contained changes should not be put into graph.


`ConsumeKubernetesWatchEvents{b8e78065-c9e4-40c8-bcf0-de3a39423092} failed to save results: failed to update db: failed to extract configs & changes from results: unable to add vertex(/ id=): vertex already exists
`