### PR TITLE
fix(aws scraper): handle empty name for ec2 instances

### DIFF
--- a/scrapers/aws/aws.go
+++ b/scrapers/aws/aws.go
@@ -1190,7 +1190,7 @@ func (aws Scraper) instances(ctx *AWSContext, config v1.AWS, results *v1.ScrapeR
 				Properties:          []*types.Property{getConsoleLink(ctx.Session.Region, v1.AWSEC2Instance, instance.InstanceID, nil)},
 				Config:              instance,
 				ConfigClass:         "VirtualMachine",
-				Name:                instance.GetHostname(),
+				Name:                lo.CoalesceOrEmpty(instance.GetHostname(), instance.InstanceID),
 				Aliases:             []string{"AmazonEC2/" + instance.InstanceID},
 				ID:                  instance.InstanceID,
 				Parents:             []v1.ConfigExternalKey{{Type: v1.AWSEC2VPC, ExternalID: instance.VpcID}},


### PR DESCRIPTION
when an Ec2 instance is in `Terminated` status, `GetHostname()` returns an empty string.

resolves: https://github.com/flanksource/config-db/issues/915