### PR TITLE
fix: duplicate key value violates unique constraint "config_changes_config_id_external_change_id_key"

### DIFF
--- a/db/models/config_change.go
+++ b/db/models/config_change.go
@@ -76,6 +76,13 @@ func (c *ConfigChange) BeforeCreate(tx *gorm.DB) (err error) {
 		c.ID = uuid.New().String()
 	}
 
-	tx.Statement.AddClause(clause.OnConflict{UpdateAll: true})
+	tx.Statement.AddClause(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "config_id"},
+			{Name: "external_change_id"},
+		},
+		DoNothing: true,
+	})
+
 	return
 }

--- a/db/models/config_change.go
+++ b/db/models/config_change.go
@@ -84,10 +84,5 @@ func (c *ConfigChange) BeforeCreate(tx *gorm.DB) (err error) {
 		UpdateAll: true,
 	})
 
-	tx.Statement.AddClause(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "id"}},
-		UpdateAll: true,
-	})
-
 	return
 }

--- a/db/models/config_change.go
+++ b/db/models/config_change.go
@@ -81,7 +81,12 @@ func (c *ConfigChange) BeforeCreate(tx *gorm.DB) (err error) {
 			{Name: "config_id"},
 			{Name: "external_change_id"},
 		},
-		DoNothing: true,
+		UpdateAll: true,
+	})
+
+	tx.Statement.AddClause(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "id"}},
+		UpdateAll: true,
 	})
 
 	return

--- a/db/update.go
+++ b/db/update.go
@@ -436,8 +436,12 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 		return summary, fmt.Errorf("failed to create config changes: %w", db.ErrorDetails(err))
 	}
 
-	if len(changesToUpdate) != 0 {
-		if err := ctx.DB().Save(changesToUpdate).Error; err != nil {
+	// TODO: Find a way to bulk insert these changes.
+	// Couldn't find a way to do it with gorm.
+	// Cannot use .Save() because it will try to insert first and then update.
+	// That'll trigger the .BeforeCreate() hook which doesn't have a ON Conflict clause on the primary key.
+	for _, changeToUpdate := range changesToUpdate {
+		if err := ctx.DB().Updates(&changeToUpdate).Error; err != nil {
 			return summary, fmt.Errorf("failed to update config changes: %w", err)
 		}
 	}


### PR DESCRIPTION
resolves: https://github.com/flanksource/config-db/issues/827

On full scrape, it's possible that we try to save the same k8s event or cloudtrail event twice.
On external_change_id conflict, ~~we should do nothing.~~ we update all the columns. The existing code set the on conflict clause to the id column.

Here's one of the change that was causing the unique constraint error

```json
{
  "id": "a1da9c2f-036e-44c3-b41a-ba5e6f7a296e",
  "config_id": "0ebe0548-9f35-4227-8eee-0f33d73a7f28",
  "external_change_id": "bba882cb-0817-43f8-902d-36541aab55d7",
  "external_created_by": null,
  "change_type": "GitOperationSucceeded",
  "severity": "info",
  "source": "source-controller",
  "summary": "no changes since last reconcilation: observed revision 'master@sha1:0778012042fb4d523cb03179ee6e4a0d2c5a9eda'",
  "patches": null,
  "diff": null,
  "details": {
    "reason": "GitOperationSucceeded",
    "source": {
      "component": "source-controller"
    },
    "message": "no changes since last reconcilation: observed revision 'master@sha1:0778012042fb4d523cb03179ee6e4a0d2c5a9eda'",
    "metadata": {
      "uid": "bba882cb-0817-43f8-902d-36541aab55d7",
      "name": "flux-system.17eb9ea6d0ac1a86",
      "namespace": "flux-system",
      "resourceVersion": "74658587",
      "creationTimestamp": null
    },
    "involvedObject": {
      "uid": "0ebe0548-9f35-4227-8eee-0f33d73a7f28",
      "kind": "GitRepository",
      "name": "flux-system",
      "namespace": "flux-system",
      "apiVersion": "source.toolkit.fluxcd.io/v1",
      "resourceVersion": "74657392"
    }
  },
  "created_by": null,
  "created_at": "2024-08-14T14:30:48.122762+00:00",
  "is_pushed": false,
  "count": 1,
  "fingerprint": "ac8a5a6dfb779040f6cb5ddb7612e9ba",
  "first_observed": null
}

```