### PR TITLE
chore: handle nil for pq

### DIFF
--- a/scrapers/kubernetes/informers.go
+++ b/scrapers/kubernetes/informers.go
@@ -357,6 +357,10 @@ func NewQueueItem(obj *unstructured.Unstructured, operation QueueItemOperation) 
 }
 
 func pqComparator(a, b any) int {
+	if a == nil || b == nil {
+		return 0
+	}
+
 	qa := a.(*QueueItem)
 	qb := b.(*QueueItem)
 


### PR DESCRIPTION
Got this error, not sure why since nil objects do not go into queue

```
panic: interface conversion: interface {} is nil, not *kubernetes.QueueItem

goroutine 3048372 [running]:
github.com/flanksource/config-db/scrapers/kubernetes.pqComparator({0x0?, 0x0?}, {0x8b41ce0?, 0xc0080548c0?})
	/home/yash/Work/config-db/scrapers/kubernetes/informers.go:353 +0x31d
github.com/emirpasic/gods/trees/binaryheap.(*Heap).bubbleDownIndex(0xc001563ad0, 0x0?)
	/home/yash/go/pkg/mod/github.com/emirpasic/gods@v1.18.1/trees/binaryheap/binaryheap.go:133 +0xf0
github.com/emirpasic/gods/trees/binaryheap.(*Heap).bubbleDown(...)
	/home/yash/go/pkg/mod/github.com/emirpasic/gods@v1.18.1/trees/binaryheap/binaryheap.go:121
github.com/emirpasic/gods/trees/binaryheap.(*Heap).Pop(0xc001563ad0?)
	/home/yash/go/pkg/mod/github.com/emirpasic/gods@v1.18.1/trees/binaryheap/binaryheap.go:73 +0x251
github.com/emirpasic/gods/queues/priorityqueue.(*Queue).Dequeue(...)
	/home/yash/go/pkg/mod/github.com/emirpasic/gods@v1.18.1/queues/priorityqueue/priorityqueue.go:48
github.com/flanksource/config-db/scrapers.ConsumeKubernetesWatchJobFunc.func1({{{{0xa9994e0, 0xc003cab230}, {0xa9d1010, 0xc0042ade60}, 0x9fa2a80, 0x9fa2a88, {0xa913390, 0xc000874720}}}, 0xc0010ca160, {0xa9b66b0, ...}, ...})
	/home/yash/Work/config-db/scrapers/incremental.go:65 +0x830
github.com/flanksource/duty/job.(*Job).Run(0xc0010ca160)
	/home/yash/go/pkg/mod/github.com/flanksource/duty@v1.0.766/job/job.go:426 +0x14dd
github.com/robfig/cron/v3.(*Cron).startJob.func1()
	/home/yash/go/pkg/mod/github.com/robfig/cron/v3@v3.0.1/cron.go:312 +0x55
created by github.com/robfig/cron/v3.(*Cron).startJob in goroutine 90
	/home/yash/go/pkg/mod/github.com/robfig/cron/v3@v3.0.1/cron.go:310 +0x90
exit status 2
```