### PR TITLE
chore: skip client if creation fails instead of failing job

### DIFF
--- a/utils/kube/fetcher.go
+++ b/utils/kube/fetcher.go
@@ -74,7 +74,9 @@ func FetchInvolvedObjects(ctx api.ScrapeContext, iObjs []v1.InvolvedObject) ([]*
 					ctx.JobHistory().AddErrorf("failed to create dynamic client %s: %v, existing crds: %s", gvk, err, strings.Join(crdList, ","))
 				}
 			}
-			return nil, fmt.Errorf("failed to create dynamic client for %s: %w", gvk, err)
+
+			// Skip this client and continue with others
+			continue
 		}
 
 		eg.Go(func() error {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced resilience in object fetching. The system now gracefully handles failures for individual objects by logging them and continuing to process remaining items, rather than halting the entire operation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->