### PR TITLE
fix: kubernetes file scraper support kubernetes connection with defaults

### DIFF
--- a/api/v1/kubernetes.go
+++ b/api/v1/kubernetes.go
@@ -8,7 +8,6 @@ import (
 	"github.com/flanksource/commons/collections"
 	"github.com/flanksource/duty"
 	"github.com/flanksource/duty/connection"
-	"github.com/flanksource/duty/types"
 	coreV1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -269,11 +268,12 @@ func (t *Kubernetes) Hash() string {
 }
 
 type KubernetesFile struct {
-	BaseScraper `json:",inline"`
-	Kubeconfig  *types.EnvVar    `json:"kubeconfig,omitempty"`
-	Selector    ResourceSelector `json:"selector" yaml:"selector"`
-	Container   string           `json:"container,omitempty" yaml:"container,omitempty"`
-	Files       []PodFile        `json:"files,omitempty" yaml:"files,omitempty"`
+	BaseScraper                     `json:",inline"`
+	connection.KubernetesConnection `json:",inline"`
+
+	Selector  ResourceSelector `json:"selector" yaml:"selector"`
+	Container string           `json:"container,omitempty" yaml:"container,omitempty"`
+	Files     []PodFile        `json:"files,omitempty" yaml:"files,omitempty"`
 }
 
 type PodFile struct {

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1020,11 +1020,7 @@ func (in *KubernetesExclusionConfig) DeepCopy() *KubernetesExclusionConfig {
 func (in *KubernetesFile) DeepCopyInto(out *KubernetesFile) {
 	*out = *in
 	in.BaseScraper.DeepCopyInto(&out.BaseScraper)
-	if in.Kubeconfig != nil {
-		in, out := &in.Kubeconfig, &out.Kubeconfig
-		*out = new(types.EnvVar)
-		(*in).DeepCopyInto(*out)
-	}
+	in.KubernetesConnection.DeepCopyInto(&out.KubernetesConnection)
 	out.Selector = in.Selector
 	if in.Files != nil {
 		in, out := &in.Files, &out.Files

--- a/chart/crds/configs.flanksource.com_scrapeconfigs.yaml
+++ b/chart/crds/configs.flanksource.com_scrapeconfigs.yaml
@@ -2567,6 +2567,8 @@ spec:
                           type: object
                         connection:
                           type: string
+                        depth:
+                          type: integer
                         destination:
                           description: |-
                             Destination is the full path to where the contents of the URL should be downloaded to.
@@ -7023,6 +7025,88 @@ spec:
                       description: A static value or JSONPath expression to use as
                         the class for the resource.
                       type: string
+                    cnrm:
+                      properties:
+                        clusterResource:
+                          type: string
+                        clusterResourceNamespace:
+                          type: string
+                        gke:
+                          properties:
+                            cluster:
+                              type: string
+                            connection:
+                              description: ConnectionName of the connection. It'll
+                                be used to populate the endpoint and credentials.
+                              type: string
+                            credentials:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    configMapKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - key
+                                      type: object
+                                    helmRef:
+                                      properties:
+                                        key:
+                                          description: Key is a JSONPath expression
+                                            used to fetch the key from the merged
+                                            JSON.
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - key
+                                      type: object
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - key
+                                      type: object
+                                    serviceAccount:
+                                      description: ServiceAccount specifies the service
+                                        account whose token should be fetched
+                                      type: string
+                                  type: object
+                              type: object
+                            endpoint:
+                              type: string
+                            project:
+                              type: string
+                            projectID:
+                              type: string
+                            skipTLSVerify:
+                              description: Skip TLS verify
+                              type: boolean
+                            zone:
+                              type: string
+                          required:
+                          - cluster
+                          - projectID
+                          - zone
+                          type: object
+                      required:
+                      - clusterResource
+                      - clusterResourceNamespace
+                      - gke
+                      type: object
+                    connection:
+                      description: Connection name to populate kubeconfig
+                      type: string
                     container:
                       type: string
                     createFields:
@@ -7043,6 +7127,155 @@ spec:
                       description: A static value or JSONPath expression to use as
                         the description for the resource.
                       type: string
+                    eks:
+                      properties:
+                        accessKey:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - key
+                                  type: object
+                                helmRef:
+                                  properties:
+                                    key:
+                                      description: Key is a JSONPath expression used
+                                        to fetch the key from the merged JSON.
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - key
+                                  type: object
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - key
+                                  type: object
+                                serviceAccount:
+                                  description: ServiceAccount specifies the service
+                                    account whose token should be fetched
+                                  type: string
+                              type: object
+                          type: object
+                        assumeRole:
+                          type: string
+                        cluster:
+                          type: string
+                        connection:
+                          description: ConnectionName of the connection. It'll be
+                            used to populate the endpoint, accessKey and secretKey.
+                          type: string
+                        endpoint:
+                          type: string
+                        region:
+                          type: string
+                        secretKey:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - key
+                                  type: object
+                                helmRef:
+                                  properties:
+                                    key:
+                                      description: Key is a JSONPath expression used
+                                        to fetch the key from the merged JSON.
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - key
+                                  type: object
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - key
+                                  type: object
+                                serviceAccount:
+                                  description: ServiceAccount specifies the service
+                                    account whose token should be fetched
+                                  type: string
+                              type: object
+                          type: object
+                        sessionToken:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - key
+                                  type: object
+                                helmRef:
+                                  properties:
+                                    key:
+                                      description: Key is a JSONPath expression used
+                                        to fetch the key from the merged JSON.
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - key
+                                  type: object
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - key
+                                  type: object
+                                serviceAccount:
+                                  description: ServiceAccount specifies the service
+                                    account whose token should be fetched
+                                  type: string
+                              type: object
+                          type: object
+                        skipTLSVerify:
+                          description: Skip TLS verify when connecting to aws
+                          type: boolean
+                      required:
+                      - cluster
+                      type: object
                     files:
                       items:
                         properties:
@@ -7058,6 +7291,73 @@ spec:
                       description: Format of config item, defaults to JSON, available
                         options are JSON, properties
                       type: string
+                    gke:
+                      properties:
+                        cluster:
+                          type: string
+                        connection:
+                          description: ConnectionName of the connection. It'll be
+                            used to populate the endpoint and credentials.
+                          type: string
+                        credentials:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - key
+                                  type: object
+                                helmRef:
+                                  properties:
+                                    key:
+                                      description: Key is a JSONPath expression used
+                                        to fetch the key from the merged JSON.
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - key
+                                  type: object
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - key
+                                  type: object
+                                serviceAccount:
+                                  description: ServiceAccount specifies the service
+                                    account whose token should be fetched
+                                  type: string
+                              type: object
+                          type: object
+                        endpoint:
+                          type: string
+                        project:
+                          type: string
+                        projectID:
+                          type: string
+                        skipTLSVerify:
+                          description: Skip TLS verify
+                          type: boolean
+                        zone:
+                          type: string
+                      required:
+                      - cluster
+                      - projectID
+                      - zone
+                      type: object
                     health:
                       description: A static value or JSONPath expression to use as
                         the health of the config item
@@ -7855,6 +8155,8 @@ spec:
                       properties:
                         address:
                           type: string
+                        connection:
+                          type: string
                         index:
                           type: string
                         limit:
@@ -7948,7 +8250,6 @@ spec:
                               type: object
                           type: object
                       required:
-                      - address
                       - index
                       - query
                       type: object

--- a/config/schemas/config_exec.schema.json
+++ b/config/schemas/config_exec.schema.json
@@ -477,6 +477,9 @@
         "branch": {
           "type": "string"
         },
+        "depth": {
+          "type": "integer"
+        },
         "destination": {
           "type": "string"
         }

--- a/config/schemas/config_kubernetesfile.schema.json
+++ b/config/schemas/config_kubernetesfile.schema.json
@@ -3,6 +3,26 @@
   "$id": "https://github.com/flanksource/config-db/api/v1/kubernetes-file",
   "$ref": "#/$defs/KubernetesFile",
   "$defs": {
+    "CNRMConnection": {
+      "properties": {
+        "gke": {
+          "$ref": "#/$defs/GKEConnection"
+        },
+        "clusterResource": {
+          "type": "string"
+        },
+        "clusterResourceNamespace": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "gke",
+        "clusterResource",
+        "clusterResourceNamespace"
+      ]
+    },
     "ChangeMapping": {
       "properties": {
         "filter": {
@@ -120,6 +140,42 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "EKSConnection": {
+      "properties": {
+        "connection": {
+          "type": "string"
+        },
+        "accessKey": {
+          "$ref": "#/$defs/EnvVar"
+        },
+        "secretKey": {
+          "$ref": "#/$defs/EnvVar"
+        },
+        "sessionToken": {
+          "$ref": "#/$defs/EnvVar"
+        },
+        "assumeRole": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "skipTLSVerify": {
+          "type": "boolean"
+        },
+        "cluster": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "cluster"
+      ]
+    },
     "EnvVar": {
       "properties": {
         "name": {
@@ -152,6 +208,41 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "GKEConnection": {
+      "properties": {
+        "connection": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "credentials": {
+          "$ref": "#/$defs/EnvVar"
+        },
+        "skipTLSVerify": {
+          "type": "boolean"
+        },
+        "project": {
+          "type": "string"
+        },
+        "projectID": {
+          "type": "string"
+        },
+        "zone": {
+          "type": "string"
+        },
+        "cluster": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "projectID",
+        "zone",
+        "cluster"
+      ]
     },
     "HelmRefKeySelector": {
       "properties": {
@@ -233,8 +324,20 @@
           },
           "type": "array"
         },
+        "connection": {
+          "type": "string"
+        },
         "kubeconfig": {
           "$ref": "#/$defs/EnvVar"
+        },
+        "eks": {
+          "$ref": "#/$defs/EKSConnection"
+        },
+        "gke": {
+          "$ref": "#/$defs/GKEConnection"
+        },
+        "cnrm": {
+          "$ref": "#/$defs/CNRMConnection"
         },
         "selector": {
           "$ref": "#/$defs/ResourceSelector"

--- a/config/schemas/config_logs.schema.json
+++ b/config/schemas/config_logs.schema.json
@@ -485,6 +485,9 @@
     },
     "OpenSearchConfig": {
       "properties": {
+        "connection": {
+          "type": "string"
+        },
         "address": {
           "type": "string"
         },
@@ -507,7 +510,6 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "address",
         "index",
         "query"
       ]

--- a/config/schemas/scrape_config.schema.json
+++ b/config/schemas/scrape_config.schema.json
@@ -1444,6 +1444,9 @@
         "branch": {
           "type": "string"
         },
+        "depth": {
+          "type": "integer"
+        },
         "destination": {
           "type": "string"
         }
@@ -1969,8 +1972,20 @@
           },
           "type": "array"
         },
+        "connection": {
+          "type": "string"
+        },
         "kubeconfig": {
           "$ref": "#/$defs/EnvVar"
+        },
+        "eks": {
+          "$ref": "#/$defs/EKSConnection"
+        },
+        "gke": {
+          "$ref": "#/$defs/GKEConnection"
+        },
+        "cnrm": {
+          "$ref": "#/$defs/CNRMConnection"
         },
         "selector": {
           "$ref": "#/$defs/ResourceSelector"
@@ -2410,6 +2425,9 @@
     },
     "OpenSearchConfig": {
       "properties": {
+        "connection": {
+          "type": "string"
+        },
         "address": {
           "type": "string"
         },
@@ -2432,7 +2450,6 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "address",
         "index",
         "query"
       ]


### PR DESCRIPTION
- **fix: kubernetes file scraper kubeconfig default**
- **feat: support kubernetes connection**

resolves: https://github.com/flanksource/config-db/issues/1846


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for EKS, GKE, and CNRM connections for Kubernetes File scraping, enabling cloud-provider-specific credential configurations.
  * Added optional `connection` field to OpenSearch configuration for flexible credential management.
  * Added `depth` field support to Git connections.

* **Bug Fixes**
  * OpenSearch configuration no longer requires the `address` field, allowing more flexible configuration options.

* **Refactor**
  * Improved Kubernetes client management through context-based initialization for better resource handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->