### PR TITLE
fix: chart otel labels

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -96,9 +96,9 @@ spec:
             - name: UPSTREAM_PAGE_SIZE
               value: '{{ .Values.upstream.pageSize }}'
             {{- end}}
-            {{- if .Values.otel.labels}}
+            {{- if (tpl .Values.otel.labels .)}}
             - name: OTEL_LABELS
-              value: '{{ .Values.otel.labels }}'
+              value: '{{ tpl .Values.otel.labels .}}'
             {{- end}}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
So it can use the global value when being used as a subchart.