### PR TITLE
fix: dont error out on duplicate edge insertion

### DIFF
--- a/db/update.go
+++ b/db/update.go
@@ -785,8 +785,8 @@ func setConfigPaths(ctx api.ScrapeContext, tree graph.Graph[string, string], roo
 
 	for _, c := range allConfigs {
 		if c.ParentID != nil {
-			if err := tree.AddEdge(*c.ParentID, c.ID); err != nil {
-				return fmt.Errorf("unable to add edge(%s): %w", c, err)
+			if err := tree.AddEdge(*c.ParentID, c.ID); err != nil && !errors.Is(err, graph.ErrEdgeAlreadyExists) {
+				return fmt.Errorf("unable to add edge(%s -> %s): %w", *c.ParentID, c.ID, err)
 			}
 		}
 	}

--- a/scrapers/cron.go
+++ b/scrapers/cron.go
@@ -297,7 +297,7 @@ func ConsumeKubernetesWatchResourcesJobFunc(sc api.ScrapeContext, config v1.Kube
 			}
 
 			if err := SaveResults(cc, results); err != nil {
-				return fmt.Errorf("failed to save results: %w", err)
+				return fmt.Errorf("failed to save %d results: %w", len(results), err)
 			}
 
 			for i := range results {


### PR DESCRIPTION
when forming partial graphs we'll often try to insert duplicate edges. It's safe to ignore that error.

Example: when we fetch two deployment parents after receiving two different pods in a batch of event, we try to add edges from the paths in the deployment.

```
Deploy A path: Cluster.Namespace.DA
Deploy B path: Cluster.Namespace.DB
```

`Cluster->Namespace` edge is then attempted to add twice.