### PR TITLE
fix: handle empty vpc id for eks

### DIFF
--- a/scrapers/aws/aws.go
+++ b/scrapers/aws/aws.go
@@ -742,6 +742,11 @@ func (aws Scraper) eksClusters(ctx *AWSContext, config v1.AWS, results *v1.Scrap
 			Relationship:      "EKSSecuritygroups",
 		})
 
+		var parents []v1.ConfigExternalKey
+		if vpcID := lo.FromPtr(cluster.Cluster.ResourcesVpcConfig.VpcId); vpcID != "" {
+			parents = []v1.ConfigExternalKey{{Type: v1.AWSEC2VPC, ExternalID: vpcID}}
+		}
+
 		cluster.Cluster.Tags["account"] = lo.FromPtr(ctx.Caller.Account)
 		cluster.Cluster.Tags["region"] = getRegionFromArn(*cluster.Cluster.Arn, "eks")
 
@@ -758,7 +763,7 @@ func (aws Scraper) eksClusters(ctx *AWSContext, config v1.AWS, results *v1.Scrap
 			Aliases:             []string{*cluster.Cluster.Arn, "AmazonEKS/" + *cluster.Cluster.Arn},
 			ID:                  *cluster.Cluster.Arn,
 			Ignore:              []string{"createdAt", "name"},
-			Parents:             []v1.ConfigExternalKey{{Type: v1.AWSEC2VPC, ExternalID: *cluster.Cluster.ResourcesVpcConfig.VpcId}},
+			Parents:             parents,
 			RelationshipResults: relationships,
 		})
 


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x990a660]

goroutine 12906 [running]:
github.com/flanksource/config-db/scrapers/aws.Scraper.eksClusters({}, _, {{{{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, ...}, ...}, ...}, ...)
	/app/scrapers/aws/aws.go:761 +0xce0
github.com/flanksource/config-db/scrapers/aws.Scraper.Scrape({}, {{{{0xc72c570, 0xc00d5485a0}, {0xc7769d0, 0xc00d548480}, 0xbc50718, 0xbc50720, {0xc6983f0, 0xc0009e8540}}}, 0xc001110d20, ...})
	/app/scrapers/aws/aws.go:1846 +0xba8
github.com/flanksource/config-db/scrapers.Run({{{{0xc72c570, 0xc00d5485a0}, {0xc7769d0, 0xc00d548480}, 0xbc50718, 0xbc50720, {0xc6983f0, 0xc0009e8540}}}, 0xc001110d20, 0x0, ...})
	/app/scrapers/run.go:112 +0x4bd
github.com/flanksource/config-db/scrapers.RunScraper({{{{0xc72c570, 0xc00d548510}, {0xc7769d0, 0xc00d548480}, 0xbc50718, 0xbc50720, {0xc6983f0, 0xc0009e8540}}}, 0xc001110d20, 0x0, ...})
	/app/scrapers/run.go:49 +0x79a
github.com/flanksource/config-db/scrapers.newScraperJob.func1({{{{0xc72c570, 0xc00d4c6f90}, {0xc7769d0, 0xc00d4c6fc0}, 0xbc50718, 0xbc50720, {0xc6983f0, 0xc0009e8540}}}, 0xc00094a2c0, {0xc7577e0, ...}, ...})
	/app/scrapers/cron.go:216 +0xb8
github.com/flanksource/duty/job.(*Job).Run(0xc00094a2c0)
	/go/pkg/mod/github.com/flanksource/duty@v1.0.909/job/job.go:438 +0x1502
github.com/robfig/cron/v3.(*Cron).startJob.func1()
	/go/pkg/mod/github.com/robfig/cron/v3@v3.0.1/cron.go:312 +0x55
created by github.com/robfig/cron/v3.(*Cron).startJob in goroutine 110
	/go/pkg/mod/github.com/robfig/cron/v3@v3.0.1/cron.go:310 +0x90
	```