### PR TITLE
chore: use scrape ctx namespace for azure

### DIFF
--- a/scrapers/azure/azure.go
+++ b/scrapers/azure/azure.go
@@ -102,12 +102,12 @@ func (azure Scraper) hydrateConnection(ctx api.ScrapeContext, t v1.Azure) (v1.Az
 	}
 
 	var err error
-	t.ClientID.ValueStatic, err = ctx.GetEnvValueFromCache(t.ClientID, ctx.GetNamespace())
+	t.ClientID.ValueStatic, err = ctx.GetEnvValueFromCache(t.ClientID, ctx.Namespace())
 	if err != nil {
 		return t, fmt.Errorf("failed to get client id: %w", err)
 	}
 
-	t.ClientSecret.ValueStatic, err = ctx.GetEnvValueFromCache(t.ClientSecret, ctx.GetNamespace())
+	t.ClientSecret.ValueStatic, err = ctx.GetEnvValueFromCache(t.ClientSecret, ctx.Namespace())
 	if err != nil {
 		return t, fmt.Errorf("failed to get client secret: %w", err)
 	}


### PR DESCRIPTION
@moshloop This is the fix for https://mission-control.workload-prod-eu-01.flanksource.com/settings/config_scrapers/b302865d-b948-463d-8f0a-6fa1e95cec1c?name=Scraper

I think we might have to refactor how scrape context works with duty context