### PR TITLE
fix(changes): normalize bare duration values in fingerprints

### DIFF
--- a/changes/fingerprint.go
+++ b/changes/fingerprint.go
@@ -36,7 +36,7 @@ func init() {
 	tokenizer = NewReplacements(
 		"UUID", `\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b`,
 		"TIMESTAMP", `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})`,
-		"DURATION", `\s+\d+(.\d+){0,1}(ms|s|h|d|m)`,
+		"DURATION", `\b\d+(?:\.\d+)?(?:ns|us|µs|ms|s|m|h|d)\b`,
 		"SHA256", `[a-z0-9]{64}`,
 		"NUMBER", `^\d+$`,
 		"HEX16", `[0-9a-f]{16}`, // matches a 16 character long hex string

--- a/changes/fingerprint_test.go
+++ b/changes/fingerprint_test.go
@@ -63,6 +63,22 @@ var _ = Describe("Change Fingerprints", func() {
 		Expect(err2).ToNot(HaveOccurred())
 		Expect(fp1).To(Equal(fp2))
 	})
+
+	It("bare duration values should be ignored", func() {
+		fp1, err1 := changes.Fingerprint(readChange("status_history_duration_1.json"))
+		fp2, err2 := changes.Fingerprint(readChange("status_history_duration_2.json"))
+		Expect(err1).ToNot(HaveOccurred())
+		Expect(err2).ToNot(HaveOccurred())
+		Expect(fp1).To(Equal(fp2))
+	})
+
+	It("status history patches should fingerprint the same across reconcile churn", func() {
+		fp1, err1 := changes.Fingerprint(readChange("status_history_query_1.json"))
+		fp2, err2 := changes.Fingerprint(readChange("status_history_query_2.json"))
+		Expect(err1).ToNot(HaveOccurred())
+		Expect(err2).ToNot(HaveOccurred())
+		Expect(fp1).To(Equal(fp2))
+	})
 })
 
 func TestChangeFingerprints(t *testing.T) {

--- a/changes/testdata/status_history_duration_1.json
+++ b/changes/testdata/status_history_duration_1.json
@@ -1,0 +1,20 @@
+{
+  "change_type": "diff",
+  "details": {
+    "status": {
+      "history": [
+        {
+          "digest": "sha256:6084c000bf330e46d06fb07e8b901b2b685dc8dd146e41385f2bf0cd81d297e6",
+          "metadata": {
+            "revision": "main@sha1:1a2bdf942e1a95b8b1a8878c1d70c0b317a22288"
+          },
+          "lastReconciled": "2026-04-10T12:52:26Z",
+          "firstReconciled": "2026-03-29T16:00:27Z",
+          "lastReconciledStatus": "ReconciliationSucceeded",
+          "totalReconciliations": 609,
+          "lastReconciledDuration": "158.864723ms"
+        }
+      ]
+    }
+  }
+}

--- a/changes/testdata/status_history_duration_2.json
+++ b/changes/testdata/status_history_duration_2.json
@@ -1,0 +1,20 @@
+{
+  "change_type": "diff",
+  "details": {
+    "status": {
+      "history": [
+        {
+          "digest": "sha256:6084c000bf330e46d06fb07e8b901b2b685dc8dd146e41385f2bf0cd81d297e6",
+          "metadata": {
+            "revision": "main@sha1:1a2bdf942e1a95b8b1a8878c1d70c0b317a22288"
+          },
+          "lastReconciled": "2026-04-10T03:49:50Z",
+          "firstReconciled": "2026-03-29T16:00:27Z",
+          "lastReconciledStatus": "ReconciliationSucceeded",
+          "totalReconciliations": 591,
+          "lastReconciledDuration": "124.429793ms"
+        }
+      ]
+    }
+  }
+}

--- a/changes/testdata/status_history_query_1.json
+++ b/changes/testdata/status_history_query_1.json
@@ -1,0 +1,6 @@
+{
+  "id": "11111111-1111-1111-1111-111111111111",
+  "config_id": "1459a2bc-1889-4637-951b-3cc0ded83571",
+  "change_type": "diff",
+  "patches": "{\"status\":{\"history\":[{\"digest\":\"sha256:e93e0f0501c0feb29de49bfafe0afc4ed5b44bfb1d6d287c2f907a9347b1e825\",\"metadata\":{\"revision\":\"main@sha1:7736c590d6011a5f0ec37d43f55fc087b83a2a27\"},\"lastReconciled\":\"2026-04-19T09:06:06Z\",\"firstReconciled\":\"2025-12-10T20:09:42Z\",\"lastReconciledStatus\":\"ReconciliationSucceeded\",\"totalReconciliations\":37391,\"lastReconciledDuration\":\"104.143091ms\"},{\"digest\":\"sha256:feda35648eb512db4771edab5b17e8c6e44438672a1825692cc6f917a1f61df3\",\"metadata\":{\"revision\":\"main@sha1:65bdf1491abf296ae287a650c680bac378302c71\"},\"lastReconciled\":\"2025-12-10T20:05:29Z\",\"firstReconciled\":\"2025-11-22T06:21:01Z\",\"lastReconciledStatus\":\"ReconciliationSucceeded\",\"totalReconciliations\":5427,\"lastReconciledDuration\":\"175.854963ms\"},{\"digest\":\"sha256:cdb9933fdd48d72e66903066493aca4ffc9fcccdd53a2da4898f776e7678d882\",\"metadata\":{\"revision\":\"main@sha1:50d6781937c9ddda0b123c43af321579503c8954\"},\"lastReconciled\":\"2025-11-22T06:20:45Z\",\"firstReconciled\":\"2025-10-05T08:47:19Z\",\"lastReconciledStatus\":\"ReconciliationSucceeded\",\"totalReconciliations\":13344,\"lastReconciledDuration\":\"457.975121ms\"}]}}"
+}

--- a/changes/testdata/status_history_query_2.json
+++ b/changes/testdata/status_history_query_2.json
@@ -1,0 +1,6 @@
+{
+  "id": "22222222-2222-2222-2222-222222222222",
+  "config_id": "1459a2bc-1889-4637-951b-3cc0ded83571",
+  "change_type": "diff",
+  "patches": "{\"status\":{\"history\":[{\"digest\":\"sha256:e93e0f0501c0feb29de49bfafe0afc4ed5b44bfb1d6d287c2f907a9347b1e825\",\"metadata\":{\"revision\":\"main@sha1:7736c590d6011a5f0ec37d43f55fc087b83a2a27\"},\"lastReconciled\":\"2026-04-19T09:10:54Z\",\"firstReconciled\":\"2025-12-10T20:09:42Z\",\"lastReconciledStatus\":\"ReconciliationSucceeded\",\"totalReconciliations\":37392,\"lastReconciledDuration\":\"114.046818ms\"},{\"digest\":\"sha256:feda35648eb512db4771edab5b17e8c6e44438672a1825692cc6f917a1f61df3\",\"metadata\":{\"revision\":\"main@sha1:65bdf1491abf296ae287a650c680bac378302c71\"},\"lastReconciled\":\"2025-12-10T20:05:29Z\",\"firstReconciled\":\"2025-11-22T06:21:01Z\",\"lastReconciledStatus\":\"ReconciliationSucceeded\",\"totalReconciliations\":5427,\"lastReconciledDuration\":\"175.854963ms\"},{\"digest\":\"sha256:cdb9933fdd48d72e66903066493aca4ffc9fcccdd53a2da4898f776e7678d882\",\"metadata\":{\"revision\":\"main@sha1:50d6781937c9ddda0b123c43af321579503c8954\"},\"lastReconciled\":\"2025-11-22T06:20:45Z\",\"firstReconciled\":\"2025-10-05T08:47:19Z\",\"lastReconciledStatus\":\"ReconciliationSucceeded\",\"totalReconciliations\":13344,\"lastReconciledDuration\":\"457.975121ms\"}]}}"
+}


### PR DESCRIPTION
Diff changes under status.history were not deduplicating because duration strings like '158.864723ms' were not tokenized as DURATION. The previous regex required leading whitespace, so these values produced different fingerprints across otherwise equivalent reconcile updates.

Update duration tokenization to match bare duration values and add fixture-based fingerprint tests that mirror existing readChange() patterns. This ensures noisy lastReconciledDuration/timestamp/counter churn can collapse to the same fingerprint when appropriate.

Prevents: 

Reduces the number of changes in our database. Ensure deduplication of events in event_queue

<img width="2332" height="1212" alt="image" src="https://github.com/user-attachments/assets/763b814d-9cd8-470c-889a-4ebbdfa91491" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced duration value recognition to support additional time units (ns, us, µs, ms, s, m, h, d) with improved pattern matching for more consistent change detection.

* **Tests**
  * Added test coverage for duration fingerprinting and status history change detection to ensure consistency across different data formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->