### PR TITLE
fix: update scraper id for config item

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -116,12 +116,8 @@ func (t *TempCache) Get(ctx ScrapeContext, id string) (*models.ConfigItem, error
 		return &item, nil
 	}
 
-	q := ctx.DB().Limit(1).Where("id = ?", id)
-	if scraperID := ctx.ScraperID(); scraperID != "" {
-		q = q.Where("scraper_id = ?", scraperID)
-	}
 	result := models.ConfigItem{}
-	if err := q.Find(&result).Error; err != nil {
+	if err := ctx.DB().Limit(1).Find(&result, "id = ? ", id).Error; err != nil {
 		return nil, dutydb.ErrorDetails(err)
 	}
 

--- a/api/v1/interface.go
+++ b/api/v1/interface.go
@@ -161,6 +161,9 @@ func (summary ConfigTypeScrapeSummary) String() string {
 	if summary.Unchanged > 0 {
 		s = append(s, fmt.Sprintf("unchanged=%d", summary.Unchanged))
 	}
+	for _, w := range summary.Warnings {
+		s = append(s, "warning=%s", w)
+	}
 
 	if summary.Change != nil && len(summary.Change.Ignored) > 0 {
 		s = append(s, fmt.Sprintf("ignored=%d", lo.Sum(lo.Values(summary.Change.Ignored))))
@@ -235,6 +238,12 @@ func (t *ScrapeSummary) AddUnchanged(configType string) {
 	(*t)[configType] = v
 }
 
+func (t *ScrapeSummary) AddWarning(configType, warning string) {
+	v := (*t)[configType]
+	v.Warnings = append(v.Warnings, warning)
+	(*t)[configType] = v
+}
+
 type ChangeSummary struct {
 	Orphaned map[string]int `json:"orphaned,omitempty"`
 	Ignored  map[string]int `json:"ignored,omitempty"`
@@ -291,6 +300,7 @@ type ConfigTypeScrapeSummary struct {
 	Updated   int            `json:"updated,omitempty"`
 	Unchanged int            `json:"unchanged,omitempty"`
 	Change    *ChangeSummary `json:"change,omitempty"`
+	Warnings  []string       `json:"warnings,omitempty"`
 }
 
 // +kubebuilder:object:generate=false

--- a/db/config_scraper.go
+++ b/db/config_scraper.go
@@ -102,7 +102,7 @@ func PersistScrapeConfigFromCRD(ctx context.Context, scrapeConfig *v1.ScrapeConf
 	return changed, tx.Error
 }
 
-func GetScrapeConfigsOfAgent(ctx api.ScrapeContext, agentID uuid.UUID) ([]models.ConfigScraper, error) {
+func GetScrapeConfigsOfAgent(ctx context.Context, agentID uuid.UUID) ([]models.ConfigScraper, error) {
 	var configScrapers []models.ConfigScraper
 	err := ctx.DB().Where("deleted_at IS NULL").Find(&configScrapers, "agent_id = ?", agentID).Error
 	return configScrapers, err

--- a/db/update.go
+++ b/db/update.go
@@ -242,6 +242,14 @@ func updateCI(ctx api.ScrapeContext, result v1.ScrapeResult, ci, existing *model
 	if !mapStringEqual(existing.Tags, ci.Tags) {
 		updates["tags"] = ci.Tags
 	}
+
+	// This could happen when kubernetes scrapers are replaced and scrape
+	// same config items
+	if lo.FromPtr(existing.ScraperID) != lo.FromPtr(ci.ScraperID) {
+		updates["scraper_id"] = ci.ScraperID
+		ctx.Warnf("updated scraper_id of config[%s] from %s to %s", ci, existing.ScraperID, ci.ScraperID)
+	}
+
 	if ci.Properties != nil && len(*ci.Properties) > 0 && (existing.Properties == nil || !mapEqual(ci.Properties.AsMap(), existing.Properties.AsMap())) {
 		updates["properties"] = *ci.Properties
 	}

--- a/jobs/retention.go
+++ b/jobs/retention.go
@@ -12,12 +12,12 @@ import (
 
 func ProcessChangeRetentionRules(ctx job.JobRuntime) error {
 	ctx.History.ResourceType = JobResourceType
-	var activeScrapers []models.ConfigScraper
-	if err := ctx.DB().Where("deleted_at IS NULL").Find(&activeScrapers).Error; err != nil {
+	var allScrapers []models.ConfigScraper
+	if err := ctx.DB().Find(&allScrapers).Error; err != nil {
 		return err
 	}
 
-	for _, s := range activeScrapers {
+	for _, s := range allScrapers {
 		var spec v1.ScraperSpec
 		if err := json.Unmarshal([]byte(s.Spec), &spec); err != nil {
 			ctx.History.AddErrorf("failed to unmarshal scraper spec (%s): %v", s.ID, err)

--- a/scrapers/cron.go
+++ b/scrapers/cron.go
@@ -74,7 +74,7 @@ func SyncScrapeConfigs(sc api.ScrapeContext) {
 		Retention:  job.RetentionFew,
 		RunNow:     true,
 		Fn: func(jr job.JobRuntime) error {
-			scraperConfigsDB, err := db.GetScrapeConfigsOfAgent(sc, uuid.Nil)
+			scraperConfigsDB, err := db.GetScrapeConfigsOfAgent(jr.Context, uuid.Nil)
 			if err != nil {
 				return fmt.Errorf("error getting configs from database: %v", err)
 			}


### PR DESCRIPTION
This was causing a lot of bugs and unexpected results in catalog features

Old scrapers were replaced with new but config items' scraper id was not updated, and most of our post process jobs  use non deleted scraper_ids