### PR TITLE
feat: shared informer priority queue improvements

### DIFF
--- a/scrapers/incremental.go
+++ b/scrapers/incremental.go
@@ -73,7 +73,7 @@ func ConsumeKubernetesWatchJobFunc(sc api.ScrapeContext, config v1.Kubernetes, q
 				}
 				obj := queueItem.Obj
 
-				if queueItem.Operation == "delete" {
+				if queueItem.Operation == kubernetes.QueueItemOperationDelete {
 					deletedObjects = append(deletedObjects, string(obj.GetUID()))
 					continue
 				}

--- a/scrapers/kubernetes/informers.go
+++ b/scrapers/kubernetes/informers.go
@@ -386,11 +386,24 @@ func pqCompareOperation(a, b QueueItemOperation) int {
 func pqCompareKind(a, b string) int {
 	// smaller means earlier in the queue
 	priority := map[string]int{
-		"Namespace":  1,
-		"Deployment": 2,
-		"ReplicaSet": 3,
-		"Pod":        4,
-		"Event":      5,
+		"Namespace":          1,
+		"Deployment":         2,
+		"StatefulSet":        2,
+		"DaemonSet":          2,
+		"Service":            2,
+		"ClusterRole":        2,
+		"Role":               2,
+		"HelmChart":          2,
+		"HelmRepository":     2,
+		"OCIRepository":      2,
+		"ClusterRoleBinding": 3,
+		"RoleBinding":        3,
+		"Endpoints":          3,
+		"CronJob":            3,
+		"Job":                3,
+		"ReplicaSet":         3,
+		"Pod":                4,
+		"Event":              5,
 	}
 
 	pa := lo.CoalesceOrEmpty(priority[a], 3)

--- a/scrapers/kubernetes/informers_test.go
+++ b/scrapers/kubernetes/informers_test.go
@@ -1,0 +1,171 @@
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/emirpasic/gods/queues/priorityqueue"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestPqComparator(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		a        QueueItem
+		b        QueueItem
+		expected []string
+	}{
+		{
+			name: "add should have higher priority than update",
+			a: QueueItem{
+				Operation: "add",
+				Obj:       getUnstructured("Pod", "a", now),
+			},
+			b: QueueItem{
+				Operation: "update",
+				Obj:       getUnstructured("Pod", "b", now),
+			},
+			expected: []string{"a", "b"},
+		},
+		{
+			name: "update should have higher priority than delete",
+			a: QueueItem{
+				Operation: "update",
+				Obj:       getUnstructured("Pod", "a", now),
+			},
+			b: QueueItem{
+				Operation: "delete",
+				Obj:       getUnstructured("Pod", "b", now),
+			},
+			expected: []string{"a", "b"},
+		},
+		{
+			name: "same operation should compare by kind - Namespace vs Pod",
+			a: QueueItem{
+				Operation: "add",
+				Obj:       getUnstructured("Namespace", "a", now),
+			},
+			b: QueueItem{
+				Operation: "add",
+				Obj:       getUnstructured("Pod", "b", now),
+			},
+			expected: []string{"a", "b"},
+		},
+		{
+			name: "same operation and kind should compare by timestamp - earlier first",
+			a: QueueItem{
+				Operation: "add",
+				Obj:       getUnstructured("Pod", "a", now.Add(-1*time.Hour)),
+			},
+			b: QueueItem{
+				Operation: "add",
+				Obj:       getUnstructured("Pod", "b", now),
+			},
+			expected: []string{"a", "b"},
+		},
+		{
+			name: "namespace comes first even before a pod created earlier",
+			a: QueueItem{
+				Operation: "add",
+				Obj:       getUnstructured("Pod", "a", now.Add(-1*time.Hour)),
+			},
+			b: QueueItem{
+				Operation: "add",
+				Obj:       getUnstructured("Namespace", "b", now),
+			},
+			expected: []string{"b", "a"},
+		},
+		{
+			name: "operation priority should override kind priority",
+			a: QueueItem{
+				Operation: "add",
+				Obj:       getUnstructured("Pod", "a", now),
+			},
+			b: QueueItem{
+				Operation: "delete",
+				Obj:       getUnstructured("Namespace", "b", now),
+			},
+			expected: []string{"a", "b"},
+		},
+		{
+			name: "unknown kind should use default priority",
+			a: QueueItem{
+				Operation: "add",
+				Obj:       getUnstructured("Canary", "a", now),
+			},
+			b: QueueItem{
+				Operation: "add",
+				Obj:       getUnstructured("Pod", "b", now),
+			},
+			expected: []string{"a", "b"},
+		},
+		{
+			name: "events with managed fields",
+			a: QueueItem{
+				Operation: "add",
+				Obj:       getUnstructuredEvent("Event", "a", now.Add(-2*time.Hour), now.Add(time.Hour)), // created ealier but re-created later
+			},
+			b: QueueItem{
+				Operation: "add",
+				Obj:       getUnstructuredEvent("Event", "b", now.Add(-time.Hour), now.Add(time.Minute)),
+			},
+			expected: []string{"b", "a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := priorityqueue.NewWith(pqComparator)
+			q.Enqueue(&tt.a)
+			q.Enqueue(&tt.b)
+
+			var result []string
+			for {
+				v, ok := q.Dequeue()
+				if !ok {
+					break
+				}
+
+				item := v.(*QueueItem)
+				result = append(result, item.Obj.GetName())
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("Test %s failed\nExpected: %v\nGot: %v", tt.name, tt.expected, result)
+			}
+		})
+	}
+}
+
+func getUnstructuredEvent(kind, name string, creationTimestamp, recreationTimestamp time.Time) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"kind": kind,
+			"metadata": map[string]any{
+				"name":              name,
+				"creationTimestamp": creationTimestamp.Format(time.RFC3339),
+				"managedFields": []any{
+					map[string]any{
+						"operation": "Update",
+						"time":      recreationTimestamp.Format(time.RFC3339),
+					},
+				},
+			},
+		},
+	}
+}
+
+func getUnstructured(kind, name string, creationTimestamp time.Time) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"kind": kind,
+			"metadata": map[string]any{
+				"name":              name,
+				"creationTimestamp": creationTimestamp.Format(time.RFC3339),
+			},
+		},
+	}
+}

--- a/scrapers/kubernetes/informers_test.go
+++ b/scrapers/kubernetes/informers_test.go
@@ -21,11 +21,11 @@ func TestPqComparator(t *testing.T) {
 		{
 			name: "add should have higher priority than update",
 			a: QueueItem{
-				Operation: "add",
+				Operation: QueueItemOperationAdd,
 				Obj:       getUnstructured("Pod", "a", now),
 			},
 			b: QueueItem{
-				Operation: "update",
+				Operation: QueueItemOperationUpdate,
 				Obj:       getUnstructured("Pod", "b", now),
 			},
 			expected: []string{"a", "b"},
@@ -33,11 +33,11 @@ func TestPqComparator(t *testing.T) {
 		{
 			name: "update should have higher priority than delete",
 			a: QueueItem{
-				Operation: "update",
+				Operation: QueueItemOperationUpdate,
 				Obj:       getUnstructured("Pod", "a", now),
 			},
 			b: QueueItem{
-				Operation: "delete",
+				Operation: QueueItemOperationDelete,
 				Obj:       getUnstructured("Pod", "b", now),
 			},
 			expected: []string{"a", "b"},
@@ -45,11 +45,11 @@ func TestPqComparator(t *testing.T) {
 		{
 			name: "same operation should compare by kind - Namespace vs Pod",
 			a: QueueItem{
-				Operation: "add",
+				Operation: QueueItemOperationAdd,
 				Obj:       getUnstructured("Namespace", "a", now),
 			},
 			b: QueueItem{
-				Operation: "add",
+				Operation: QueueItemOperationAdd,
 				Obj:       getUnstructured("Pod", "b", now),
 			},
 			expected: []string{"a", "b"},
@@ -57,11 +57,11 @@ func TestPqComparator(t *testing.T) {
 		{
 			name: "same operation and kind should compare by timestamp - earlier first",
 			a: QueueItem{
-				Operation: "add",
+				Operation: QueueItemOperationAdd,
 				Obj:       getUnstructured("Pod", "a", now.Add(-1*time.Hour)),
 			},
 			b: QueueItem{
-				Operation: "add",
+				Operation: QueueItemOperationAdd,
 				Obj:       getUnstructured("Pod", "b", now),
 			},
 			expected: []string{"a", "b"},
@@ -69,11 +69,11 @@ func TestPqComparator(t *testing.T) {
 		{
 			name: "namespace comes first even before a pod created earlier",
 			a: QueueItem{
-				Operation: "add",
+				Operation: QueueItemOperationAdd,
 				Obj:       getUnstructured("Pod", "a", now.Add(-1*time.Hour)),
 			},
 			b: QueueItem{
-				Operation: "add",
+				Operation: QueueItemOperationAdd,
 				Obj:       getUnstructured("Namespace", "b", now),
 			},
 			expected: []string{"b", "a"},
@@ -81,11 +81,11 @@ func TestPqComparator(t *testing.T) {
 		{
 			name: "operation priority should override kind priority",
 			a: QueueItem{
-				Operation: "add",
+				Operation: QueueItemOperationAdd,
 				Obj:       getUnstructured("Pod", "a", now),
 			},
 			b: QueueItem{
-				Operation: "delete",
+				Operation: QueueItemOperationDelete,
 				Obj:       getUnstructured("Namespace", "b", now),
 			},
 			expected: []string{"a", "b"},
@@ -93,11 +93,11 @@ func TestPqComparator(t *testing.T) {
 		{
 			name: "unknown kind should use default priority",
 			a: QueueItem{
-				Operation: "add",
+				Operation: QueueItemOperationAdd,
 				Obj:       getUnstructured("Canary", "a", now),
 			},
 			b: QueueItem{
-				Operation: "add",
+				Operation: QueueItemOperationAdd,
 				Obj:       getUnstructured("Pod", "b", now),
 			},
 			expected: []string{"a", "b"},
@@ -105,11 +105,11 @@ func TestPqComparator(t *testing.T) {
 		{
 			name: "events with managed fields",
 			a: QueueItem{
-				Operation: "add",
+				Operation: QueueItemOperationAdd,
 				Obj:       getUnstructuredEvent("Event", "a", now.Add(-2*time.Hour), now.Add(time.Hour)), // created ealier but re-created later
 			},
 			b: QueueItem{
-				Operation: "add",
+				Operation: QueueItemOperationAdd,
 				Obj:       getUnstructuredEvent("Event", "b", now.Add(-time.Hour), now.Add(time.Minute)),
 			},
 			expected: []string{"b", "a"},


### PR DESCRIPTION
* use queue for deleted objects as well. Get rid of delete buffers so every updates from the shared informers go into the queue.