### PR TITLE
fix: paths for availability zone & zone ID in aws scraper

### DIFF
--- a/scrapers/aws/aws.go
+++ b/scrapers/aws/aws.go
@@ -263,8 +263,8 @@ func (aws Scraper) availabilityZones(ctx *AWSContext, config v1.AWS, results *v1
 			Tags:             []v1.Tag{{Name: "region", Value: lo.FromPtr(az.RegionName)}},
 			Aliases:          nil,
 			Name:             lo.FromPtr(az.ZoneName),
-			ParentExternalID: lo.FromPtr(ctx.Caller.Account),
-			ParentType:       v1.AWSAccount,
+			ParentExternalID: lo.FromPtr(az.RegionName),
+			ParentType:       v1.AWSRegion,
 		})
 
 		if _, ok := uniqueAvailabilityZoneIDs[lo.FromPtr(az.ZoneId)]; !ok {

--- a/scrapers/cron.go
+++ b/scrapers/cron.go
@@ -226,7 +226,7 @@ func ConsumeKubernetesWatchEventsJobFunc(sc api.ScrapeContext, config v1.Kuberne
 				return err
 			}
 
-			if err := SaveResults(cc, results); err != nil {
+			if err := db.SavePartialResults(cc, results); err != nil {
 				return fmt.Errorf("failed to save results: %w", err)
 			}
 
@@ -303,7 +303,7 @@ func ConsumeKubernetesWatchResourcesJobFunc(sc api.ScrapeContext, config v1.Kube
 				return err
 			}
 
-			if err := SaveResults(cc, results); err != nil {
+			if err := db.SavePartialResults(cc, results); err != nil {
 				return fmt.Errorf("failed to save %d results: %w", len(results), err)
 			}
 

--- a/scrapers/run.go
+++ b/scrapers/run.go
@@ -29,7 +29,7 @@ func RunScraper(ctx api.ScrapeContext) (v1.ScrapeResults, error) {
 		return nil, fmt.Errorf("failed to run scraper %v: %w", ctx.ScrapeConfig().Name, scraperErr)
 	}
 
-	if err := SaveResults(ctx, results); err != nil {
+	if err := db.SaveResults(ctx, results); err != nil {
 		return nil, fmt.Errorf("failed to save results: %w", err)
 	}
 
@@ -39,16 +39,6 @@ func RunScraper(ctx api.ScrapeContext) (v1.ScrapeResults, error) {
 
 	ctx.Logger.V(1).Infof("Completed scraping with %d results in %s", len(results), time.Since(ctx.Value(contextKeyScrapeStart).(time.Time)))
 	return results, nil
-}
-
-func SaveResults(ctx api.ScrapeContext, results v1.ScrapeResults) error {
-	dbErr := db.SaveResults(ctx, results)
-	if dbErr != nil {
-		//FIXME cache results to save to db later
-		return dbErr
-	}
-
-	return nil
 }
 
 func UpdateStaleConfigItems(ctx api.ScrapeContext, results v1.ScrapeResults) error {


### PR DESCRIPTION
resolves: https://github.com/flanksource/config-db/issues/577

We use a virtual root to deal with graphs with multiple parent-less items.

Fixes:
- [x] no need to manually define what config item is the root
- [x] can handle result set with multiple roots (example: results from aws scraper where the account config & all the configs for the aws regions are root)
- [x] parent of availability zone id