### PR TITLE
fix: saving changes for non existing configs

### DIFF
--- a/db/update.go
+++ b/db/update.go
@@ -627,6 +627,12 @@ func extractConfigsAndChangesFromResults(ctx api.ScrapeContext, scrapeStartTime 
 				if existing == nil || existing.ID == "" {
 					newConfigs = append(newConfigs, ci)
 				} else {
+					// In case, we are not able to derive the path & parent_id
+					// by forming a tree, we need to use the existing one
+					// otherwise they'll be updated to empty values
+					ci.ParentID = existing.ParentID
+					ci.Path = existing.Path
+
 					configsToUpdate = append(configsToUpdate, &updateConfigArgs{
 						Result:   result,
 						Existing: existing,

--- a/scrapers/aws/aws.go
+++ b/scrapers/aws/aws.go
@@ -1106,7 +1106,7 @@ func (aws Scraper) Scrape(ctx api.ScrapeContext) v1.ScrapeResults {
 				continue
 			}
 
-			logger.Infof("Scraping %s", awsCtx)
+			ctx.Logger.V(2).Infof("scraping %s", awsCtx)
 			aws.subnets(awsCtx, awsConfig, results)
 			aws.instances(awsCtx, awsConfig, results)
 			aws.vpcs(awsCtx, awsConfig, results)

--- a/scrapers/aws/aws.go
+++ b/scrapers/aws/aws.go
@@ -1106,7 +1106,7 @@ func (aws Scraper) Scrape(ctx api.ScrapeContext) v1.ScrapeResults {
 				continue
 			}
 
-			ctx.Logger.V(2).Infof("scraping %s", awsCtx)
+			ctx.Logger.V(1).Infof("scraping %s", awsCtx)
 			aws.subnets(awsCtx, awsConfig, results)
 			aws.instances(awsCtx, awsConfig, results)
 			aws.vpcs(awsCtx, awsConfig, results)

--- a/scrapers/aws/cloudtrail.go
+++ b/scrapers/aws/cloudtrail.go
@@ -124,7 +124,7 @@ func (aws Scraper) cloudtrail(ctx *AWSContext, config v1.AWS, results *v1.Scrape
 		}
 
 		LastEventTime.Store(lastEventKey, maxTime)
-		logger.Infof("Processed %d events, changes=%d ignored=%d", count, len(*results), ignored)
+		ctx.Logger.V(3).Infof("processed %d cloudtrail events, changes=%d ignored=%d", count, len(*results), ignored)
 		wg.Done()
 	}()
 

--- a/scrapers/cron.go
+++ b/scrapers/cron.go
@@ -40,10 +40,9 @@ func SyncScrapeConfigs(sc api.ScrapeContext) {
 		Fn: func(jr job.JobRuntime) error {
 			scraperConfigsDB, err := db.GetScrapeConfigsOfAgent(sc, uuid.Nil)
 			if err != nil {
-				logger.Fatalf("error getting configs from database: %v", err)
+				return fmt.Errorf("error getting configs from database: %v", err)
 			}
 
-			logger.Infof("Starting %d scrapers", len(scraperConfigsDB))
 			for _, scraper := range scraperConfigsDB {
 				_scraper, err := v1.ScrapeConfigFromModel(scraper)
 				if err != nil {
@@ -58,6 +57,7 @@ func SyncScrapeConfigs(sc api.ScrapeContext) {
 
 				jr.History.SuccessCount += 1
 			}
+
 			return nil
 		},
 	}


### PR DESCRIPTION
resolves: https://github.com/flanksource/config-db/issues/537

When saving changes the `config_id` was either `""` or a generated uuid of a non existing config items _(example: change from a kubernetes event for replicaset but it's excluded from scraping)_.

