### PR TITLE
fix: scraper_added metrics

### DIFF
--- a/db/update.go
+++ b/db/update.go
@@ -568,6 +568,7 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 	}
 	for _, config := range extractResult.newConfigs {
 		summary.AddInserted(config.Type)
+		ctx.TempCache().Insert(*config)
 	}
 
 	// nonUpdatedConfigs are existing configs that were not updated in this scrape.


### PR DESCRIPTION
when a new config was inserted, we never updated the temp cache. As a result, once the config is set as not found - any subsequent Get() calls to that config returns not found and we treat the same config as a new one.

resolves: https://github.com/flanksource/config-db/issues/1242