### PR TITLE
fix: delete correct parent relationship in config item cleanup query

### DIFF
--- a/jobs/cleanup.go
+++ b/jobs/cleanup.go
@@ -110,7 +110,10 @@ var CleanupConfigItems = &job.Job{
 		breakParentRelationshipQuery := fmt.Sprintf(`
 		UPDATE config_items
 		SET parent_id = NULL
-		WHERE id IN (%s) AND parent_id IS NOT NULL AND deleted_at < NOW() - interval '1 SECONDS' * ?`,
+		WHERE
+            id NOT IN (%s) AND
+            parent_id IS NOT NULL AND
+            deleted_at < NOW() - interval '1 SECONDS' * ?`,
 			linkedConfigsQuery)
 		if tx := ctx.Context.DB().Exec(breakParentRelationshipQuery, seconds); tx.Error != nil {
 			return fmt.Errorf("failed to remove config parent relationships: %w", tx.Error)

--- a/jobs/cleanup.go
+++ b/jobs/cleanup.go
@@ -139,7 +139,8 @@ var CleanupConfigItems = &job.Job{
 			iter++
 			tx := ctx.Context.DB().Exec(configDeleteQuery, seconds, deleteBatchSize)
 			if tx.Error != nil {
-				return fmt.Errorf("failed to delete config items: %w", tx.Error)
+				ctx.Errorf("failed to delete config items: %v", tx.Error)
+				continue
 			}
 
 			if tx.RowsAffected == 0 {


### PR DESCRIPTION
Fixes: https://github.com/flanksource/config-db/issues/638