### PR TITLE
fix: parent id of Namespace & Cluster in incremental k8s scraper

### DIFF
--- a/db/models/config_item.go
+++ b/db/models/config_item.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flanksource/duty/types"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
+	"github.com/samber/lo"
 )
 
 // ConfigItem represents the config item database table
@@ -48,10 +49,10 @@ type ConfigItem struct {
 
 func (ci ConfigItem) String() string {
 	if len(ci.ExternalID) == 0 {
-		return fmt.Sprintf("id=%s name=%s type=%s", ci.ID, *ci.Type, *ci.Name)
+		return fmt.Sprintf("id=%s type=%s name=%s ", ci.ID, lo.FromPtr(ci.Type), lo.FromPtr(ci.Name))
 	}
 
-	return fmt.Sprintf("id=%s name=%s type=%s external_id=%s", ci.ID, *ci.Type, *ci.Name, ci.ExternalID[0])
+	return fmt.Sprintf("id=%s type=%s name=%s external_id=%s", ci.ID, lo.FromPtr(ci.Type), lo.FromPtr(ci.Name), ci.ExternalID[0])
 }
 
 func (ci ConfigItem) ConfigJSONStringMap() (map[string]interface{}, error) {

--- a/db/update.go
+++ b/db/update.go
@@ -711,6 +711,10 @@ func extractConfigsAndChangesFromResults(ctx api.ScrapeContext, scrapeStartTime 
 
 func setConfigParents(ctx api.ScrapeContext, parentTypeToConfigMap map[configExternalKey]string, allConfigs []*models.ConfigItem) error {
 	for _, ci := range allConfigs {
+		if ci.ParentID != nil {
+			continue // existing item. Parent is already set.
+		}
+
 		if ci.ParentExternalID == "" || ci.ParentType == "" {
 			continue
 		}


### PR DESCRIPTION
resolves: https://github.com/flanksource/config-db/issues/585

In an incremental scraper, we don't have the namespace object. Hence, resourceIDMap would be empty for all the namespaces. 
If any namespaced object, like a Deployment, were to be scraped by the incremental scraper, we wouldn't be able to set the parent of that deployment because we don't know the id of the parent namespace.

In the workload cluster, the incremental scraper wasn't able to set the parent for a newly created cronjob so the saving of CronJob config failed. Consequently, saving of the job and also the pod would fail. This would happen until a full scrape.

**The fix**: use the Namespace config alias as the parent's external id.