### PR TITLE
chore(chart): allow config-db-sa to patch scrapeplugins

### DIFF
--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -87,8 +87,21 @@ rules:
   - configs.flanksource.com
   resources:
   - scrapeconfigs/finalizers
+  - scrapeplugins/finalizers
   verbs:
   - update
+- apiGroups:
+  - configs.flanksource.com
+  resources:
+  - scrapeplugins
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - configs.flanksource.com
   resources:


### PR DESCRIPTION
Fixes:
```json
{
  "time": "2026-04-14T09:13:02.775084172Z",
  "level": "ERROR",
  "msg": "Reconciler error",
  "controller": "scrapeplugin",
  "controllerGroup": "configs.flanksource.com",
  "controllerKind": "ScrapePlugin",
  "ScrapePlugin": {
    "name": "aws-locations",
    "namespace": "mission-control"
  },
  "namespace": "mission-control",
  "name": "aws-locations",
  "reconcileID": "f4c96bd5-5f94-49d9-8332-3c82a19ef42d",
  "err": "scrapeplugins.configs.flanksource.com \"aws-locations\" is forbidden: User \"system:serviceaccount:mission-control:config-db-sa\" cannot update resource \"scrapeplugins\" in API group \"configs.flanksource.com\" in the namespace \"mission-control\""
}
```
