### PR TITLE
fix: sync cache on config updates

### DIFF
--- a/db/update.go
+++ b/db/update.go
@@ -584,6 +584,7 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 
 		if updated {
 			summary.AddUpdated(updateArg.Existing.Type)
+			ctx.TempCache().Insert(*updateArg.New)
 		} else {
 			summary.AddUnchanged(updateArg.Existing.Type)
 			nonUpdatedConfigs = append(nonUpdatedConfigs, updateArg.Existing.ID)


### PR DESCRIPTION
resolves: https://github.com/flanksource/config-db/issues/1249

This happened after a full scrape when we run `InitTempCache` which caches the entire configs of the scraper to `scraperTempCache`.

During scaling up (from replica 1 to 4)

- first event:
all replicas aren't ready so we save `health = warning` to the db. But this was never updated in the cache.

- second event:
all replicas are ready so we try to update the config `health = healthy`.
The comparison is done against the stale cache which also has `health = healthy`.
config-db sees no change in health and doesn't update the health in db leaving a fully ready deployment in a warning state.