### PR TITLE
chore: exclude events in full scrape

### DIFF
--- a/scrapers/kubernetes/ketall.go
+++ b/scrapers/kubernetes/ketall.go
@@ -42,7 +42,7 @@ func updateOptions(ctx context.Context, opts *options.KetallOptions, config v1.K
 	opts.FieldSelector = config.FieldSelector
 	opts.UseCache = config.UseCache
 	opts.MaxInflight = config.MaxInflight
-	opts.Exclusions = append(config.Exclusions.List(), "componentstatuses")
+	opts.Exclusions = append(config.Exclusions.List(), "componentstatuses", "Event")
 	opts.Since = config.Since
 	if config.Kubeconfig != nil {
 		val, err := ctx.GetEnvValueFromCache(*config.Kubeconfig, ctx.GetNamespace())


### PR DESCRIPTION
We were processing the same events again and again due to having both a Watcher for events and full scrape