### PR TITLE
chore: link eks cluster to ec2 instance

### DIFF
--- a/scrapers/aws/aws.go
+++ b/scrapers/aws/aws.go
@@ -1351,7 +1351,7 @@ func (aws Scraper) instances(ctx *AWSContext, config v1.AWS, results *v1.ScrapeR
 			for _, tag := range i.Tags {
 				if *tag.Key == "aws:eks:cluster-name" {
 					relationships = append(relationships, v1.RelationshipResult{
-						ConfigExternalID:  v1.ExternalID{ExternalID: getEKSClusterArn("", lo.FromPtr(ctx.Caller.Account), lo.FromPtr(tag.Value)), ConfigType: v1.AWSEKSCluster},
+						ConfigExternalID:  v1.ExternalID{ExternalID: getEKSClusterArn(region, lo.FromPtr(ctx.Caller.Account), lo.FromPtr(tag.Value)), ConfigType: v1.AWSEKSCluster},
 						RelatedExternalID: selfExternalID,
 						Relationship:      "ClusterInstance",
 					})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced EC2 instance metadata collection with improved network, subnet, and zone information
  * Improved accuracy of EKS cluster relationship identification for EC2 instances by switching to ARN-based references

* **Refactor**
  * Consolidated instance labeling logic to remove duplicated metadata assembly and simplify processing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->