### PR TITLE
fix: AWS EFS arn as aliases

### DIFF
--- a/scrapers/aws/aws.go
+++ b/scrapers/aws/aws.go
@@ -817,6 +817,7 @@ func (aws Scraper) efs(ctx *AWSContext, config v1.AWS, results *v1.ScrapeResults
 			ConfigClass: "FileSystem",
 			Name:        getName(labels, *fs.FileSystemId),
 			ID:          *fs.FileSystemId,
+			Aliases:     []string{lo.FromPtr(fs.FileSystemArn)},
 		})
 	}
 }


### PR DESCRIPTION
resolves: https://github.com/flanksource/config-db/issues/1828


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AWS EFS filesystem resources now include their Amazon Resource Name (ARN) as a public alias for reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->