### PR TITLE
fix: exclude deleted when looking up by external id

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -46,7 +46,7 @@ func (t *TempCache) Find(ctx ScrapeContext, lookup v1.ExternalID) (*models.Confi
 	}
 
 	var result models.ConfigItem
-	query := ctx.DB().Limit(1).Where("type = ? and external_id @> ?", lookup.ConfigType, pq.StringArray{externalID})
+	query := ctx.DB().Limit(1).Where("deleted_at IS NULL").Where("type = ? and external_id @> ?", lookup.ConfigType, pq.StringArray{externalID})
 	if scraperID != "all" && scraperID != "" {
 		query = query.Where("scraper_id = ?", scraperID)
 	}

--- a/scrapers/aws/aws.go
+++ b/scrapers/aws/aws.go
@@ -1473,6 +1473,7 @@ func (aws Scraper) subnets(ctx *AWSContext, config v1.AWS, results *v1.ScrapeRes
 	subnets, err := ctx.EC2.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{})
 	if err != nil {
 		results.Errorf(err, "failed to get subnets")
+		return
 	}
 
 	for _, subnet := range subnets.Subnets {


### PR DESCRIPTION
We have two helm releases with the same name on the same namespace but different ids.
The deleted one is being fetched currently when setting up the parent.