### PR TITLE
fix: Disable caching on Dockerbuild

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,21 @@ jobs:
   test-clickhouse:
     runs-on: ubuntu-latest
     steps:
+      - name: Free up disk space
+        run: |
+          initial_space=$(df / | grep / | awk '{print $4}')
+          sudo docker system prune -af
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf $AGENT_TOOLSDIRECTORY
+          sudo rm -rf /opt/hostedtoolcache
+
+          final_space=$(df / | grep / | awk '{print $4}')
+          difference=$((final_space - initial_space))
+          echo "Disk space difference (in KB): $difference"
+
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 


### PR DESCRIPTION
```
/usr/bin/docker buildx build --cache-from type=gha --cache-to type=gha,mode=max --file ./build/Dockerfile --iidfile /home/runner/work/_temp/docker-actions-toolkit-ZI5wM0/build-iidfile-04e9fb5963.txt --tag localhost:5000/flanksource/config-db:latest --metadata-file /home/runner/work/_temp/docker-actions-toolkit-ZI5wM0/build-metadata-65477e26c9.json --push .
ERROR: failed to build: Cache export is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
Learn more at https://docs.docker.com/go/build-cache-backends/
Reference
Check build summary support
Error: buildx failed with: Learn more at https://docs.docker.com/go/build-cache-backends/
```