### PR TITLE
chore: cleaner error count for orphaned

### DIFF
--- a/db/update.go
+++ b/db/update.go
@@ -120,7 +120,7 @@ func updateCI(ctx api.ScrapeContext, result v1.ScrapeResult, ci, existing *model
 		if newChanges, _, orphanedChanges, err := extractChanges(ctx, &result, ci); err != nil {
 			return false, nil, err
 		} else {
-			ctx.JobHistory().ErrorCount += orphanedChanges
+			ctx.JobHistory().AddErrorf("%d changes were orphaned for config item: [%s/%s]", orphanedChanges, existing.ID, *existing.Name)
 			changes = append(changes, newChanges...)
 		}
 
@@ -345,7 +345,7 @@ func saveResults(ctx api.ScrapeContext, isPartialResultSet bool, results []v1.Sc
 	if err != nil {
 		return fmt.Errorf("failed to extract configs & changes from results: %w", err)
 	}
-	ctx.JobHistory().ErrorCount += orphanedChanges
+	ctx.JobHistory().AddErrorf("%d changes were orphaned for scraper: [%s/%s]", orphanedChanges, ctx.ScrapeConfig().Namespace, ctx.ScrapeConfig().Name)
 
 	ctx.Logger.V(2).Infof("%d new configs, %d configs to update, %d new changes & %d changes to update",
 		len(newConfigs), len(configsToUpdate), len(newChanges), len(changesToUpdate))


### PR DESCRIPTION
Having a high error count without any description does not make sense

![image](https://github.com/flanksource/config-db/assets/5863972/07e928ba-1016-4d02-8a8a-d48cfafce6e8)
