### PR TITLE
feat: discard diffs that are just reordering of lines

### DIFF
--- a/db/update.go
+++ b/db/update.go
@@ -779,6 +779,10 @@ func generateConfigChange(ctx api.ScrapeContext, newConf, prev models.ConfigItem
 		return nil, nil
 	}
 
+	if utils.IsReorderingDiff(diff) {
+		return nil, nil
+	}
+
 	patch, err := jsonpatch.CreateMergePatch([]byte(*newConf.Config), []byte(*prev.Config))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create merge patch: %w", err)

--- a/utils/diff.go
+++ b/utils/diff.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"bufio"
+	"strings"
+)
+
+// IsReorderingDiff returns true if the diff only contains reordered lines.
+func IsReorderingDiff(diff string) bool {
+	scanner := bufio.NewScanner(strings.NewReader(diff))
+	lines := make(map[string]struct{})
+
+	// discard the headers of the diff.
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "@@") && strings.Contains(line, "@@") {
+			break
+		}
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// For each line addition, we try to find the corresponding line removal
+		// and vice versa.
+		// If all lines are paired, then it's a reordering change.
+
+		if strings.HasPrefix(line, "+") {
+			opposite := strings.Replace(line, "+", "-", 1)
+			if _, ok := lines[opposite]; ok {
+				delete(lines, opposite)
+			} else {
+				lines[line] = struct{}{}
+			}
+		}
+
+		if strings.HasPrefix(line, "-") {
+			opposite := strings.Replace(line, "-", "+", 1)
+			if _, ok := lines[opposite]; ok {
+				delete(lines, opposite)
+			} else {
+				lines[line] = struct{}{}
+			}
+		}
+
+	}
+
+	return len(lines) == 0
+}

--- a/utils/diff_test.go
+++ b/utils/diff_test.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsReorderingDiff(t *testing.T) {
+	tests := []struct {
+		name string
+		diff string
+		want bool
+	}{
+		{
+			name: "reordered lines",
+			diff: "testdata/reordered.diff",
+			want: true,
+		},
+		{
+			name: "new line addition with reordered lines",
+			diff: "testdata/non-reordered.diff",
+			want: false,
+		},
+		{
+			name: "reordered lines",
+			diff: "testdata/number-reordered.diff",
+			want: true,
+		},
+		{
+			name: "config change",
+			diff: "testdata/config-change.diff",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diff, err := os.ReadFile(tt.diff)
+			if err != nil {
+				t.Errorf("error reading file: %v", err)
+			}
+
+			if got := IsReorderingDiff(string(diff)); got != tt.want {
+				t.Errorf("IsDiffAnOrderChange() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/utils/testdata/config-change.diff
+++ b/utils/testdata/config-change.diff
@@ -1,0 +1,12 @@
+--- a/config.yml
++++ b/config.yml
+@@ -1,7 +1,8 @@
+ server:
+-  host: localhost
++  host: 0.0.0.0
+   port: 8080
+ 
+ database:
+   name: myapp
+-  user: admin
++  user: app_user

--- a/utils/testdata/non-reordered.diff
+++ b/utils/testdata/non-reordered.diff
@@ -1,0 +1,17 @@
+--- before
++++ after
+@@ -145,11 +145,11 @@
+     "conditions": [
+       {
+         "status": "True",
+-        "type": "Initialized"
++        "type": "Ready"
+       },
+       {
+         "status": "True",
+-        "type": "Ready"
++        "type": "Initialized"
++        "color": "Blue"
+       },
+       {
+         "status": "True",

--- a/utils/testdata/number-reordered.diff
+++ b/utils/testdata/number-reordered.diff
@@ -1,0 +1,9 @@
+--- before
++++ after
+@@ -1,5 +1,5 @@
++Third line
+ First line
+ Second line
+-Third line
+ Fourth line
+ Fifth line

--- a/utils/testdata/reordered.diff
+++ b/utils/testdata/reordered.diff
@@ -1,0 +1,16 @@
+--- before
++++ after
+@@ -145,11 +145,11 @@
+     "conditions": [
+       {
+         "status": "True",
+-        "type": "Initialized"
++        "type": "Ready"
+       },
+       {
+         "status": "True",
+-        "type": "Ready"
++        "type": "Initialized"
+       },
+       {
+         "status": "True",


### PR DESCRIPTION
resolves: https://github.com/flanksource/config-db/issues/1015

@moshloop I think this is a more efficient way to filter out changes caused by re-ordering of `.status.conditions`.

We don't have to unmarshal and sort and works for diffs from any scrapers.

if we really want to limit this to `.status.conditions` check then that's also possible.