### PR TITLE
fix: handle incorrect soft deletion for rbac external_* in incremental scrape

### DIFF
--- a/db/external_entities.go
+++ b/db/external_entities.go
@@ -353,70 +353,74 @@ func upsertExternalEntities(
 		}
 	}
 
-	// Stale deletion: user_groups first (FK dependency)
-	if len(userGroups) > 0 {
-		if err := tx.Exec(fmt.Sprintf(`
-			UPDATE external_user_groups SET deleted_at = NOW()
-			WHERE deleted_at IS NULL
-				AND external_user_id IN (SELECT id FROM external_users WHERE scraper_id = ?)
-				AND NOT EXISTS (SELECT 1 FROM %s t
-					WHERE t.external_user_id = external_user_groups.external_user_id
-						AND t.external_group_id = external_user_groups.external_group_id)
-		`, tempUserGroups), *scraperID).Error; err != nil {
-			tx.Rollback()
-			return counts, fmt.Errorf("failed to delete stale external user groups: %w", err)
+	// Skip stale deletion during incremental scrapes because the batch is
+	// partial and would incorrectly remove entities not present in this batch.
+	if !ctx.IsIncrementalScrape() {
+		// Stale deletion: user_groups first (FK dependency)
+		if len(userGroups) > 0 {
+			if err := tx.Exec(fmt.Sprintf(`
+				UPDATE external_user_groups SET deleted_at = NOW()
+				WHERE deleted_at IS NULL
+					AND external_user_id IN (SELECT id FROM external_users WHERE scraper_id = ?)
+					AND NOT EXISTS (SELECT 1 FROM %s t
+						WHERE t.external_user_id = external_user_groups.external_user_id
+							AND t.external_group_id = external_user_groups.external_group_id)
+			`, tempUserGroups), *scraperID).Error; err != nil {
+				tx.Rollback()
+				return counts, fmt.Errorf("failed to delete stale external user groups: %w", err)
+			}
+		} else if len(users) > 0 || len(groups) > 0 {
+			// No user groups scraped but we have users/groups — delete all user_groups for this scraper's users
+			if err := tx.Exec(`
+				UPDATE external_user_groups SET deleted_at = NOW()
+				WHERE deleted_at IS NULL
+					AND external_user_id IN (SELECT id FROM external_users WHERE scraper_id = ?)
+			`, *scraperID).Error; err != nil {
+				tx.Rollback()
+				return counts, fmt.Errorf("failed to delete stale external user groups: %w", err)
+			}
 		}
-	} else if len(users) > 0 || len(groups) > 0 {
-		// No user groups scraped but we have users/groups — delete all user_groups for this scraper's users
-		if err := tx.Exec(`
-			UPDATE external_user_groups SET deleted_at = NOW()
-			WHERE deleted_at IS NULL
-				AND external_user_id IN (SELECT id FROM external_users WHERE scraper_id = ?)
-		`, *scraperID).Error; err != nil {
-			tx.Rollback()
-			return counts, fmt.Errorf("failed to delete stale external user groups: %w", err)
-		}
-	}
 
-	// Stale deletion: roles (hard delete, preserving current behavior)
-	if len(roles) > 0 {
-		r := tx.Exec(fmt.Sprintf(`
-			DELETE FROM external_roles WHERE scraper_id = ?
-				AND NOT EXISTS (SELECT 1 FROM %s t WHERE t.id = external_roles.id)
-		`, tempRoles), *scraperID)
-		if r.Error != nil {
-			tx.Rollback()
-			return counts, fmt.Errorf("failed to delete stale external roles: %w", r.Error)
+		// Stale deletion: roles (hard delete, preserving current behavior)
+		if len(roles) > 0 {
+			r := tx.Exec(fmt.Sprintf(`
+				DELETE FROM external_roles WHERE scraper_id = ?
+					AND NOT EXISTS (SELECT 1 FROM %s t WHERE t.id = external_roles.id)
+			`, tempRoles), *scraperID)
+			if r.Error != nil {
+				tx.Rollback()
+				return counts, fmt.Errorf("failed to delete stale external roles: %w", r.Error)
+			}
+			counts.rolesDeleted = int(r.RowsAffected)
 		}
-		counts.rolesDeleted = int(r.RowsAffected)
-	}
 
-	// Stale deletion: groups (soft delete)
-	if len(groups) > 0 {
-		r := tx.Exec(fmt.Sprintf(`
-			UPDATE external_groups SET deleted_at = NOW()
-			WHERE scraper_id = ? AND deleted_at IS NULL
-				AND NOT EXISTS (SELECT 1 FROM %s t WHERE t.id = external_groups.id)
-		`, tempGroups), *scraperID)
-		if r.Error != nil {
-			tx.Rollback()
-			return counts, fmt.Errorf("failed to delete stale external groups: %w", r.Error)
+		// Stale deletion: groups (soft delete)
+		if len(groups) > 0 {
+			r := tx.Exec(fmt.Sprintf(`
+				UPDATE external_groups SET deleted_at = NOW()
+				WHERE scraper_id = ? AND deleted_at IS NULL
+					AND NOT EXISTS (SELECT 1 FROM %s t WHERE t.id = external_groups.id)
+			`, tempGroups), *scraperID)
+			if r.Error != nil {
+				tx.Rollback()
+				return counts, fmt.Errorf("failed to delete stale external groups: %w", r.Error)
+			}
+			counts.groupsDeleted = int(r.RowsAffected)
 		}
-		counts.groupsDeleted = int(r.RowsAffected)
-	}
 
-	// Stale deletion: users (soft delete)
-	if len(users) > 0 {
-		r := tx.Exec(fmt.Sprintf(`
-			UPDATE external_users SET deleted_at = NOW()
-			WHERE scraper_id = ? AND deleted_at IS NULL
-				AND NOT EXISTS (SELECT 1 FROM %s t WHERE t.id = external_users.id)
-		`, tempUsers), *scraperID)
-		if r.Error != nil {
-			tx.Rollback()
-			return counts, fmt.Errorf("failed to delete stale external users: %w", r.Error)
+		// Stale deletion: users (soft delete)
+		if len(users) > 0 {
+			r := tx.Exec(fmt.Sprintf(`
+				UPDATE external_users SET deleted_at = NOW()
+				WHERE scraper_id = ? AND deleted_at IS NULL
+					AND NOT EXISTS (SELECT 1 FROM %s t WHERE t.id = external_users.id)
+			`, tempUsers), *scraperID)
+			if r.Error != nil {
+				tx.Rollback()
+				return counts, fmt.Errorf("failed to delete stale external users: %w", r.Error)
+			}
+			counts.usersDeleted = int(r.RowsAffected)
 		}
-		counts.usersDeleted = int(r.RowsAffected)
 	}
 
 	if err := tx.Commit().Error; err != nil {

--- a/db/permission_changes.go
+++ b/db/permission_changes.go
@@ -114,48 +114,51 @@ func upsertConfigAccess(ctx api.ScrapeContext, accesses []v1.ExternalConfigAcces
 		}
 	}
 
-	// Soft-delete stale records not in current scrape
-	// The temp table is empty when no accesses are scraped, which causes all existing rows to be deleted
-	var staleRows []staleAccessResult
-	staleSQL := fmt.Sprintf(`
-		WITH stale AS (
-			UPDATE config_access
-			SET deleted_at = NOW()
-			WHERE scraper_id = ?
-				AND deleted_at IS NULL
-				AND NOT EXISTS (
-					SELECT 1 FROM %s t
-					WHERE t.config_id = config_access.config_id
-						AND t.scraper_id = config_access.scraper_id
-						AND t.external_user_id IS NOT DISTINCT FROM config_access.external_user_id
-						AND t.external_role_id IS NOT DISTINCT FROM config_access.external_role_id
-						AND t.external_group_id IS NOT DISTINCT FROM config_access.external_group_id
-				)
-			RETURNING config_access.config_id, config_access.external_user_id, config_access.external_role_id, config_access.external_group_id
-		)
-		SELECT s.config_id,
-			COALESCE(eu.name, '') as user_name,
-			COALESCE(er.name, '') as role_name,
-			COALESCE(eg.name, '') as group_name
-		FROM stale s
-		LEFT JOIN external_users eu ON s.external_user_id = eu.id
-		LEFT JOIN external_roles er ON s.external_role_id = er.id
-		LEFT JOIN external_groups eg ON s.external_group_id = eg.id
-	`, tempTable)
+	// Soft-delete stale records not in current scrape.
+	// Skip during incremental scrapes because the batch is partial and
+	// would incorrectly remove records that simply weren't in this batch.
+	if !ctx.IsIncrementalScrape() {
+		var staleRows []staleAccessResult
+		staleSQL := fmt.Sprintf(`
+			WITH stale AS (
+				UPDATE config_access
+				SET deleted_at = NOW()
+				WHERE scraper_id = ?
+					AND deleted_at IS NULL
+					AND NOT EXISTS (
+						SELECT 1 FROM %s t
+						WHERE t.config_id = config_access.config_id
+							AND t.scraper_id = config_access.scraper_id
+							AND t.external_user_id IS NOT DISTINCT FROM config_access.external_user_id
+							AND t.external_role_id IS NOT DISTINCT FROM config_access.external_role_id
+							AND t.external_group_id IS NOT DISTINCT FROM config_access.external_group_id
+					)
+				RETURNING config_access.config_id, config_access.external_user_id, config_access.external_role_id, config_access.external_group_id
+			)
+			SELECT s.config_id,
+				COALESCE(eu.name, '') as user_name,
+				COALESCE(er.name, '') as role_name,
+				COALESCE(eg.name, '') as group_name
+			FROM stale s
+			LEFT JOIN external_users eu ON s.external_user_id = eu.id
+			LEFT JOIN external_roles er ON s.external_role_id = er.id
+			LEFT JOIN external_groups eg ON s.external_group_id = eg.id
+		`, tempTable)
 
-	if err := tx.Raw(staleSQL, *scraperID).Scan(&staleRows).Error; err != nil {
-		tx.Rollback()
-		return result, fmt.Errorf("failed to delete stale config access: %w", err)
-	}
+		if err := tx.Raw(staleSQL, *scraperID).Scan(&staleRows).Error; err != nil {
+			tx.Rollback()
+			return result, fmt.Errorf("failed to delete stale config access: %w", err)
+		}
 
-	for _, row := range staleRows {
-		result.removed = append(result.removed, &models.ConfigChange{
-			ID:         uuid.NewString(),
-			ConfigID:   row.ConfigID,
-			ChangeType: v1.ChangeTypePermissionRemoved,
-			Summary:    buildRemovalSummary(row),
-			CreatedAt:  now,
-		})
+		for _, row := range staleRows {
+			result.removed = append(result.removed, &models.ConfigChange{
+				ID:         uuid.NewString(),
+				ConfigID:   row.ConfigID,
+				ChangeType: v1.ChangeTypePermissionRemoved,
+				Summary:    buildRemovalSummary(row),
+				CreatedAt:  now,
+			})
+		}
 	}
 
 	if err := tx.Commit().Error; err != nil {

--- a/fixtures/data/incremental_rbac_full_test.json
+++ b/fixtures/data/incremental_rbac_full_test.json
@@ -1,0 +1,39 @@
+{
+  "id": "test-org-incremental-rbac",
+  "config": {
+    "name": "Incremental RBAC Test Org",
+    "type": "organization"
+  },
+  "external_users": [
+    {
+      "name": "Alice Smith",
+      "account_id": "org-inc",
+      "user_type": "human",
+      "email": "alice-inc@example.com",
+      "aliases": ["alice-inc", "alice-inc@example.com"]
+    },
+    {
+      "name": "Bob Jones",
+      "account_id": "org-inc",
+      "user_type": "human",
+      "email": "bob-inc@example.com",
+      "aliases": ["bob-inc", "bob-inc@example.com"]
+    }
+  ],
+  "config_access": [
+    {
+      "external_config_id": {
+        "config_type": "Organization",
+        "external_id": "test-org-incremental-rbac"
+      },
+      "external_user_aliases": ["alice-inc"]
+    },
+    {
+      "external_config_id": {
+        "config_type": "Organization",
+        "external_id": "test-org-incremental-rbac"
+      },
+      "external_user_aliases": ["bob-inc"]
+    }
+  ]
+}

--- a/fixtures/data/incremental_rbac_partial_test.json
+++ b/fixtures/data/incremental_rbac_partial_test.json
@@ -1,0 +1,25 @@
+{
+  "id": "test-org-incremental-rbac",
+  "config": {
+    "name": "Incremental RBAC Test Org",
+    "type": "organization"
+  },
+  "external_users": [
+    {
+      "name": "Alice Smith",
+      "account_id": "org-inc",
+      "user_type": "human",
+      "email": "alice-inc@example.com",
+      "aliases": ["alice-inc", "alice-inc@example.com"]
+    }
+  ],
+  "config_access": [
+    {
+      "external_config_id": {
+        "config_type": "Organization",
+        "external_id": "test-org-incremental-rbac"
+      },
+      "external_user_aliases": ["alice-inc"]
+    }
+  ]
+}

--- a/fixtures/file-incremental-rbac-full.yaml
+++ b/fixtures/file-incremental-rbac-full.yaml
@@ -1,0 +1,12 @@
+apiVersion: configs.flanksource.com/v1
+kind: ScrapeConfig
+metadata:
+  name: file-incremental-rbac-full-scraper
+spec:
+  full: true
+  file:
+    - type: Organization
+      class: Organization
+      id: $.id
+      paths:
+        - fixtures/data/incremental_rbac_full_test.json

--- a/fixtures/file-incremental-rbac-partial.yaml
+++ b/fixtures/file-incremental-rbac-partial.yaml
@@ -1,0 +1,12 @@
+apiVersion: configs.flanksource.com/v1
+kind: ScrapeConfig
+metadata:
+  name: file-incremental-rbac-partial-scraper
+spec:
+  full: true
+  file:
+    - type: Organization
+      class: Organization
+      id: $.id
+      paths:
+        - fixtures/data/incremental_rbac_partial_test.json

--- a/scrapers/incremental_rbac_test.go
+++ b/scrapers/incremental_rbac_test.go
@@ -1,0 +1,110 @@
+// ABOUTME: Tests that incremental scrapes do not soft-delete RBAC entities
+// ABOUTME: or config access records that are absent from the partial batch.
+package scrapers
+
+import (
+	"github.com/flanksource/config-db/api"
+	v1 "github.com/flanksource/config-db/api/v1"
+	"github.com/flanksource/config-db/db"
+	"github.com/flanksource/config-db/db/models"
+	dutymodels "github.com/flanksource/duty/models"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Incremental scrape preserves RBAC data", Ordered, func() {
+	var scrapeConfigFull v1.ScrapeConfig
+	var scraperCtx api.ScrapeContext
+	var scraperModel dutymodels.ConfigScraper
+	var initialUserIDs []uuid.UUID
+
+	BeforeAll(func() {
+		scrapeConfigFull = getConfigSpec("file-incremental-rbac-full")
+
+		scModel, err := scrapeConfigFull.ToModel()
+		Expect(err).NotTo(HaveOccurred())
+		scModel.Source = dutymodels.SourceUI
+
+		err = DefaultContext.DB().Create(&scModel).Error
+		Expect(err).NotTo(HaveOccurred())
+
+		scrapeConfigFull.SetUID(k8sTypes.UID(scModel.ID.String()))
+		scraperCtx = api.NewScrapeContext(DefaultContext).WithScrapeConfig(&scrapeConfigFull)
+		scraperModel = scModel
+	})
+
+	AfterAll(func() {
+		Expect(DefaultContext.DB().Unscoped().Where("scraper_id = ?", scraperModel.ID).Delete(&dutymodels.ConfigAccess{}).Error).NotTo(HaveOccurred())
+		Expect(DefaultContext.DB().Unscoped().Where("scraper_id = ?", scraperModel.ID).Delete(&dutymodels.ExternalUser{}).Error).NotTo(HaveOccurred())
+		Expect(DefaultContext.DB().Where("scraper_id = ?", scraperModel.ID).Delete(&models.ConfigItem{}).Error).NotTo(HaveOccurred())
+		Expect(DefaultContext.DB().Delete(&scraperModel).Error).NotTo(HaveOccurred())
+	})
+
+	It("should establish baseline with full scrape", func() {
+		_, err := RunScraper(scraperCtx)
+		Expect(err).To(BeNil())
+
+		var users []dutymodels.ExternalUser
+		err = DefaultContext.DB().Where("scraper_id = ? AND deleted_at IS NULL", scraperModel.ID).Find(&users).Error
+		Expect(err).NotTo(HaveOccurred())
+		Expect(users).To(HaveLen(2), "full scrape should create 2 users")
+
+		initialUserIDs = lo.Map(users, func(u dutymodels.ExternalUser, _ int) uuid.UUID { return u.ID })
+
+		var accesses []dutymodels.ConfigAccess
+		err = DefaultContext.DB().Where("scraper_id = ? AND deleted_at IS NULL", scraperModel.ID).Find(&accesses).Error
+		Expect(err).NotTo(HaveOccurred())
+		Expect(accesses).To(HaveLen(2), "full scrape should create 2 config access entries")
+	})
+
+	It("should not delete entities during incremental scrape with partial batch", func() {
+		db.ExternalUserCache.Flush()
+
+		partialConfig := getConfigSpec("file-incremental-rbac-partial")
+		partialConfig.SetUID(k8sTypes.UID(scraperModel.ID.String()))
+		incrementalCtx := api.NewScrapeContext(DefaultContext).
+			WithScrapeConfig(&partialConfig).
+			AsIncrementalScrape()
+
+		_, err := RunScraper(incrementalCtx)
+		Expect(err).To(BeNil())
+
+		var activeUsers []dutymodels.ExternalUser
+		err = DefaultContext.DB().Where("scraper_id = ? AND deleted_at IS NULL", scraperModel.ID).Find(&activeUsers).Error
+		Expect(err).NotTo(HaveOccurred())
+		Expect(activeUsers).To(HaveLen(2), "incremental scrape should preserve all users")
+
+		activeUserIDs := lo.Map(activeUsers, func(u dutymodels.ExternalUser, _ int) uuid.UUID { return u.ID })
+		Expect(activeUserIDs).To(ConsistOf(initialUserIDs))
+
+		var activeAccesses []dutymodels.ConfigAccess
+		err = DefaultContext.DB().Where("scraper_id = ? AND deleted_at IS NULL", scraperModel.ID).Find(&activeAccesses).Error
+		Expect(err).NotTo(HaveOccurred())
+		Expect(activeAccesses).To(HaveLen(2), "incremental scrape should preserve all config access entries")
+	})
+
+	It("should still delete stale entities on a full scrape", func() {
+		db.ExternalUserCache.Flush()
+
+		reducedConfig := getConfigSpec("file-incremental-rbac-partial")
+		reducedConfig.SetUID(k8sTypes.UID(scraperModel.ID.String()))
+		fullCtx := api.NewScrapeContext(DefaultContext).WithScrapeConfig(&reducedConfig)
+
+		_, err := RunScraper(fullCtx)
+		Expect(err).To(BeNil())
+
+		var activeUsers []dutymodels.ExternalUser
+		err = DefaultContext.DB().Where("scraper_id = ? AND deleted_at IS NULL", scraperModel.ID).Find(&activeUsers).Error
+		Expect(err).NotTo(HaveOccurred())
+		Expect(activeUsers).To(HaveLen(1), "full scrape with reduced data should delete stale user")
+		Expect(activeUsers[0].Name).To(Equal("Alice Smith"))
+
+		var activeAccesses []dutymodels.ConfigAccess
+		err = DefaultContext.DB().Where("scraper_id = ? AND deleted_at IS NULL", scraperModel.ID).Find(&activeAccesses).Error
+		Expect(err).NotTo(HaveOccurred())
+		Expect(activeAccesses).To(HaveLen(1), "full scrape with reduced data should delete stale config access")
+	})
+})


### PR DESCRIPTION
Fixes: #1899 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incremental scrapes to preserve RBAC entities and permission records when processing partial data batches. Previously, partial scrapes would incorrectly delete entities not present in the current batch. Full scrapes continue to properly remove stale data.

* **Tests**
  * Added comprehensive test coverage for incremental scrape behavior with RBAC configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->