### PR TITLE
feat: link kubernetes LB services to AWS ELB

### DIFF
--- a/scrapers/aws/aws.go
+++ b/scrapers/aws/aws.go
@@ -1264,7 +1264,7 @@ func (aws Scraper) loadBalancers(ctx *AWSContext, config v1.AWS, results *v1.Scr
 			Name:                *lb.LoadBalancerName,
 			Labels:              labels,
 			Tags:                tags,
-			Aliases:             []string{"AWSELB/" + arn, arn},
+			Aliases:             []string{"AWSELB/" + arn, arn, lo.FromPtr(lb.CanonicalHostedZoneName)},
 			ID:                  *lb.LoadBalancerName,
 			Parents:             []v1.ConfigExternalKey{{Type: v1.AWSEC2VPC, ExternalID: lo.FromPtr(lb.VPCId)}},
 			RelationshipResults: relationships,

--- a/scrapers/kubernetes/kubernetes.go
+++ b/scrapers/kubernetes/kubernetes.go
@@ -516,6 +516,13 @@ func ExtractResults(ctx api.ScrapeContext, config v1.Kubernetes, objs []*unstruc
 										if ingress, ok := ing.(map[string]any); ok {
 											if hostname, ok := ingress["hostname"].(string); ok && hostname != "" {
 												labels["hostname"] = hostname
+
+												if strings.HasSuffix(hostname, "elb.amazonaws.com") {
+													relationships = append(relationships, v1.RelationshipResult{
+														ConfigID:          string(obj.GetUID()),
+														RelatedExternalID: v1.ExternalID{ExternalID: []string{hostname}, ConfigType: v1.AWSLoadBalancer},
+													})
+												}
 											}
 
 											if ip, ok := ingress["ip"].(string); ok && ip != "" {


### PR DESCRIPTION
~~## fix source vertex not found error by namespacing all look ups to the scraper.~~

~~The source vertex not found error would occur only in cases where multiple clusters were being scraped. The lookups needed to be scoped to the given scraper.~~

~~_Example_: When forming a `Namespace default` -> `Deployment Nginx` relationship for **cluster A,** the lookup for external id `Kubernetes/Namespace//default` would return the ID of the `default namespace` from **cluster B.** This would cause failure when forming the graph as the edge couldn't be inserted since there's no source vertex in the graph.~~

~~resolves: https://github.com/flanksource/config-db/issues/703~~