### PR TITLE
fix: handle deletion of configs

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -101,7 +101,8 @@ func (e ExternalID) WhereClause(db *gorm.DB) *gorm.DB {
 type ConfigDeleteReason string
 
 var (
-	// DeletedReasonStale is used when a config item doesn't get updated on a scrape run.
+	// DeletedReasonStale is used when a config item doesn't get updated
+	// for a period of `staleItemAge`.
 	DeletedReasonStale ConfigDeleteReason = "STALE"
 
 	// DeletedReasonFromAttribute is used when a deletion field (& reason)

--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -101,9 +101,14 @@ func (e ExternalID) WhereClause(db *gorm.DB) *gorm.DB {
 type ConfigDeleteReason string
 
 var (
-	// DeletedReasonStale is used when a config item doesn't get updated on a scrape run
-	DeletedReasonStale           ConfigDeleteReason = "STALE"
-	DeletedReasonFromAttribute   ConfigDeleteReason = "FROM_ATTRIBUTE"
-	DeletedReasonFromEvent       ConfigDeleteReason = "FROM_EVENT"
+	// DeletedReasonStale is used when a config item doesn't get updated on a scrape run.
+	DeletedReasonStale ConfigDeleteReason = "STALE"
+
+	// DeletedReasonFromAttribute is used when a deletion field (& reason)
+	// is picked up from the scraped config itself.
+	DeletedReasonFromAttribute ConfigDeleteReason = "FROM_ATTRIBUTE"
+
+	// DeletedReasonFromDeleteField is used when a deletion field (& reason)
+	// is picked up from the JSONPath expression provided in the scraper config.
 	DeletedReasonFromDeleteField ConfigDeleteReason = "FROM_DELETE_FIELD"
 )

--- a/db/config.go
+++ b/db/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/lib/pq"
 	"github.com/ohler55/ojg/oj"
+	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
 
@@ -210,4 +211,16 @@ func FindConfigChangesByItemID(ctx api.ScrapeContext, configItemID string) ([]du
 	}
 
 	return ci, nil
+}
+
+func SoftDeleteConfigItems(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	return ctx.DB().
+		Model(&models.ConfigItem{}).
+		Where("id IN (?)", ids).
+		Update("deleted_at", gorm.Expr("NOW()")).
+		Error
 }

--- a/db/models/config_item.go
+++ b/db/models/config_item.go
@@ -44,7 +44,6 @@ type ConfigItem struct {
 
 	ParentExternalID string `gorm:"-" json:"-"`
 	ParentType       string `gorm:"-" json:"-"`
-	TouchDeletedAt   bool   `gorm:"-" json:"-"`
 }
 
 func (ci ConfigItem) String() string {

--- a/db/update.go
+++ b/db/update.go
@@ -104,11 +104,9 @@ func updateCI(ctx api.ScrapeContext, result v1.ScrapeResult, ci, existing *model
 	updates := make(map[string]interface{})
 	changes := make([]*models.ConfigChange, 0)
 
-	// In case a resource was marked as deleted but is un-deleted now
-	// we set an update flag as gorm ignores nil pointers
 	if ci.DeletedAt != existing.DeletedAt {
-		ci.TouchDeletedAt = true
 		updates["deleted_at"] = ci.DeletedAt
+		updates["delete_reason"] = ci.DeleteReason
 	}
 
 	changeResult, err := generateConfigChange(*ci, *existing)
@@ -176,11 +174,6 @@ func updateCI(ctx api.ScrapeContext, result v1.ScrapeResult, ci, existing *model
 	}
 	if ci.Properties != nil && len(*ci.Properties) > 0 && (existing.Properties == nil || !mapEqual(ci.Properties.AsMap(), existing.Properties.AsMap())) {
 		updates["properties"] = *ci.Properties
-	}
-
-	if ci.TouchDeletedAt && ci.DeleteReason != v1.DeletedReasonFromEvent {
-		updates["deleted_at"] = nil
-		updates["delete_reason"] = nil
 	}
 
 	if len(updates) == 0 {

--- a/scrapers/kubernetes/kubernetes.go
+++ b/scrapers/kubernetes/kubernetes.go
@@ -401,14 +401,8 @@ func ExtractResults(ctx context.Context, config v1.Kubernetes, objs []*unstructu
 			resourceHealth = &health.HealthStatus{}
 		}
 
-		createdAt := obj.GetCreationTimestamp().Time
 		var deletedAt *time.Time
 		var deleteReason v1.ConfigDeleteReason
-		if !obj.GetDeletionTimestamp().IsZero() {
-			deletedAt = &obj.GetDeletionTimestamp().Time
-			deleteReason = v1.DeletedReasonFromAttribute
-		}
-
 		// Evicted Pods must be considered deleted
 		if obj.GetKind() == "Pod" {
 			if objStatus, ok := obj.Object["status"].(map[string]any); ok {
@@ -437,7 +431,7 @@ func ExtractResults(ctx context.Context, config v1.Kubernetes, objs []*unstructu
 			Health:              models.Health(resourceHealth.Health),
 			Ready:               resourceHealth.Ready,
 			Description:         resourceHealth.Message,
-			CreatedAt:           &createdAt,
+			CreatedAt:           lo.ToPtr(obj.GetCreationTimestamp().Time),
 			DeletedAt:           deletedAt,
 			DeleteReason:        deleteReason,
 			Config:              configObj,


### PR DESCRIPTION
resolves: https://github.com/flanksource/config-db/issues/559

When a pod of a job is deleted, an event isn't created. We need to delete the pod based in the watch event type.