### PR TITLE
chore: add better error messages for scrape errors

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -8,6 +8,7 @@ import (
 	v1 "github.com/flanksource/config-db/api/v1"
 	"github.com/flanksource/config-db/db/models"
 	"github.com/flanksource/duty/context"
+	dutydb "github.com/flanksource/duty/db"
 	"github.com/samber/lo"
 )
 
@@ -118,7 +119,7 @@ func (t *TempCache) Get(ctx ScrapeContext, id string) (*models.ConfigItem, error
 
 	result := models.ConfigItem{}
 	if err := ctx.DB().Limit(1).Find(&result, "id = ? ", id).Error; err != nil {
-		return nil, err
+		return nil, dutydb.ErrorDetails(err)
 	}
 
 	if result.ID != "" {

--- a/scrapers/kubernetes/exclusions.go
+++ b/scrapers/kubernetes/exclusions.go
@@ -86,7 +86,7 @@ func (ctx *KubernetesContext) IgnoreChange(change v1.ChangeResult, event v1.Kube
 	}
 	changeTypeExclusion, changeSeverityExclusion, err := ctx.getObjectChangeExclusionAnnotations(string(event.InvolvedObject.UID))
 	if err != nil {
-		return false, fmt.Errorf("failed to get annotation for object from db (%s)", event.InvolvedObject.UID)
+		return false, fmt.Errorf("failed to get annotation for object from db (%s): %w", event.InvolvedObject.UID, err)
 	}
 
 	if changeTypeExclusion != "" {

--- a/scrapers/processors/json.go
+++ b/scrapers/processors/json.go
@@ -340,7 +340,7 @@ func (e Extract) Extract(ctx api.ScrapeContext, inputs ...v1.ScrapeResult) ([]v1
 		}
 
 		if parsed, err := input.Tags.Eval(input.Labels, input.ConfigString()); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to evaluate tags for result[%s]: %w", input.String(), err)
 		} else {
 			input.Tags = parsed
 		}


### PR DESCRIPTION
# Error 1:
My best assumption is that this is due to us adding a tag["zone"] = var, where var is an empty string, added more details about the config item here

![image](https://github.com/user-attachments/assets/c4613048-eb0f-4292-89d7-911b29c1eafe)


# Error 2:
We probably our trying to "get" items that do not exist (or are ignored) from temp cache/database, we should probably use .Find() in the `ctx.getObjectChangeExclusionAnnotations(string(event.InvolvedObject.UID))` function
![image](https://github.com/user-attachments/assets/8c59fbd1-9843-44d8-87c6-1414cbf30530)
