### PR TITLE
fix: handle nil ptr error for empty kubeconfig

### DIFF
--- a/scrapers/kubernetes/informers.go
+++ b/scrapers/kubernetes/informers.go
@@ -108,7 +108,7 @@ func (t *SharedInformerManager) getOrCreate(ctx api.ScrapeContext, apiVersion, k
 	defer t.mu.Unlock()
 
 	cacheKey := apiVersion + kind
-	kubeconfig := ctx.KubernetesRestConfig().Host
+	kubeconfig := lo.FromPtr(ctx.KubernetesRestConfig()).Host
 
 	if val, ok := t.cache[kubeconfig]; ok {
 		if data, ok := val[cacheKey]; ok {


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x87369e1]

goroutine 135 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:115 +0x1e5
panic({0x908ebc0?, 0xe27ef80?})
	/usr/local/go/src/runtime/panic.go:770 +0x132
github.com/flanksource/config-db/scrapers/kubernetes.(*SharedInformerManager).getOrCreate(0xe57c080, {{{{0xad06b40, 0xc00a73d650}, {0xad3d7f0, 0xc000b2c690}, 0x9f817a0, 0x9f817a8, {0xac81ce0, 0xc00045edf0}}}, 0xc005596fa8, ...}, ...)
	/app/scrapers/kubernetes/informers.go:111 +0x141
github.com/flanksource/config-db/scrapers/kubernetes.(*SharedInformerManager).Register(0x100000009c45a5e?, {{{{0xad06b40, 0xc00a73d650}, {0xad3d7f0, 0xc000b2c690}, 0x9f817a0, 0x9f817a8, {0xac81ce0, 0xc00045edf0}}}, 0xc005596fa8, ...}, ...)
	/app/scrapers/kubernetes/informers.go:42 +0xaa
github.com/flanksource/config-db/scrapers/kubernetes.WatchResources({{{{0xad06b40, 0xc00a73d650}, {0xad3d7f0, 0xc000b2c690}, 0x9f817a0, 0x9f817a8, {0xac81ce0, 0xc00045edf0}}}, 0xc005596fa8, {0x0, ...}, ...}, ...)
	/app/scrapers/kubernetes/events_watch.go:70 +0x5f8
github.com/flanksource/config-db/scrapers.scheduleScraperJob({{{{0xad06b40, 0xc00a73d650}, {0xad3d7f0, 0xc000b2c690}, 0x9f817a0, 0x9f817a8, {0xac81ce0, 0xc00045edf0}}}, 0xc005596fa8, {0x0, ...}, ...})
	/app/scrapers/cron.go:241 +0x4f8
github.com/flanksource/config-db/scrapers.SyncScrapeJob({{{{0xad06b40, 0xc00a73d650}, {0xad3d7f0, 0xc000b2c690}, 0x9f817a0, 0x9f817a8, {0xac81ce0, 0xc00045edf0}}}, 0xc005596fa8, {0x0, ...}, ...})
```