### PR TITLE
chore: do not append tags if empty

### DIFF
--- a/api/v1/interface.go
+++ b/api/v1/interface.go
@@ -421,6 +421,10 @@ func (t *Tags) Append(name, value string) {
 		return
 	}
 
+	if value == "" {
+		return
+	}
+
 	if *t == nil {
 		*t = make(Tags, 0, 1)
 	}


### PR DESCRIPTION
We have to do this check because terminated instances that get scraped do not have zones (which we get from subnet id which is empty in this case)

Should we:
a) Just handle for this case ?
b) Remove the tag eval error which says `failed to evaluate tags for result[VirtualMachine/ip-172-29-130-89.eu-west-1.compute.internal (i-07dbff1b152cd402e) relationships=400]: tag "zone" should specify either value, jsonpath or label`
c) in tags.append, skip if value is empty