### PR TITLE
fix: aws resource exclusion logic

### DIFF
--- a/api/v1/aws.go
+++ b/api/v1/aws.go
@@ -97,7 +97,7 @@ func (aws AWS) Includes(resource string) bool {
 
 func (aws AWS) Excludes(resource string) bool {
 	if len(aws.Exclude) == 0 {
-		return !lo.ContainsBy(defaultAWSExclusions, func(item string) bool {
+		return lo.ContainsBy(defaultAWSExclusions, func(item string) bool {
 			return strings.EqualFold(item, resource)
 		})
 	}


### PR DESCRIPTION
Trusted advisor analyses were not running because of this