### PR TITLE
fix: reconciler db

### DIFF
--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -83,6 +83,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	if err = (&controllers.ScrapeConfigReconciler{
 		Client: mgr.GetClient(),
+		DB:     dutyCtx.DB(),
 		Scheme: mgr.GetScheme(),
 		Log:    ctrl.Log.WithName("controllers").WithName("scrape_config"),
 	}).SetupWithManager(mgr); err != nil {

--- a/controllers/scrapeconfig_controller.go
+++ b/controllers/scrapeconfig_controller.go
@@ -22,6 +22,7 @@ import (
 
 	dutyContext "github.com/flanksource/duty/context"
 	"github.com/go-logr/logr"
+	"gorm.io/gorm"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -39,6 +40,7 @@ const ScrapeConfigFinalizerName = "scrapeConfig.config.flanksource.com"
 // ScrapeConfigReconciler reconciles a ScrapeConfig object
 type ScrapeConfigReconciler struct {
 	client.Client
+	DB     *gorm.DB
 	Scheme *runtime.Scheme
 	Log    logr.Logger
 }
@@ -69,7 +71,7 @@ func (r *ScrapeConfigReconciler) Reconcile(c context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	ctx := api.NewScrapeContext(dutyContext.NewContext(c)).WithScrapeConfig(scrapeConfig)
+	ctx := api.NewScrapeContext(dutyContext.NewContext(c).WithDB(r.DB, nil)).WithScrapeConfig(scrapeConfig)
 
 	// Check if it is deleted, remove scrape config
 	if !scrapeConfig.DeletionTimestamp.IsZero() {


### PR DESCRIPTION
The context the reconciler handler receives is a plain gocontext with no db in it.

Couldn't find a way to add a middleware to inject our duty context. 
So added the db as a struct field.