### PR TITLE
fix: kubernetes event creation timestamps

### DIFF
--- a/api/v1/kubernetes.go
+++ b/api/v1/kubernetes.go
@@ -8,7 +8,6 @@ import (
 	"github.com/flanksource/commons/collections"
 	"github.com/flanksource/duty"
 	"github.com/flanksource/duty/types"
-	"github.com/flanksource/mapstructure"
 	coreV1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -312,20 +311,6 @@ func (t *KubernetesEvent) AsMap() (map[string]any, error) {
 	}
 
 	return result, nil
-}
-
-func (t *KubernetesEvent) FromObj(obj any) error {
-	conf := mapstructure.DecoderConfig{
-		TagName: "json", // Need to set this to json because when `obj` is v1.Event there's no mapstructure struct tag.
-		Result:  t,
-	}
-
-	decoder, err := mapstructure.NewDecoder(&conf)
-	if err != nil {
-		return err
-	}
-
-	return decoder.Decode(obj)
 }
 
 func (t *KubernetesEvent) FromObjMap(obj any) error {

--- a/api/v1/kubernetes.go
+++ b/api/v1/kubernetes.go
@@ -314,10 +314,27 @@ func (t *KubernetesEvent) AsMap() (map[string]any, error) {
 }
 
 func (t *KubernetesEvent) FromObjMap(obj any) error {
+	if v, ok := obj.(coreV1.Event); ok {
+		// Don't go through marshalling/unmarshalling.
+		// Map manually.
+
+		t.InvolvedObject = (*InvolvedObject)(&v.InvolvedObject)
+		t.Metadata = &v.ObjectMeta
+		t.Reason = v.Reason
+		t.Message = v.Message
+		t.Source = map[string]string{
+			"component": v.Source.Component,
+			"host":      v.Source.Host,
+		}
+
+		return nil
+	}
+
 	b, err := json.Marshal(obj)
 	if err != nil {
 		return err
 	}
 
 	return json.Unmarshal(b, t)
+
 }

--- a/scrapers/kubernetes/events_test.go
+++ b/scrapers/kubernetes/events_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"testing"
+	"time"
 
 	v1 "github.com/flanksource/config-db/api/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -47,7 +48,7 @@ func TestEvent_FromObjMap(t *testing.T) {
 			},
 		}
 		var eventFromV1 v1.KubernetesEvent
-		if err := eventFromV1.FromObj(eventV1); err != nil {
+		if err := eventFromV1.FromObjMap(eventV1); err != nil {
 			t.Fatalf("error was not expected %v", err)
 		}
 
@@ -72,6 +73,25 @@ func TestEvent_FromObjMap(t *testing.T) {
 
 		if eventFromMap.Metadata == nil {
 			t.Fail()
+		}
+	})
+
+	t.Run("from map II", func(t *testing.T) {
+		eventMap := corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Time{
+					Time: time.Date(1995, 8, 1, 0, 0, 0, 0, time.UTC),
+				},
+			},
+		}
+
+		var expected v1.KubernetesEvent
+		if err := expected.FromObjMap(eventMap); err != nil {
+			t.Fatalf("error was not expected %v", err)
+		}
+
+		if !expected.Metadata.CreationTimestamp.Time.Equal(eventMap.ObjectMeta.CreationTimestamp.Time) {
+			t.Fatalf("creation timestamps do not match, expected %v, got %v", eventMap.ObjectMeta.CreationTimestamp.Time, expected.Metadata.CreationTimestamp.Time)
 		}
 	})
 }

--- a/scrapers/kubernetes/events_watch.go
+++ b/scrapers/kubernetes/events_watch.go
@@ -109,7 +109,7 @@ func WatchEvents(ctx api.ScrapeContext, config v1.Kubernetes) error {
 	ctx.Counter("kubernetes_scraper_event_watcher", "scraper_id", ctx.ScraperID()).Add(1)
 	for watchEvent := range watcher.ResultChan() {
 		var event v1.KubernetesEvent
-		if err := event.FromObj(watchEvent.Object); err != nil {
+		if err := event.FromObjMap(watchEvent.Object); err != nil {
 			ctx.Errorf("failed to unmarshal event (id=%s): %v", event.GetUID(), err)
 			continue
 		}


### PR DESCRIPTION
resolves: https://github.com/flanksource/config-db/issues/1007

mapstructure couldn't properly decode watch events into `v1.KubernetesEvent`. More specifically, the creation timestamp would get lost (it was zero value).

On the other hand, the events that came from a full scrape had the creation timestamp set.

This would cause mismatch in the change details and we would increment the count based on this logic: https://github.com/flanksource/duty/blob/main/views/030_config_changes.sql#L13