### PR TITLE
fix: config_changes_config_id_fkey

### DIFF
--- a/api/v1/interface.go
+++ b/api/v1/interface.go
@@ -220,7 +220,7 @@ func (t *ScrapeSummary) AddChangeSummary(configType string, cs ChangeSummary) {
 	v.Change = &ChangeSummary{
 		Ignored:          cs.Ignored,
 		Orphaned:         cs.Orphaned,
-		ForeginKeyErrors: cs.ForeginKeyErrors,
+		ForeignKeyErrors: cs.ForeignKeyErrors,
 	}
 	(*t)[configType] = v
 }
@@ -252,7 +252,7 @@ func (t *ScrapeSummary) AddWarning(configType, warning string) {
 type ChangeSummary struct {
 	Orphaned         map[string]int `json:"orphaned,omitempty"`
 	Ignored          map[string]int `json:"ignored,omitempty"`
-	ForeginKeyErrors int            `json:"foreign_key_errors,omitempty"`
+	ForeignKeyErrors int            `json:"foreign_key_errors,omitempty"`
 }
 
 func (t ChangeSummary) IsEmpty() bool {

--- a/db/update.go
+++ b/db/update.go
@@ -604,9 +604,11 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 		for _, c := range newChanges {
 			if err := ctx.DB().Create(&c).Error; err != nil {
 				if !dutydb.IsForeignKeyError(err) {
-					return summary, fmt.Errorf("failed to create config changes: %w", dutydb.ErrorDetails(err))
+					return summary, fmt.Errorf("failed to create config change: %w", dutydb.ErrorDetails(err))
 				}
-				summary.AddChangeSummary(c.ConfigType, v1.ChangeSummary{ForeginKeyErrors: 1})
+
+				ctx.Errorf("failed to save config change: (config:%s, details:%v changeType:%s, externalChangeID:%s)", c.ConfigID, c.Details, c.ChangeType, lo.FromPtr(c.ExternalChangeID))
+				summary.AddChangeSummary(c.ConfigType, v1.ChangeSummary{ForeignKeyErrors: 1})
 			}
 		}
 	}

--- a/scrapers/cron.go
+++ b/scrapers/cron.go
@@ -124,7 +124,6 @@ func SyncScrapeConfigs(sc context.Context) {
 			var existing []string
 			for _, m := range scraperConfigsDB {
 				existing = append(existing, m.ID.String())
-				existing = append(existing, consumeKubernetesWatchResourcesJobKey(m.ID.String()))
 				existing = append(existing, consumeKubernetesWatchEventsJobKey(m.ID.String()))
 			}
 
@@ -272,17 +271,11 @@ func scheduleScraperJob(sc api.ScrapeContext) error {
 			return fmt.Errorf("failed to watch kubernetes resources: %v", err)
 		}
 
-		eventsWatchJob := ConsumeKubernetesWatchEventsJobFunc(sc, config)
-		if err := eventsWatchJob.AddToScheduler(scrapeJobScheduler); err != nil {
-			return fmt.Errorf("failed to schedule kubernetes watch event consumer job: %v", err)
+		watchConsumerJob := ConsumeKubernetesWatchJobFunc(sc, config)
+		if err := watchConsumerJob.AddToScheduler(scrapeJobScheduler); err != nil {
+			return fmt.Errorf("failed to schedule kubernetes watch consumer job: %v", err)
 		}
-		scrapeJobs.Store(consumeKubernetesWatchEventsJobKey(sc.ScraperID()), eventsWatchJob)
-
-		resourcesWatchJob := ConsumeKubernetesWatchResourcesJobFunc(sc, config)
-		if err := resourcesWatchJob.AddToScheduler(scrapeJobScheduler); err != nil {
-			return fmt.Errorf("failed to schedule kubernetes watch resources consumer job: %v", err)
-		}
-		scrapeJobs.Store(consumeKubernetesWatchResourcesJobKey(sc.ScraperID()), resourcesWatchJob)
+		scrapeJobs.Store(consumeKubernetesWatchEventsJobKey(sc.ScraperID()), watchConsumerJob)
 	}
 
 	return nil
@@ -292,12 +285,12 @@ func consumeKubernetesWatchEventsJobKey(id string) string {
 	return id + "-consume-kubernetes-watch-events"
 }
 
-// ConsumeKubernetesWatchEventsJobFunc returns a job that consumes kubernetes watch events
+// ConsumeKubernetesWatchJobFunc returns a job that consumes kubernetes watch events
 // for the given config of the scrapeconfig.
-func ConsumeKubernetesWatchEventsJobFunc(sc api.ScrapeContext, config v1.Kubernetes) *job.Job {
+func ConsumeKubernetesWatchJobFunc(sc api.ScrapeContext, config v1.Kubernetes) *job.Job {
 	scrapeConfig := *sc.ScrapeConfig()
 	return &job.Job{
-		Name:         "ConsumeKubernetesWatchEvents",
+		Name:         "ConsumeKubernetesWatch",
 		Context:      sc.DutyContext().WithObject(sc.ScrapeConfig().ObjectMeta),
 		JobHistory:   true,
 		Singleton:    true,
@@ -307,42 +300,116 @@ func ConsumeKubernetesWatchEventsJobFunc(sc api.ScrapeContext, config v1.Kuberne
 		ID:           fmt.Sprintf("%s/%s", sc.ScrapeConfig().Namespace, sc.ScrapeConfig().Name),
 		ResourceType: job.ResourceTypeScraper,
 		Fn: func(ctx job.JobRuntime) error {
-			_ch, ok := kubernetes.WatchEventBuffers.Load(config.Hash())
-			if !ok {
-				return fmt.Errorf("no watcher found for config (scrapeconfig: %s) %s", scrapeConfig.GetUID(), config.Hash())
-			}
+			// TODO: Use priority queue
+			{
+				_ch, ok := kubernetes.WatchResourceBuffer.Load(config.Hash())
+				if !ok {
+					return fmt.Errorf("no resource watcher channel found for config (scrapeconfig: %s)", config.Hash())
+				}
+				ch := _ch.(chan *unstructured.Unstructured)
+				objs, _, _, _ := lo.Buffer(ch, len(ch))
 
-			ch := _ch.(chan v1.KubernetesEvent)
-			events, _, _, _ := lo.Buffer(ch, len(ch))
-
-			cc := api.NewScrapeContext(ctx.Context).WithScrapeConfig(&scrapeConfig).WithJobHistory(ctx.History).AsIncrementalScrape()
-			cc.Context = cc.Context.WithoutName().WithName(fmt.Sprintf("%s/%s", ctx.GetNamespace(), ctx.GetName()))
-			results, err := RunK8IncrementalScraper(cc, config, events)
-			if err != nil {
-				return err
-			}
-
-			if summary, err := db.SaveResults(cc, results); err != nil {
-				return fmt.Errorf("failed to save results: %w", err)
-			} else {
-				ctx.History.AddDetails("scrape_summary", summary)
-			}
-
-			for i := range results {
-				if results[i].Error != nil {
-					ctx.History.AddError(results[i].Error.Error())
-				} else {
-					ctx.History.SuccessCount++
+				// NOTE: The resource watcher can return multiple objects for the same NEW resource.
+				// Example: if a new pod is created, we'll get that pod object multiple times for different events.
+				// All those resource objects are seen as distinct new config items.
+				// Hence, we need to use the latest one otherwise saving fails
+				// as we'll be trying to BATCH INSERT multiple config items with the same id.
+				//
+				// In the process, we will lose diff changes though.
+				// If diff changes are necessary, then we can split up the results in such
+				// a way that no two objects in a batch have the same id.
+				objs = dedup(objs)
+				if err := consumeResources(ctx, scrapeConfig, config, objs); err != nil {
+					ctx.History.AddErrorf("failed to consume resources: %v", err)
+					return err
 				}
 			}
 
-			return nil
+			{
+				_ch, ok := kubernetes.WatchEventBuffers.Load(config.Hash())
+				if !ok {
+					return fmt.Errorf("no watcher found for config (scrapeconfig: %s) %s", scrapeConfig.GetUID(), config.Hash())
+				}
+
+				ch := _ch.(chan v1.KubernetesEvent)
+				events, _, _, _ := lo.Buffer(ch, len(ch))
+
+				return consumeWatchEvents(ctx, scrapeConfig, config, events)
+			}
 		},
 	}
 }
 
-func consumeKubernetesWatchResourcesJobKey(id string) string {
-	return id + "-consume-kubernetes-watch-resources"
+func consumeWatchEvents(ctx job.JobRuntime, scrapeConfig v1.ScrapeConfig, config v1.Kubernetes, events []v1.KubernetesEvent) error {
+	cc := api.NewScrapeContext(ctx.Context).WithScrapeConfig(&scrapeConfig).WithJobHistory(ctx.History).AsIncrementalScrape()
+	cc.Context = cc.Context.WithoutName().WithName(fmt.Sprintf("%s/%s", ctx.GetNamespace(), ctx.GetName()))
+	results, err := RunK8IncrementalScraper(cc, config, events)
+	if err != nil {
+		return err
+	}
+
+	if summary, err := db.SaveResults(cc, results); err != nil {
+		return fmt.Errorf("failed to save results: %w", err)
+	} else {
+		ctx.History.AddDetails("scrape_summary", summary)
+	}
+
+	for i := range results {
+		if results[i].Error != nil {
+			ctx.History.AddError(results[i].Error.Error())
+		} else {
+			ctx.History.SuccessCount++
+		}
+	}
+
+	return nil
+}
+
+func consumeResources(ctx job.JobRuntime, scrapeConfig v1.ScrapeConfig, config v1.Kubernetes, objs []*unstructured.Unstructured) error {
+	cc := api.NewScrapeContext(ctx.Context).WithScrapeConfig(&scrapeConfig).WithJobHistory(ctx.History).AsIncrementalScrape()
+	cc.Context = cc.Context.WithoutName().WithName(fmt.Sprintf("watch[%s/%s]", cc.GetNamespace(), cc.GetName()))
+	results, err := RunK8sObjectsScraper(cc, config, objs)
+	if err != nil {
+		return err
+	}
+
+	if summary, err := db.SaveResults(cc, results); err != nil {
+		return fmt.Errorf("failed to save %d results: %w", len(results), err)
+	} else {
+		ctx.History.AddDetails("scrape_summary", summary)
+	}
+
+	for i := range results {
+		if results[i].Error != nil {
+			ctx.History.AddError(results[i].Error.Error())
+		} else {
+			ctx.History.SuccessCount++
+		}
+	}
+
+	_deleteCh, ok := kubernetes.DeleteResourceBuffer.Load(config.Hash())
+	if !ok {
+		return fmt.Errorf("no resource watcher channel found for config (scrapeconfig: %s)", config.Hash())
+	}
+	deleteChan := _deleteCh.(chan string)
+
+	if len(deleteChan) > 0 {
+		deletedResourcesIDs, _, _, _ := lo.Buffer(deleteChan, len(deleteChan))
+
+		total, err := db.SoftDeleteConfigItems(ctx.Context, deletedResourcesIDs...)
+		if err != nil {
+			return fmt.Errorf("failed to delete %d resources: %w", len(deletedResourcesIDs), err)
+		} else if total != len(deletedResourcesIDs) {
+			ctx.GetSpan().SetAttributes(attribute.StringSlice("deletedResourcesIDs", deletedResourcesIDs))
+			if cc.PropertyOn(false, "log.missing") {
+				ctx.Logger.Warnf("attempted to delete %d resources but only deleted %d", len(deletedResourcesIDs), total)
+			}
+		}
+
+		ctx.History.SuccessCount += total
+	}
+
+	return nil
 }
 
 func dedup(objs []*unstructured.Unstructured) []*unstructured.Unstructured {
@@ -362,87 +429,6 @@ func dedup(objs []*unstructured.Unstructured) []*unstructured.Unstructured {
 	return output
 }
 
-// ConsumeKubernetesWatchEventsJobFunc returns a job that consumes kubernetes watch events
-// for the given config of the scrapeconfig.
-func ConsumeKubernetesWatchResourcesJobFunc(sc api.ScrapeContext, config v1.Kubernetes) *job.Job {
-	scrapeConfig := *sc.ScrapeConfig()
-	return &job.Job{
-		Name:         "ConsumeKubernetesWatchResources",
-		Context:      sc.DutyContext().WithObject(sc.ScrapeConfig().ObjectMeta),
-		JobHistory:   true,
-		Singleton:    true,
-		Retention:    job.RetentionFew,
-		Schedule:     "@every 15s",
-		ResourceID:   string(scrapeConfig.GetUID()),
-		ID:           fmt.Sprintf("%s/%s", sc.ScrapeConfig().Namespace, sc.ScrapeConfig().Name),
-		ResourceType: job.ResourceTypeScraper,
-		Fn: func(ctx job.JobRuntime) error {
-			_ch, ok := kubernetes.WatchResourceBuffer.Load(config.Hash())
-			if !ok {
-				return fmt.Errorf("no resource watcher channel found for config (scrapeconfig: %s)", config.Hash())
-			}
-			ch := _ch.(chan *unstructured.Unstructured)
-			objs, _, _, _ := lo.Buffer(ch, len(ch))
-
-			// NOTE: The resource watcher can return multiple objects for the same NEW resource.
-			// Example: if a new pod is created, we'll get that pod object multiple times for different events.
-			// All those resource objects are seen as distinct new config items.
-			// Hence, we need to use the latest one otherwise saving fails
-			// as we'll be trying to BATCH INSERT multiple config items with the same id.
-			//
-			// In the process, we will lose diff changes though.
-			// If diff changes are necessary, then we can split up the results in such
-			// a way that no two objects in a batch have the same id.
-			objs = dedup(objs)
-
-			cc := api.NewScrapeContext(ctx.Context).WithScrapeConfig(&scrapeConfig).WithJobHistory(ctx.History).AsIncrementalScrape()
-			cc.Context = cc.Context.WithoutName().WithName(fmt.Sprintf("watch[%s/%s]", cc.GetNamespace(), cc.GetName()))
-			results, err := RunK8sObjectsScraper(cc, config, objs)
-			if err != nil {
-				return err
-			}
-
-			if summary, err := db.SaveResults(cc, results); err != nil {
-				return fmt.Errorf("failed to save %d results: %w", len(results), err)
-			} else {
-				ctx.History.AddDetails("scrape_summary", summary)
-			}
-
-			for i := range results {
-				if results[i].Error != nil {
-					ctx.History.AddError(results[i].Error.Error())
-				} else {
-					ctx.History.SuccessCount++
-				}
-			}
-
-			_deleteCh, ok := kubernetes.DeleteResourceBuffer.Load(config.Hash())
-			if !ok {
-				return fmt.Errorf("no resource watcher channel found for config (scrapeconfig: %s)", config.Hash())
-			}
-			deleteChan := _deleteCh.(chan string)
-
-			if len(deleteChan) > 0 {
-				deletedResourcesIDs, _, _, _ := lo.Buffer(deleteChan, len(deleteChan))
-
-				total, err := db.SoftDeleteConfigItems(ctx.Context, deletedResourcesIDs...)
-				if err != nil {
-					return fmt.Errorf("failed to delete %d resources: %w", len(deletedResourcesIDs), err)
-				} else if total != len(deletedResourcesIDs) {
-					ctx.GetSpan().SetAttributes(attribute.StringSlice("deletedResourcesIDs", deletedResourcesIDs))
-					if sc.PropertyOn(false, "log.missing") {
-						ctx.Logger.Warnf("attempted to delete %d resources but only deleted %d", len(deletedResourcesIDs), total)
-					}
-				}
-
-				ctx.History.SuccessCount += total
-			}
-
-			return nil
-		},
-	}
-}
-
 func DeleteScrapeJob(id string) {
 	logger.Debugf("deleting scraper job for %s", id)
 
@@ -453,12 +439,6 @@ func DeleteScrapeJob(id string) {
 	}
 
 	if j, ok := scrapeJobs.Load(consumeKubernetesWatchEventsJobKey(id)); ok {
-		existingJob := j.(*job.Job)
-		existingJob.Unschedule()
-		scrapeJobs.Delete(id)
-	}
-
-	if j, ok := scrapeJobs.Load(consumeKubernetesWatchResourcesJobKey(id)); ok {
 		existingJob := j.(*job.Job)
 		existingJob.Unschedule()
 		scrapeJobs.Delete(id)

--- a/scrapers/cron.go
+++ b/scrapers/cron.go
@@ -251,6 +251,10 @@ func newScraperJob(sc api.ScrapeContext) *job.Job {
 func scheduleScraperJob(sc api.ScrapeContext) error {
 	j := newScraperJob(sc)
 
+	if sc.PropertyOn(false, "disable") {
+		return nil
+	}
+
 	scrapeJobs.Store(sc.ScraperID(), j)
 	if err := j.AddToScheduler(scrapeJobScheduler); err != nil {
 		return fmt.Errorf("[%s] failed to schedule %v", j.Name, err)

--- a/scrapers/kubernetes/events_watch.go
+++ b/scrapers/kubernetes/events_watch.go
@@ -127,7 +127,9 @@ func WatchEvents(ctx api.ScrapeContext, config v1.Kubernetes) error {
 			continue
 		}
 
-		// TODO: Labels missing in here
+		// NOTE: Labels missing in here
+		// as a result we have to make of the ignoredConfigsCache to filter out events of resources that have been excluded
+		// with labels.
 		if config.Exclusions.Filter(event.InvolvedObject.Name, event.InvolvedObject.Namespace, event.InvolvedObject.Kind, nil) {
 			continue
 		}

--- a/scrapers/kubernetes/events_watch.go
+++ b/scrapers/kubernetes/events_watch.go
@@ -127,6 +127,7 @@ func WatchEvents(ctx api.ScrapeContext, config v1.Kubernetes) error {
 			continue
 		}
 
+		// TODO: Labels missing in here
 		if config.Exclusions.Filter(event.InvolvedObject.Name, event.InvolvedObject.Namespace, event.InvolvedObject.Kind, nil) {
 			continue
 		}


### PR DESCRIPTION
resolves: https://github.com/flanksource/config-db/issues/1168

This happens on two scenarsio

**1. Resources watched via the resource watcher are created and then deleted when config-db is down.**

In this case, when config-db is back up 
- the resource watcher will not receive the object _(if it was live, then it would have)._
- however, the event watcher will still receive all the events for that object. The configs aren't excluded _(they are missed)_ so we try to save the changes.

**2.** (bug) if an object is excluded via labels

The object gets excluded due to the label.
However, the event cannot exclude it as the event object's involved object doesn't have the label.

Adding exclusion cache doesn't help because if the event consumer runs first before it's excluded, we run into the same issue.