### PR TITLE
fix: parent lookup

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -114,7 +114,7 @@ func QueryCache(ctx context.Context, query string, args ...interface{}) (*TempCa
 		aliases: make(map[string]string),
 	}
 	items := []models.ConfigItem{}
-	if err := ctx.DB().Table("config_items").Where(query, args...).Find(&items).Error; err != nil {
+	if err := ctx.DB().Table("config_items").Where("deleted_at IS NULL").Where(query, args...).Find(&items).Error; err != nil {
 		return nil, err
 	}
 	for _, item := range items {

--- a/api/context.go
+++ b/api/context.go
@@ -33,6 +33,7 @@ func (ctx ScrapeContext) withTempCache(cache *TempCache) ScrapeContext {
 	ctx.temp = cache
 	return ctx
 }
+
 func (ctx ScrapeContext) InitTempCache() (ScrapeContext, error) {
 	if ctx.ScrapeConfig().GetPersistedID() == nil {
 		cache, err := QueryCache(ctx.Context, "scraper_id IS NULL")

--- a/scrapers/kubernetes/kubernetes.go
+++ b/scrapers/kubernetes/kubernetes.go
@@ -698,7 +698,7 @@ func getKubernetesParent(obj *unstructured.Unstructured, exclusions v1.Kubernete
 	if helmName != "" && helmNamespace != "" {
 		allParents = append([]v1.ConfigExternalKey{{
 			Type:       ConfigTypePrefix + "HelmRelease",
-			ExternalID: getKubernetesAlias("HelmRelease", helmNamespace, helmName),
+			ExternalID: lo.CoalesceOrEmpty(resourceIDMap.Get(helmNamespace, "HelmRelease", helmName), getKubernetesAlias("HelmRelease", helmNamespace, helmName)),
 		}}, allParents...)
 	}
 


### PR DESCRIPTION
On the aws cluster, we had two HelmReleases under the same scraper with the same KNN & external ids. One of them is deleted & the other is active.

On temp cache init, we would fetch both the helm releases but the older (deleted) one would replace the active one in the cache.

The parent lookup for all the resources created by the helm release would then get the wrong parent id and the graph formation would fail.