### PR TITLE
fix: pass actual error to Errorf in kubernetes scraper

### DIFF
--- a/scrapers/kubernetes/kubernetes.go
+++ b/scrapers/kubernetes/kubernetes.go
@@ -93,11 +93,13 @@ func (kubernetes KubernetesScraper) Scrape(ctx api.ScrapeContext) v1.ScrapeResul
 				Find(&scraperIDs).Error; err != nil {
 				return results.Errorf(err, "error querying db for scraper_id with cluster name: %s", config.ClusterName)
 			}
+
 			if len(scraperIDs) > 1 {
-				return results.Errorf(err, "multiple scraper_ids[%s] found with cluster name: %s", strings.Join(scraperIDs, ","), config.ClusterName)
+				return results.Errorf(fmt.Errorf("multiple scraper_ids[%s] found with cluster name: %s", strings.Join(scraperIDs, ","), config.ClusterName), "")
 			}
+
 			if len(scraperIDs) == 1 && lo.FirstOrEmpty(scraperIDs) != scraperID {
-				return results.Errorf(err, "scraper_id[%s] already exists with cluster name: %s", strings.Join(scraperIDs, ","), config.ClusterName)
+				return results.Errorf(fmt.Errorf("scraper_id[%s] already exists with cluster name: %s", strings.Join(scraperIDs, ","), config.ClusterName), "")
 			}
 		}
 


### PR DESCRIPTION
## Summary
Fixes error handling in the kubernetes scraper where `err` was being passed to `Errorf` even though it was `nil`, causing incorrect error messages.