### PR TITLE
fix(chart): additional properties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ $(KUSTOMIZE): $(LOCALBIN)
 
 .PHONY: chart
 chart: helm-docs helm-schema
-	cd chart && helm-schema -k additionalProperties && helm-docs
+	cd chart && ../.bin/helm-schema -k additionalProperties && ../.bin/helm-docs
 
 .PHONY: helm-docs
 helm-docs:

--- a/chart/README.md
+++ b/chart/README.md
@@ -25,6 +25,7 @@ A Helm chart for config-db
 | env | object | `{}` |  |
 | extra | object | `{}` |  |
 | extraArgs | object | `{}` |  |
+| extraEnvFrom | list | `[]` |  |
 | global.affinity | object | `{}` |  |
 | global.db.connectionPooler.enabled | bool | `false` |  |
 | global.db.connectionPooler.secretKeyRef.key | string | `"DB_URL"` |  |
@@ -37,7 +38,7 @@ A Helm chart for config-db
 | global.otel.collector | string | `""` |  |
 | global.otel.labels | string | `""` |  |
 | global.serviceAccount.annotations | object | `{}` |  |
-| global.serviceAccount.name | string | `nil` |  |
+| global.serviceAccount.name | string | `""` |  |
 | global.serviceMonitor.enabled | bool | `false` |  |
 | global.serviceMonitor.labels | object | `{}` |  |
 | global.tolerations | list | `[]` |  |

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1,9 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "additionalProperties": false,
   "properties": {
     "affinity": {
-      "additionalProperties": false,
       "required": [],
       "title": "affinity",
       "type": "object"
@@ -135,21 +133,18 @@
       "type": "boolean"
     },
     "env": {
-      "additionalProperties": false,
       "description": "environment variables to add e.g. GOMEMLIMIT",
       "required": [],
       "title": "env",
       "type": "object"
     },
     "extra": {
-      "additionalProperties": false,
       "description": "Extra values to be applied to the pod spec",
       "required": [],
       "title": "extra",
       "type": "object"
     },
     "extraArgs": {
-      "additionalProperties": false,
       "description": "command line arguments to config-db",
       "required": [],
       "title": "extraArgs",
@@ -164,20 +159,16 @@
       "title": "extraEnvFrom"
     },
     "global": {
-      "additionalProperties": false,
       "description": "yaml-language-server: $schema=values.schema.json\nDefault values for config-db.\nDeclare variables to be passed into your templates.\nyaml-language-server: $schema=./values.schema.json",
       "properties": {
         "affinity": {
-          "additionalProperties": false,
           "required": [],
           "title": "affinity",
           "type": "object"
         },
         "db": {
-          "additionalProperties": false,
           "properties": {
             "connectionPooler": {
-              "additionalProperties": false,
               "properties": {
                 "enabled": {
                   "default": false,
@@ -186,7 +177,6 @@
                   "type": "boolean"
                 },
                 "secretKeyRef": {
-                  "additionalProperties": false,
                   "properties": {
                     "key": {
                       "default": "DB_URL",
@@ -244,19 +234,16 @@
           "type": "string"
         },
         "labels": {
-          "additionalProperties": false,
           "required": [],
           "title": "labels",
           "type": "object"
         },
         "nodeSelector": {
-          "additionalProperties": false,
           "required": [],
           "title": "nodeSelector",
           "type": "object"
         },
         "otel": {
-          "additionalProperties": false,
           "properties": {
             "collector": {
               "default": "",
@@ -279,10 +266,8 @@
           "type": "object"
         },
         "serviceAccount": {
-          "additionalProperties": false,
           "properties": {
             "annotations": {
-              "additionalProperties": false,
               "required": [],
               "title": "annotations",
               "type": "object"
@@ -303,7 +288,6 @@
           "type": "object"
         },
         "serviceMonitor": {
-          "additionalProperties": false,
           "properties": {
             "enabled": {
               "default": false,
@@ -312,7 +296,6 @@
               "type": "boolean"
             },
             "labels": {
-              "additionalProperties": false,
               "required": [],
               "title": "labels",
               "type": "object"
@@ -351,7 +334,6 @@
       "type": "object"
     },
     "image": {
-      "additionalProperties": false,
       "properties": {
         "name": {
           "default": "{{.Values.global.imagePrefix}}/config-db",
@@ -393,7 +375,6 @@
       "additionalProperties": false,
       "properties": {
         "annotations": {
-          "additionalProperties": false,
           "required": [],
           "title": "annotations",
           "type": "object"
@@ -448,7 +429,6 @@
       "type": "string"
     },
     "nodeSelector": {
-      "additionalProperties": false,
       "required": [],
       "title": "nodeSelector",
       "type": "object"
@@ -485,7 +465,6 @@
       "title": "otel"
     },
     "podSecurityContext": {
-      "additionalProperties": false,
       "properties": {
         "fsGroup": {
           "default": 1000,
@@ -500,7 +479,6 @@
       "title": "podSecurityContext"
     },
     "properties": {
-      "additionalProperties": false,
       "description": "config-db properties to override",
       "required": [],
       "title": "properties",
@@ -516,7 +494,6 @@
       "additionalProperties": false,
       "properties": {
         "limits": {
-          "additionalProperties": false,
           "properties": {
             "cpu": {
               "default": "500m",
@@ -539,7 +516,6 @@
           "type": "object"
         },
         "requests": {
-          "additionalProperties": false,
           "properties": {
             "cpu": {
               "default": "200m",
@@ -584,7 +560,6 @@
       "type": "array"
     },
     "securityContext": {
-      "additionalProperties": false,
       "required": [],
       "title": "securityContext",
       "type": "object"
@@ -593,7 +568,6 @@
       "additionalProperties": false,
       "properties": {
         "annotations": {
-          "additionalProperties": false,
           "required": [],
           "title": "annotations",
           "type": "object"
@@ -673,7 +647,6 @@
       "title": "serviceAccount"
     },
     "serviceMonitor": {
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "default": false,
@@ -702,7 +675,6 @@
       "type": "array"
     },
     "upstream": {
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "default": false,
@@ -717,7 +689,6 @@
           "type": "integer"
         },
         "secretKeyRef": {
-          "additionalProperties": false,
           "properties": {
             "name": {
               "default": "config-db-upstream",


### PR DESCRIPTION
additionalProperties were set to `false` here: https://github.com/flanksource/config-db/pull/1397

Upgrades were failing

```
Helm upgrade failed for release mission-control/mission-control with chart mission-control@0.1.237-beta.1: values don't meet the specifications of the schema(s) in the following chart(s):
config-db:
- global: Additional property logLevel is not allowed
- global: Additional property ui is not allowed
- global: Additional property api is not allowed
- global.db.connectionPooler: Additional property extraContainers is not allowed
- global.db.connectionPooler: Additional property image is not allowed
- global.db.connectionPooler: Additional property serviceAccount is not allowed
- serviceAccount.annotations: Additional property eks.amazonaws.com/role-arn is not allowed
```