### PR TITLE
chore: use new workflow for helm push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
   push-helm-chart:
     needs: [semantic-release, helm]
     if: needs.semantic-release.outputs.new-release-published == 'true'
-    uses: flanksource/action-workflows/.github/workflows/push-helm-chart.yml@main
+    uses: flanksource/action-workflows/.github/workflows/push-helm-chart.yml@3207dcd2ee17aa8a78d47fd397ccfdaf6de308c0 # main
     with:
       filename_regex: "config-db-*.tgz"
       version: ${{ needs.semantic-release.outputs.release-version }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reworked Helm chart release to publish packaged charts as build artifacts rather than committing/updating a separate charts repository.
  * Added a dedicated chart-publishing workflow that runs earlier in the pipeline and is triggered after release publishing.
  * Updated pipeline job dependencies so chart publication occurs before downstream release-related jobs for a more streamlined release flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->