### PR TITLE
fix: use correct primary key columns in config_access_logs OnConflict

### DIFF
--- a/db/update.go
+++ b/db/update.go
@@ -886,10 +886,7 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 			accessLog.ConfigID = uuid.MustParse(config)
 		}
 
-		if err := ctx.DB().Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "config_id"}, {Name: "external_user_id"}, {Name: "scraper_id"}},
-			DoNothing: true,
-		}).Save(&accessLog.ConfigAccessLog).Error; err != nil {
+		if err := SaveConfigAccessLog(ctx, &accessLog.ConfigAccessLog); err != nil {
 			return summary, fmt.Errorf("failed to save access log: %w", err)
 		}
 	}
@@ -1395,6 +1392,20 @@ type updateConfigArgs struct {
 type configExternalKey struct {
 	externalID string
 	parentType string
+}
+
+func SaveConfigAccessLog(ctx api.ScrapeContext, accessLog *dutyModels.ConfigAccessLog) error {
+	if accessLog == nil {
+		return nil
+	}
+
+	return ctx.DB().Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "config_id"}, {Name: "external_user_id"}, {Name: "scraper_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"created_at", "mfa", "properties"}),
+		Where: clause.Where{Exprs: []clause.Expression{
+			clause.Expr{SQL: "excluded.created_at > config_access_logs.created_at"},
+		}},
+	}).Create(accessLog).Error
 }
 
 // extractResult holds the extracted configs & changes from the scrape result


### PR DESCRIPTION
## Problem

The OnConflict clause in `saveResults` was referencing a non-existent `id` column when saving config access logs:

```go
clause.OnConflict{Columns: []clause.Column{{Name: "id"}}, DoNothing: true}
```

The `config_access_logs` table has a composite primary key on `(config_id, external_user_id, scraper_id)`, not an `id` column.

## Fix

Updated to use the actual primary key columns:

```go
clause.OnConflict{
    Columns:   []clause.Column{{Name: "config_id"}, {Name: "external_user_id"}, {Name: "scraper_id"}},
    DoNothing: true,
}
```

## Related

- flanksource/duty#1741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Access log handling improved: incoming logs now update records only when newer, preventing older entries from overwriting recent data and ensuring MFA/status reflect the latest log.

* **Tests**
  * Added end-to-end tests verifying upsert behavior for access logs, ordering of CreatedAt, and correct propagation of MFA and related fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->