### PR TITLE
fix: bring back buffer for delete

### DIFF
--- a/db/config.go
+++ b/db/config.go
@@ -211,10 +211,10 @@ func FindConfigChangesByItemID(ctx api.ScrapeContext, configItemID string) ([]du
 	return ci, nil
 }
 
-func SoftDeleteConfigItem(ctx context.Context, id string) error {
+func SoftDeleteConfigItems(ctx context.Context, ids ...string) error {
 	return ctx.DB().
 		Model(&models.ConfigItem{}).
-		Where("id = ?", id).
+		Where("id IN ?", ids).
 		Update("deleted_at", gorm.Expr("NOW()")).
 		Error
 }


### PR DESCRIPTION
The deleted objected must only be processed after added/updated objects

resolves: https://github.com/flanksource/config-db/issues/598
resolves: https://github.com/flanksource/config-db/issues/605