### PR TITLE
ci: remove update-incident-commander job from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,26 +162,3 @@ jobs:
       pr_title: "Release ${{ needs.semantic-release.outputs.release-version }} of flanksource/config-db"
     secrets:
       token: ${{ secrets.FLANKBOT }}
-
-  update-incident-commander:
-    runs-on: ubuntu-latest
-    needs: [push-helm-chart, semantic-release]
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          repository: "${{ github.repository_owner }}/incident-commander-chart"
-          token: ${{ secrets.FLANKBOT }}
-          path: ./incident-commander-chart
-      - name: Update config-db version in chart/Chart.yaml
-        uses: mikefarah/yq@0ecdce24e83f0fa127940334be98c86b07b0c488 # v4.45.1
-        with:
-          cmd: yq eval-all -i '(.dependencies[] | select(.name == "config-db")) ref $d | $d.version = "${{ needs.semantic-release.outputs.release-version }}"' incident-commander-chart/chart/Chart.yaml
-      - name: Update config-db version in agent-chart/Chart.yaml
-        uses: mikefarah/yq@0ecdce24e83f0fa127940334be98c86b07b0c488 # v4.45.1
-        with:
-          cmd: yq eval-all -i '(.dependencies[] | select(.name == "config-db")) ref $d | $d.version = "${{ needs.semantic-release.outputs.release-version }}"' incident-commander-chart/agent-chart/Chart.yaml
-      - name: Push changes to chart repo
-        uses: stefanzweifel/git-auto-commit-action@28e16e81777b558cc906c8750092100bbb34c5e3 # v7.0.0
-        with:
-          commit_message: "chore: update config-db chart dependency to ${{ needs.semantic-release.outputs.release-version }}"
-          repository: ./incident-commander-chart


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an automated update job from the release workflow that previously synchronized and deployed chart configurations during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->