### PR TITLE
fix: config_changes_config_id_external_change_id_key conflict

### DIFF
--- a/changes/externalIDCache.go
+++ b/changes/externalIDCache.go
@@ -1,0 +1,33 @@
+package changes
+
+import (
+	"sync"
+
+	"github.com/flanksource/config-db/api"
+	"github.com/flanksource/config-db/db/models"
+)
+
+var ExternalChangeIDCache = sync.Map{}
+
+func AddToExteranlChangeIDCache(changes []*models.ConfigChange) {
+	for _, c := range changes {
+		if c.ExternalChangeID != nil {
+			ExternalChangeIDCache.Store(*c.ExternalChangeID, struct{}{})
+		}
+	}
+}
+
+func InitExternalChangeIDCache(ctx api.ScrapeContext) error {
+	var externalIDs []string
+	if err := ctx.DB().Select("external_change_id").Model(&models.ConfigChange{}).Where("external_change_id IS NOT NULL").Find(&externalIDs).Error; err != nil {
+		return err
+	}
+
+	ctx.Logger.Debugf("initializing external change id cache with %d ids", len(externalIDs))
+
+	for _, c := range externalIDs {
+		ExternalChangeIDCache.Store(c, struct{}{})
+	}
+
+	return nil
+}

--- a/changes/externalIDCache.go
+++ b/changes/externalIDCache.go
@@ -3,7 +3,8 @@ package changes
 import (
 	"sync"
 
-	"github.com/flanksource/config-db/api"
+	"github.com/flanksource/duty/context"
+
 	"github.com/flanksource/config-db/db/models"
 )
 
@@ -17,7 +18,7 @@ func AddToExteranlChangeIDCache(changes []*models.ConfigChange) {
 	}
 }
 
-func InitExternalChangeIDCache(ctx api.ScrapeContext) error {
+func InitExternalChangeIDCache(ctx context.Context) error {
 	var externalIDs []string
 	if err := ctx.DB().Select("external_change_id").Model(&models.ConfigChange{}).Where("external_change_id IS NOT NULL").Find(&externalIDs).Error; err != nil {
 		return err

--- a/changes/fingerprint_test.go
+++ b/changes/fingerprint_test.go
@@ -50,7 +50,45 @@ var _ = Describe("Change Fingerprints", func() {
 })
 
 func TestChangeFingerprints(t *testing.T) {
-
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Change Fingerprints Suite")
+}
+
+func TestFingerptingPlayground(t *testing.T) {
+	val := `{
+    "reason": "GitOperationFailed",
+    "source": {
+        "component": "source-controller"
+    },
+    "message": "failed to checkout and determine revision: unable to list remote for 'ssh://git@github.com/flanksource/aws-sandbox.git': ssh: handshake failed: knownhosts: key mismatch",
+    "metadata": {
+        "uid": "37c57cb4-8148-41bb-ae94-42c104b46e38",
+        "name": "aws-sandbox.17e5b206b0f6d6f1",
+        "namespace": "flux-system",
+        "resourceVersion": "300464456",
+        "creationTimestamp": "2024-08-15T09:44:51Z"
+    },
+    "involvedObject": {
+        "uid": "962f999c-a9bd-40a4-80bf-47c84b1ad750",
+        "kind": "GitRepository",
+        "name": "aws-sandbox",
+        "namespace": "flux-system",
+        "apiVersion": "source.toolkit.fluxcd.io/v1",
+        "resourceVersion": "300420822"
+    }
+}`
+
+	ch := models.ConfigChange{}
+	err := json.Unmarshal([]byte(val), &ch.Details)
+	if err != nil {
+		t.Fatal()
+	}
+	fp, err := changes.Fingerprint(&ch)
+	if err != nil {
+		t.Fail()
+	}
+
+	if fp != "fe3308b7187b2370ad8e16bd8cd5bad9" {
+		t.Fail()
+	}
 }

--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/flanksource/commons/logger"
 	"github.com/flanksource/config-db/api"
 	configsv1 "github.com/flanksource/config-db/api/v1"
+	"github.com/flanksource/config-db/changes"
 	"github.com/flanksource/config-db/controllers"
 	"github.com/flanksource/config-db/db"
 	"github.com/flanksource/duty"
@@ -59,6 +60,10 @@ func run(cmd *cobra.Command, args []string) error {
 	dedupWindow := api.DefaultContext.Properties().Duration("changes.dedup.window", time.Hour)
 	if err := db.InitChangeFingerprintCache(api.DefaultContext, dedupWindow); err != nil {
 		return fmt.Errorf("failed to initialize change fingerprint cache: %w", err)
+	}
+
+	if err := changes.InitExternalChangeIDCache(api.DefaultContext); err != nil {
+		return fmt.Errorf("failed to initialize external change ID cache: %w", err)
 	}
 
 	ctrl.SetLogger(logr.FromSlogHandler(logger.Handler()))

--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -58,11 +58,11 @@ func run(cmd *cobra.Command, args []string) error {
 	logger.SetLogLevel(k8sLogLevel)
 
 	dedupWindow := api.DefaultContext.Properties().Duration("changes.dedup.window", time.Hour)
-	if err := db.InitChangeFingerprintCache(api.DefaultContext, dedupWindow); err != nil {
+	if err := db.InitChangeFingerprintCache(api.DefaultContext.Context, dedupWindow); err != nil {
 		return fmt.Errorf("failed to initialize change fingerprint cache: %w", err)
 	}
 
-	if err := changes.InitExternalChangeIDCache(api.DefaultContext); err != nil {
+	if err := changes.InitExternalChangeIDCache(api.DefaultContext.Context); err != nil {
 		return fmt.Errorf("failed to initialize external change ID cache: %w", err)
 	}
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -48,11 +48,11 @@ var Serve = &cobra.Command{
 		api.DefaultContext = api.NewScrapeContext(dutyCtx)
 
 		dedupWindow := api.DefaultContext.Properties().Duration("changes.dedup.window", time.Hour)
-		if err := db.InitChangeFingerprintCache(api.DefaultContext, dedupWindow); err != nil {
+		if err := db.InitChangeFingerprintCache(api.DefaultContext.Context, dedupWindow); err != nil {
 			return fmt.Errorf("failed to initialize change fingerprint cache: %w", err)
 		}
 
-		if err := changes.InitExternalChangeIDCache(api.DefaultContext); err != nil {
+		if err := changes.InitExternalChangeIDCache(api.DefaultContext.Context); err != nil {
 			return fmt.Errorf("failed to initialize external change ID cache: %w", err)
 		}
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/flanksource/commons/logger"
 	"github.com/flanksource/config-db/api"
 	v1 "github.com/flanksource/config-db/api/v1"
+	"github.com/flanksource/config-db/changes"
 	"github.com/flanksource/config-db/db"
 	"github.com/flanksource/config-db/jobs"
 	"github.com/flanksource/duty"
@@ -49,6 +50,10 @@ var Serve = &cobra.Command{
 		dedupWindow := api.DefaultContext.Properties().Duration("changes.dedup.window", time.Hour)
 		if err := db.InitChangeFingerprintCache(api.DefaultContext, dedupWindow); err != nil {
 			return fmt.Errorf("failed to initialize change fingerprint cache: %w", err)
+		}
+
+		if err := changes.InitExternalChangeIDCache(api.DefaultContext); err != nil {
+			return fmt.Errorf("failed to initialize external change ID cache: %w", err)
 		}
 
 		serve(args)

--- a/db/changes.go
+++ b/db/changes.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/flanksource/duty/context"
+	"github.com/patrickmn/go-cache"
+
 	"github.com/flanksource/config-db/api"
 	"github.com/flanksource/config-db/db/models"
-	"github.com/patrickmn/go-cache"
 )
 
 var changeCacheByFingerprint = cache.New(time.Hour, time.Hour)
@@ -15,7 +17,7 @@ func changeFingeprintCacheKey(configID, fingerprint string) string {
 	return fmt.Sprintf("%s:%s", configID, fingerprint)
 }
 
-func InitChangeFingerprintCache(ctx api.ScrapeContext, window time.Duration) error {
+func InitChangeFingerprintCache(ctx context.Context, window time.Duration) error {
 	var changes []*models.ConfigChange
 	if err := ctx.DB().Where("fingerprint IS NOT NULL").Where("NOW() - created_at <= ?", window).Find(&changes).Error; err != nil {
 		return err

--- a/db/changes.go
+++ b/db/changes.go
@@ -75,6 +75,19 @@ func dedupChanges(window time.Duration, changes []*models.ConfigChange) ([]*mode
 	return nonDuped, deduped
 }
 
+func UpdateChangeByExternalID(ctx api.ScrapeContext, change *models.ConfigChange) error {
+	query := `
+	UPDATE config_changes
+	SET 
+		count = CASE 
+			WHEN details = ? THEN count
+			ELSE count + 1
+		END,
+		details = ?
+	WHERE external_change_id = ?`
+	return ctx.DB().Exec(query, change.Details, change.Details, change.ExternalChangeID).Error
+}
+
 func GetWorkflowRunCount(ctx api.ScrapeContext, workflowID string) (int64, error) {
 	var count int64
 	err := ctx.DB().Table("config_changes").


### PR DESCRIPTION
resolves: https://github.com/flanksource/config-db/issues/880

For a given  config, multiple changes _(distinct external change id_) could create the same fingerprint. 
Example: Two different `GitOperationFailed` events.

## Example:

| change_id | external_change_id | fingerprint | created_at |
| --------- | ------------------ | ----------- | ---------- |
| 1         | a                  | f          | 5h  |
| 2         | b                  | f          | 1m         |
| 3         | a                  | f          | 1s         |

