### PR TITLE
chore: bump is-healthy to v1.0.85, remove local replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/flanksource/deps v1.0.24
 	github.com/flanksource/duty v1.0.1221
 	github.com/flanksource/gomplate/v3 v3.24.73
-	github.com/flanksource/is-healthy v1.0.84
+	github.com/flanksource/is-healthy v1.0.85
 	github.com/flanksource/ketall v1.1.9
 	github.com/flanksource/kopper v1.0.18
 )

--- a/go.sum
+++ b/go.sum
@@ -476,8 +476,8 @@ github.com/flanksource/duty v1.0.1221 h1:qqKPGyFR0KAlTN3i/vaN8oYQv8p+t+wxUpHWSmY
 github.com/flanksource/duty v1.0.1221/go.mod h1:qbf6nVTUSVpA+xQdpSFF13j2jviy9PSzneLDNp8oRUI=
 github.com/flanksource/gomplate/v3 v3.24.73 h1:fMQl7NDqyfL7T0lf2tyKNthLp5rcUedQ/XuzNWERvro=
 github.com/flanksource/gomplate/v3 v3.24.73/go.mod h1:rzas3bkSTvM8ULje+VU3ZFn3ccUjlY2jwkiJv3qjn4E=
-github.com/flanksource/is-healthy v1.0.84 h1:d05/Uri+y3b6AkQAItxwjwLwHq2BZHXER42n9AtRbzo=
-github.com/flanksource/is-healthy v1.0.84/go.mod h1:6/KOjVUeevIbaIaVtSDhy6qsnbqyy5WPZNlRGQCBxcw=
+github.com/flanksource/is-healthy v1.0.85 h1:YHRDwiuaCCeF1fcJwPBwTzkj/2bZINDxDjVuD3Bl2Qo=
+github.com/flanksource/is-healthy v1.0.85/go.mod h1:xoEeeCamUiW8fGWGyRaGL9NU4xQzou+sgDC5raguDew=
 github.com/flanksource/ketall v1.1.9 h1:9AaQ6VFDYMGqQzsyZJcXMo5qgHCJHNi1IqAK8tIxS+k=
 github.com/flanksource/ketall v1.1.9/go.mod h1:7p2N6gm5kUTMA+21x4bdnfWupOPVxUW0jy7zksV6GUU=
 github.com/flanksource/kopper v1.0.18 h1:AV6mCnn+ANRvPzduoF2pbEShjiR0GOLT24xCD+rjysk=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Routine internal maintenance update. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->