### PR TITLE
chore: capture error when kubernetes watch fails

### DIFF
--- a/scrapers/kubernetes/events_watch.go
+++ b/scrapers/kubernetes/events_watch.go
@@ -103,7 +103,7 @@ func WatchEvents(ctx api.ScrapeContext, config v1.Kubernetes) error {
 		var err error
 		ctx, _, err = applyKubeconfig(ctx, *config.Kubeconfig)
 		if err != nil {
-			return fmt.Errorf("failed to apply kube config")
+			return fmt.Errorf("failed to apply kube config: %w", err)
 		}
 	}
 


### PR DESCRIPTION
```
{"level":"error","ts":"2024-07-03T09:36:46.909389845Z","msg":"failed to watch kubernetes events. cluster=sre: failed to apply kube config"}          
{"level":"error","ts":"2024-07-03T09:36:46.911043795Z","msg":"failed to watch kubernetes events. cluster=internal-apps: failed to apply kube config"}
{"level":"error","ts":"2024-07-03T09:36:46.996003032Z","msg":"failed to watch kubernetes events. cluster=sandbox-infra: failed to apply kube config"}
```