### PR TITLE
fix(kubernetes): use dynamic informer factory to support CRD watches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,3 +295,10 @@ rust-generate-header:
 	cargo install cbindgen
 	cd external/diffgen
 	cbindgen . -o libdiffgen.h --lang c
+
+.PHONY: bench
+bench:
+	go test ./scrapers/kubernetes/ -bench='^Benchmark(EventProcessing|CacheMemory|Deserialization)' \
+		-benchmem -run='^$$' \
+		-count=3 \
+		-benchtime=2s -v

--- a/go.mod
+++ b/go.mod
@@ -157,12 +157,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kms v1.49.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bmatcuk/doublestar v1.3.4 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
-	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/casbin/casbin/v2 v2.135.0 // indirect
 	github.com/casbin/casbin/v3 v3.8.1 // indirect
 	github.com/casbin/gorm-adapter/v3 v3.41.0 // indirect
@@ -253,7 +251,6 @@ require (
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/henvic/httpretty v0.1.4 // indirect
 	github.com/hirochachacha/go-smb2 v1.1.0 // indirect
-	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/itchyny/gojq v0.12.18 // indirect
 	github.com/itchyny/timefmt-go v0.1.7 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
@@ -285,7 +282,6 @@ require (
 	github.com/lrita/cmap v0.0.0-20231108122212-cb084a67f554 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
-	github.com/mailru/easyjson v0.9.1 // indirect
 	github.com/microsoft/kiota-abstractions-go v1.9.3 // indirect
 	github.com/microsoft/kiota-authentication-azure-go v1.3.1 // indirect
 	github.com/microsoft/kiota-http-go v1.5.4 // indirect
@@ -347,12 +343,8 @@ require (
 	github.com/vadimi/go-http-ntlm v1.0.3 // indirect
 	github.com/vadimi/go-http-ntlm/v2 v2.5.0 // indirect
 	github.com/vadimi/go-ntlm v1.2.1 // indirect
-	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
-	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/xuri/efp v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -330,8 +330,6 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=
 github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
-github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
-github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -348,8 +346,6 @@ github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
 github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
-github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
-github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c/go.mod h1:l/bIBLeOl9eX+wxJAzxS4TveKRtAqlyDpHjhkfO0MEI=
 github.com/casbin/casbin/v2 v2.135.0 h1:6BLkMQiGotYyS5yYeWgW19vxqugUlvHFkFiLnLR/bxk=
 github.com/casbin/casbin/v2 v2.135.0/go.mod h1:FmcfntdXLTcYXv/hxgNntcRPqAbwOG9xsism0yXT+18=
@@ -778,8 +774,6 @@ github.com/hirochachacha/go-smb2 v1.1.0/go.mod h1:8F1A4d5EZzrGu5R7PU163UcMRDJQl4
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
-github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/itchyny/gojq v0.12.18 h1:gFGHyt/MLbG9n6dqnvlliiya2TaMMh6FFaR2b1H6Drc=
 github.com/itchyny/gojq v0.12.18/go.mod h1:4hPoZ/3lN9fDL1D+aK7DY1f39XZpY9+1Xpjz8atrEkg=
 github.com/itchyny/timefmt-go v0.1.7 h1:xyftit9Tbw+Dc/huSSPJaEmX1TVL8lw5vxjJLK4GMMA=
@@ -944,8 +938,6 @@ github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 h1:PwQumkgq4/acIi
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/mailru/easyjson v0.9.1 h1:LbtsOm5WAswyWbvTEOqhypdPeZzHavpZx96/n553mR8=
-github.com/mailru/easyjson v0.9.1/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
@@ -1259,8 +1251,6 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
-github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
-github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
@@ -1268,12 +1258,6 @@ github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
 github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
-github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
-github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
-github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
-github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
-github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
-github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xhit/go-str2duration v1.2.0/go.mod h1:3cPSlfZlUHVlneIVfePFWcJZsuwf+P1v2SRTV4cUmp4=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=

--- a/scrapers/kubernetes/informers.go
+++ b/scrapers/kubernetes/informers.go
@@ -352,6 +352,16 @@ func logToJobHistory(ctx context.Context, job string, scraperID *uuid.UUID, err 
 }
 
 func KindToResource(kind string) string {
+	// WARNING: Naive pluralization. This breaks for irregular plurals:
+	//   Ingress        -> "ingresss"       (correct: "ingresses")
+	//   NetworkPolicy  -> "networkpolicys"  (correct: "networkpolicies")
+	//   Endpoints      -> "endpointss"      (correct: "endpoints")
+	//   StorageClass   -> "storageclasss"   (correct: "storageclasses")
+	//   IPAddress      -> "ipaddresss"      (correct: "ipaddresses")
+	//
+	// The dynamic informer will silently 404 on the wrong resource name
+	// and retry in a loop forever. If a watch resource isn't producing events,
+	// check that KindToResource returns the correct plural for that kind.
 	return strings.ToLower(kind) + "s"
 }
 

--- a/scrapers/kubernetes/informers_bench_test.go
+++ b/scrapers/kubernetes/informers_bench_test.go
@@ -1,0 +1,457 @@
+package kubernetes
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	v1 "github.com/flanksource/config-db/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	benchNumPods   = 5000
+	benchNumEvents = 5000
+	benchNumCRDs   = 1000
+)
+
+// benchSink prevents the compiler from optimizing away benchmark results.
+var benchSink any
+
+// ---------------------------------------------------------------------------
+// Data generators
+// ---------------------------------------------------------------------------
+
+// benchGenTypedPod builds a realistic corev1.Pod with 2 containers, labels,
+// annotations, env vars, resource limits, volumes, and status conditions.
+func benchGenTypedPod(i int) *corev1.Pod {
+	return &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("pod-%d", i),
+			Namespace: "default",
+			UID:       types.UID(fmt.Sprintf("uid-pod-%d", i)),
+			Labels: map[string]string{
+				"app":        fmt.Sprintf("app-%d", i%50),
+				"team":       fmt.Sprintf("team-%d", i%10),
+				"env":        "production",
+				"version":    "v1.2.3",
+				"managed-by": "helm",
+			},
+			Annotations: map[string]string{
+				"kubectl.kubernetes.io/last-applied-configuration": `{"apiVersion":"v1","kind":"Pod","metadata":{"labels":{"app":"nginx"}}}`,
+				"prometheus.io/scrape":                             "true",
+				"prometheus.io/port":                               "8080",
+			},
+			CreationTimestamp: metav1.Time{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(i) * time.Minute)},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "ReplicaSet",
+				Name:       fmt.Sprintf("deploy-%d-abc123", i%100),
+				UID:        types.UID(fmt.Sprintf("uid-rs-%d", i%100)),
+			}},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "main",
+					Image: fmt.Sprintf("registry.example.com/app-%d:v1.2.3", i%50),
+					Ports: []corev1.ContainerPort{
+						{ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
+						{ContainerPort: 9090, Protocol: corev1.ProtocolTCP},
+					},
+					Env: []corev1.EnvVar{
+						{Name: "DB_HOST", Value: "postgres.default.svc"},
+						{Name: "DB_PORT", Value: "5432"},
+						{Name: "LOG_LEVEL", Value: "info"},
+						{Name: "SECRET_KEY", ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "app-secrets"},
+								Key:                  "secret-key",
+							},
+						}},
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    apiresource.MustParse("100m"),
+							corev1.ResourceMemory: apiresource.MustParse("128Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    apiresource.MustParse("500m"),
+							corev1.ResourceMemory: apiresource.MustParse("512Mi"),
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "config", MountPath: "/etc/config", ReadOnly: true},
+						{Name: "data", MountPath: "/data"},
+					},
+				},
+				{
+					Name:  "sidecar",
+					Image: "envoyproxy/envoy:v1.28",
+					Ports: []corev1.ContainerPort{
+						{ContainerPort: 15001, Protocol: corev1.ProtocolTCP},
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    apiresource.MustParse("50m"),
+							corev1.ResourceMemory: apiresource.MustParse("64Mi"),
+						},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{Name: "config", VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "app-config"},
+					},
+				}},
+				{Name: "data", VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				}},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: metav1.Time{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}},
+				{Type: corev1.PodInitialized, Status: corev1.ConditionTrue, LastTransitionTime: metav1.Time{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}},
+				{Type: corev1.ContainersReady, Status: corev1.ConditionTrue, LastTransitionTime: metav1.Time{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         "main",
+					Ready:        true,
+					RestartCount: 0,
+					State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.Time{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}}},
+					Image:        fmt.Sprintf("registry.example.com/app-%d:v1.2.3", i%50),
+					ImageID:      "docker-pullable://registry.example.com/app@sha256:abc123def456",
+				},
+				{
+					Name:         "sidecar",
+					Ready:        true,
+					RestartCount: 0,
+					State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.Time{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}}},
+					Image:        "envoyproxy/envoy:v1.28",
+					ImageID:      "docker-pullable://envoyproxy/envoy@sha256:789abc",
+				},
+			},
+			PodIP:  fmt.Sprintf("10.0.%d.%d", i/256, i%256),
+			HostIP: fmt.Sprintf("192.168.1.%d", i%255+1),
+		},
+	}
+}
+
+func benchGenTypedEvent(i int) *corev1.Event {
+	return &corev1.Event{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Event"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              fmt.Sprintf("event-%d", i),
+			Namespace:         "default",
+			UID:               types.UID(fmt.Sprintf("uid-event-%d", i)),
+			CreationTimestamp: metav1.Time{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(i) * time.Second)},
+		},
+		InvolvedObject: corev1.ObjectReference{
+			APIVersion: "v1",
+			Kind:       "Pod",
+			Name:       fmt.Sprintf("pod-%d", i%benchNumPods),
+			Namespace:  "default",
+			UID:        types.UID(fmt.Sprintf("uid-pod-%d", i%benchNumPods)),
+		},
+		Reason:         "Scheduled",
+		Message:        fmt.Sprintf("Successfully assigned default/pod-%d to node-%d", i%benchNumPods, i%10),
+		Type:           "Normal",
+		Source:         corev1.EventSource{Component: "default-scheduler", Host: fmt.Sprintf("node-%d", i%10)},
+		FirstTimestamp: metav1.Time{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(i) * time.Second)},
+		LastTimestamp:  metav1.Time{Time: time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)},
+		Count:          int32(i%10 + 1),
+	}
+}
+
+// benchToUnstructured converts a typed object to *unstructured.Unstructured
+// via JSON round-trip, producing identical data for apples-to-apples comparison.
+func benchToUnstructured(obj any) *unstructured.Unstructured {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		panic(fmt.Sprintf("benchToUnstructured: marshal failed: %v", err))
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		panic(fmt.Sprintf("benchToUnstructured: unmarshal failed: %v", err))
+	}
+	return &unstructured.Unstructured{Object: m}
+}
+
+func benchGenUnstructuredCRD(i int) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "canaries.flanksource.com/v1",
+			"kind":       "Canary",
+			"metadata": map[string]any{
+				"name":              fmt.Sprintf("canary-%d", i),
+				"namespace":         "default",
+				"uid":               fmt.Sprintf("uid-canary-%d", i),
+				"creationTimestamp": "2026-01-01T00:00:00Z",
+				"labels": map[string]any{
+					"app":  fmt.Sprintf("app-%d", i%20),
+					"team": fmt.Sprintf("team-%d", i%5),
+				},
+				"annotations": map[string]any{
+					"flanksource.com/owner": fmt.Sprintf("team-%d", i%5),
+				},
+			},
+			"spec": map[string]any{
+				"interval": int64(30),
+				"http": []any{
+					map[string]any{
+						"name":          fmt.Sprintf("http-check-%d", i),
+						"url":           fmt.Sprintf("https://api.example.com/health/%d", i),
+						"method":        "GET",
+						"timeout":       int64(5000),
+						"responseCodes": []any{int64(200), int64(201)},
+						"headers": map[string]any{
+							"Authorization": "Bearer token-xxx",
+							"Accept":        "application/json",
+						},
+					},
+				},
+			},
+			"status": map[string]any{
+				"status":    "Healthy",
+				"lastCheck": "2026-01-01T01:00:00Z",
+				"conditions": []any{
+					map[string]any{
+						"type":               "Ready",
+						"status":             "True",
+						"lastTransitionTime": "2026-01-01T00:00:00Z",
+					},
+				},
+				"checkStatuses": []any{
+					map[string]any{
+						"name":     fmt.Sprintf("http-check-%d", i),
+						"status":   true,
+						"duration": int64(150),
+						"message":  "OK",
+					},
+				},
+			},
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helper: pre-generate all benchmark objects
+// ---------------------------------------------------------------------------
+
+type benchObject struct {
+	obj      any
+	resource v1.KubernetesResourceToWatch
+}
+
+// benchGenTypedObjects returns 10k objects (5k Pods + 5k Events) as typed structs.
+// Typed informers cannot handle CRDs, so CRDs are excluded.
+func benchGenTypedObjects() []benchObject {
+	objects := make([]benchObject, 0, benchNumPods+benchNumEvents)
+	podResource := v1.KubernetesResourceToWatch{ApiVersion: "v1", Kind: "Pod"}
+	eventResource := v1.KubernetesResourceToWatch{ApiVersion: "v1", Kind: "Event"}
+	for i := 0; i < benchNumPods; i++ {
+		objects = append(objects, benchObject{obj: benchGenTypedPod(i), resource: podResource})
+	}
+	for i := 0; i < benchNumEvents; i++ {
+		objects = append(objects, benchObject{obj: benchGenTypedEvent(i), resource: eventResource})
+	}
+	return objects
+}
+
+// benchGenDynamicObjects returns 11k objects (5k Pods + 5k Events + 1k CRDs) as unstructured.
+func benchGenDynamicObjects() []benchObject {
+	objects := make([]benchObject, 0, benchNumPods+benchNumEvents+benchNumCRDs)
+	podResource := v1.KubernetesResourceToWatch{ApiVersion: "v1", Kind: "Pod"}
+	eventResource := v1.KubernetesResourceToWatch{ApiVersion: "v1", Kind: "Event"}
+	crdResource := v1.KubernetesResourceToWatch{ApiVersion: "canaries.flanksource.com/v1", Kind: "Canary"}
+	for i := 0; i < benchNumPods; i++ {
+		objects = append(objects, benchObject{obj: benchToUnstructured(benchGenTypedPod(i)), resource: podResource})
+	}
+	for i := 0; i < benchNumEvents; i++ {
+		objects = append(objects, benchObject{obj: benchToUnstructured(benchGenTypedEvent(i)), resource: eventResource})
+	}
+	for i := 0; i < benchNumCRDs; i++ {
+		objects = append(objects, benchObject{obj: benchGenUnstructuredCRD(i), resource: crdResource})
+	}
+	return objects
+}
+
+// ---------------------------------------------------------------------------
+// CPU Benchmarks: Event Processing
+//
+// Measures the per-event cost of converting informer objects to unstructured.
+//   TypedInformer:   typed struct → json.Marshal → json.Unmarshal → map (unavoidable)
+//   DynamicInformer: type assert + DeepCopy (no serialization)
+// ---------------------------------------------------------------------------
+
+func BenchmarkEventProcessing(b *testing.B) {
+	typedObjects := benchGenTypedObjects()
+	dynamicObjects := benchGenDynamicObjects()
+
+	b.Run("TypedInformer", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			o := typedObjects[i%len(typedObjects)]
+			result, _ := getUnstructuredFromInformedObj(o.resource, o.obj)
+			benchSink = result
+		}
+	})
+
+	b.Run("DynamicInformer", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			o := dynamicObjects[i%len(dynamicObjects)]
+			u := o.obj.(*unstructured.Unstructured).DeepCopy()
+			u.SetKind(o.resource.Kind)
+			u.SetAPIVersion(o.resource.ApiVersion)
+			benchSink = u
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Memory Benchmarks: Informer Cache Footprint
+//
+// Measures the total heap cost of holding all watched objects in the informer's
+// internal store (map[string]interface{}).
+//
+// The typed informer stores compact Go structs (e.g. *corev1.Pod).
+// The dynamic informer stores *unstructured.Unstructured (nested map[string]any).
+// ---------------------------------------------------------------------------
+
+func BenchmarkCacheMemory(b *testing.B) {
+	b.Run("TypedInformer", func(b *testing.B) {
+		runtime.GC()
+		runtime.GC()
+		var before runtime.MemStats
+		runtime.ReadMemStats(&before)
+
+		cache := make(map[string]any, benchNumPods+benchNumEvents)
+		for i := 0; i < benchNumPods; i++ {
+			cache[fmt.Sprintf("default/pod-%d", i)] = benchGenTypedPod(i)
+		}
+		for i := 0; i < benchNumEvents; i++ {
+			cache[fmt.Sprintf("default/event-%d", i)] = benchGenTypedEvent(i)
+		}
+
+		runtime.GC()
+		runtime.GC()
+		var after runtime.MemStats
+		runtime.ReadMemStats(&after)
+
+		totalObjects := float64(benchNumPods + benchNumEvents)
+		b.ReportMetric(float64(after.HeapAlloc-before.HeapAlloc)/(1024*1024), "heap-MB")
+		b.ReportMetric(float64(after.HeapAlloc-before.HeapAlloc)/totalObjects, "bytes/object")
+		runtime.KeepAlive(cache)
+	})
+
+	b.Run("DynamicInformer", func(b *testing.B) {
+		runtime.GC()
+		runtime.GC()
+		var before runtime.MemStats
+		runtime.ReadMemStats(&before)
+
+		cache := make(map[string]any, benchNumPods+benchNumEvents+benchNumCRDs)
+		for i := 0; i < benchNumPods; i++ {
+			cache[fmt.Sprintf("default/pod-%d", i)] = benchToUnstructured(benchGenTypedPod(i))
+		}
+		for i := 0; i < benchNumEvents; i++ {
+			cache[fmt.Sprintf("default/event-%d", i)] = benchToUnstructured(benchGenTypedEvent(i))
+		}
+		for i := 0; i < benchNumCRDs; i++ {
+			cache[fmt.Sprintf("default/canary-%d", i)] = benchGenUnstructuredCRD(i)
+		}
+
+		runtime.GC()
+		runtime.GC()
+		var after runtime.MemStats
+		runtime.ReadMemStats(&after)
+
+		totalObjects := float64(benchNumPods + benchNumEvents + benchNumCRDs)
+		b.ReportMetric(float64(after.HeapAlloc-before.HeapAlloc)/(1024*1024), "heap-MB")
+		b.ReportMetric(float64(after.HeapAlloc-before.HeapAlloc)/totalObjects, "bytes/object")
+		runtime.KeepAlive(cache)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CPU Benchmarks: Deserialization (initial List simulation)
+//
+// Measures the cost of deserializing a JSON byte slice into:
+//   - A typed Go struct (what the typed informer does, though it normally uses protobuf)
+//   - A map[string]any (what the dynamic informer does)
+//
+// Note: the typed informer actually uses protobuf on the wire which is faster
+// than JSON. This benchmark uses JSON for both, so the typed result here is a
+// conservative (slower) estimate of real-world typed informer performance.
+// ---------------------------------------------------------------------------
+
+func BenchmarkDeserialization(b *testing.B) {
+	// Pre-generate JSON blobs from typed objects so both paths decode identical bytes.
+	type jsonBlob struct {
+		data   []byte
+		isPod  bool // true = Pod, false = Event
+	}
+
+	blobs := make([]jsonBlob, 0, benchNumPods+benchNumEvents)
+	for i := 0; i < benchNumPods; i++ {
+		data, _ := json.Marshal(benchGenTypedPod(i))
+		blobs = append(blobs, jsonBlob{data: data, isPod: true})
+	}
+	for i := 0; i < benchNumEvents; i++ {
+		data, _ := json.Marshal(benchGenTypedEvent(i))
+		blobs = append(blobs, jsonBlob{data: data, isPod: false})
+	}
+
+	// CRD blobs for the dynamic benchmark
+	crdBlobs := make([][]byte, benchNumCRDs)
+	for i := 0; i < benchNumCRDs; i++ {
+		crdBlobs[i], _ = json.Marshal(benchGenUnstructuredCRD(i).Object)
+	}
+
+	b.Run("Typed_JSON", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			blob := blobs[i%len(blobs)]
+			if blob.isPod {
+				var pod corev1.Pod
+				_ = json.Unmarshal(blob.data, &pod)
+				benchSink = &pod
+			} else {
+				var event corev1.Event
+				_ = json.Unmarshal(blob.data, &event)
+				benchSink = &event
+			}
+		}
+	})
+
+	b.Run("Unstructured_JSON", func(b *testing.B) {
+		allBlobs := make([][]byte, 0, len(blobs)+len(crdBlobs))
+		for _, blob := range blobs {
+			allBlobs = append(allBlobs, blob.data)
+		}
+		allBlobs = append(allBlobs, crdBlobs...)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var m map[string]any
+			_ = json.Unmarshal(allBlobs[i%len(allBlobs)], &m)
+			benchSink = &unstructured.Unstructured{Object: m}
+		}
+	})
+}


### PR DESCRIPTION
informers.NewSharedInformerFactory only supports built-in Kubernetes API
groups and fails with "no informer found" for CRDs (e.g.
mission-control.flanksource.com/v1, Kind=View).

Switch to dynamicinformer.NewDynamicSharedInformerFactory which uses the
dynamic client and works with any resource including CRDs.

Ref: https://github.com/kubernetes/client-go/blob/c07c271a94ae4dd33a61d9531442d12d54ab8349/informers/generic.go#L100-L475


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Kubernetes informer implementation to support dynamic informers.

* **Chores**
  * Removed 8 unused indirect dependencies from build configuration.
  * Added new `bench` build target for performance benchmarking.

* **Tests**
  * Introduced comprehensive benchmark suite measuring event processing, cache memory usage, and deserialization performance across informer types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->