### PR TITLE
feat: External entity dedupe with union-find and FK violation recovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,14 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+.PHONY: install-deps
+install-deps: $(LOCALBIN) ## Install the deps CLI if not present
+	which deps 2>/dev/null || test -x $(LOCALBIN)/deps || curl -sSL https://github.com/flanksource/deps/releases/latest/download/deps-$(OS)-$(ARCH).tar.gz | tar -xz -C $(LOCALBIN)
+
+.PHONY: deps
+deps: install-deps ginkgo controller-gen golangci-lint kustomize $(TAILWIND_JS) ## Install all tool dependencies
+
+
 .PHONY: tidy
 tidy:
 	go mod tidy
@@ -264,11 +272,11 @@ ENVTEST_ASSETS_DIR = $(LOCALBIN)
 
 
 .PHONY: envtest
-envtest: $(LOCALBIN) ## Install envtest binaries using flanksource/deps.
+envtest: install-deps $(LOCALBIN) ## Install envtest binaries using flanksource/deps.
 	@mkdir -p $(ENVTEST_ASSETS_DIR)
-	@test -x $(ENVTEST_ASSETS_DIR)/etcd || deps install etcd@v3.5.23 --bin-dir $(ENVTEST_ASSETS_DIR)
-	@test -x $(ENVTEST_ASSETS_DIR)/kube-apiserver || deps install kube-apiserver@v$(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR)
-	@test -x $(ENVTEST_ASSETS_DIR)/kubectl || deps install kubectl@v$(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR)
+	@test -x $(ENVTEST_ASSETS_DIR)/etcd || $(LOCALBIN)/deps install etcd@v3.5.23 --bin-dir $(ENVTEST_ASSETS_DIR)
+	@test -x $(ENVTEST_ASSETS_DIR)/kube-apiserver || $(LOCALBIN)/deps install kube-apiserver@v$(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR)
+	@test -x $(ENVTEST_ASSETS_DIR)/kubectl || $(LOCALBIN)/deps install kubectl@v$(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR)
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 
 .PHONY: install-deps
 install-deps: $(LOCALBIN) ## Install the deps CLI if not present
-	which deps 2>/dev/null || test -x $(LOCALBIN)/deps || curl -sSL https://github.com/flanksource/deps/releases/latest/download/deps-$(OS)-$(ARCH).tar.gz | tar -xz -C $(LOCALBIN)
+	test -x $(LOCALBIN)/deps || curl -sSL https://github.com/flanksource/deps/releases/latest/download/deps-$(OS)-$(ARCH).tar.gz | tar -xz -C $(LOCALBIN)
 
 .PHONY: deps
 deps: install-deps ginkgo controller-gen golangci-lint kustomize $(TAILWIND_JS) ## Install all tool dependencies

--- a/api/v1/interface.go
+++ b/api/v1/interface.go
@@ -132,6 +132,11 @@ type ChangeResult struct {
 	// selector for resolving target config items.
 	Target *duty.RelationshipSelectorTemplate `json:"-"`
 
+	// Resolved is the final state of the change after transformation by the
+	// change mapping pipeline. The original ChangeResult fields represent the
+	// scraper input; Resolved represents the pipeline output.
+	Resolved *models.ConfigChange `json:"resolved,omitempty"`
+
 	// For storing struct as map[string]any
 	_map map[string]any `json:"-"`
 }
@@ -354,12 +359,12 @@ type Warning struct {
 	Count  int    `json:"count,omitempty"`
 }
 
-// func warningCount(w Warning) int {
-// 	if w.Count > 0 {
-// 		return w.Count
-// 	}
-// 	return 1
-// }
+func warningCount(w Warning) int {
+	if w.Count > 0 {
+		return w.Count
+	}
+	return 1
+}
 
 // +kubebuilder:object:generate=false
 type ScrapeSummary struct {
@@ -376,6 +381,13 @@ type ScrapeSummary struct {
 	ExternalRoles  EntitySummary[models.ExternalRole]  `json:"external_roles,omitempty"`
 	ConfigAccess   EntitySummary[struct{}]             `json:"config_access,omitempty"`
 	AccessLogs     EntitySummary[struct{}]             `json:"access_logs,omitempty"`
+
+	OrphanedChanges []ChangeResult `json:"orphaned_changes,omitempty"`
+	FKErrorChanges  []ChangeResult `json:"fk_error_changes,omitempty"`
+	Warnings        []Warning      `json:"warnings,omitempty"`
+	State           map[string]any `json:"state,omitempty"`
+
+	warningIndex map[string]int `json:"-"`
 }
 
 func NewScrapeSummary() ScrapeSummary {
@@ -496,14 +508,22 @@ func (a ConfigTypeScrapeSummary) Merge(b ConfigTypeScrapeSummary) ConfigTypeScra
 	if b.Change != nil {
 		change.Merge(*b.Change)
 	}
-	return ConfigTypeScrapeSummary{
-		Added:     a.Added + b.Added,
-		Updated:   a.Updated + b.Updated,
-		Unchanged: a.Unchanged + b.Unchanged,
-		Changes:   a.Changes + b.Changes,
-		Deduped:   a.Deduped + b.Deduped,
-		Change:    change,
+	merged := ConfigTypeScrapeSummary{
+		Added:      a.Added + b.Added,
+		Updated:    a.Updated + b.Updated,
+		Unchanged:  a.Unchanged + b.Unchanged,
+		Changes:    a.Changes + b.Changes,
+		Deduped:    a.Deduped + b.Deduped,
+		Change:     change,
+		AccessLogs: a.AccessLogs.Merge(b.AccessLogs),
 	}
+	for _, warning := range a.Warnings {
+		merged.AddWarning(warning)
+	}
+	for _, warning := range b.Warnings {
+		merged.AddWarning(warning)
+	}
+	return merged
 }
 
 func (s ScrapeSummary) Totals() ConfigTypeScrapeSummary {
@@ -559,8 +579,20 @@ func (t *ScrapeSummary) AddUnchanged(configType string) {
 func (t *ScrapeSummary) AddWarning(configType, warning string) {
 	t.initConfigTypes()
 	v := t.ConfigTypes[configType]
-	v.Warnings = append(v.Warnings, warning)
+	v.AddWarning(warning)
 	t.ConfigTypes[configType] = v
+}
+
+func (t *ScrapeSummary) AddScrapeWarning(w Warning) {
+	t.initWarningIndex()
+	count := warningCount(w)
+	if idx, ok := t.warningIndex[w.Error]; ok {
+		t.Warnings[idx].Count += count
+		return
+	}
+	w.Count = count
+	t.warningIndex[w.Error] = len(t.Warnings)
+	t.Warnings = append(t.Warnings, w)
 }
 
 func (t *ScrapeSummary) AddChanges(configType string, count int) {
@@ -591,6 +623,22 @@ func (s *ScrapeSummary) Merge(other ScrapeSummary) {
 	s.ExternalRoles = s.ExternalRoles.Merge(other.ExternalRoles)
 	s.ConfigAccess = s.ConfigAccess.Merge(other.ConfigAccess)
 	s.AccessLogs = s.AccessLogs.Merge(other.AccessLogs)
+}
+
+func (t *ScrapeSummary) initWarningIndex() {
+	if t.warningIndex != nil {
+		return
+	}
+	t.warningIndex = make(map[string]int, len(t.Warnings))
+	for i := range t.Warnings {
+		if _, ok := t.warningIndex[t.Warnings[i].Error]; ok {
+			continue
+		}
+		if t.Warnings[i].Count == 0 {
+			t.Warnings[i].Count = 1
+		}
+		t.warningIndex[t.Warnings[i].Error] = i
+	}
 }
 
 // +kubebuilder:object:generate=false
@@ -735,6 +783,8 @@ type ConfigTypeScrapeSummary struct {
 	Warnings  []string       `json:"warnings,omitempty"`
 
 	AccessLogs EntitySummary[struct{}] `json:"access_logs,omitempty"`
+
+	warningIndex map[string]int `json:"-"`
 }
 
 // +kubebuilder:object:generate=false
@@ -748,6 +798,28 @@ func (t ScrapeResults) HasErr() bool {
 	}
 
 	return false
+}
+
+func (s *ConfigTypeScrapeSummary) initWarningIndex() {
+	if s.warningIndex != nil {
+		return
+	}
+	s.warningIndex = make(map[string]int, len(s.Warnings))
+	for i := range s.Warnings {
+		if _, ok := s.warningIndex[s.Warnings[i]]; ok {
+			continue
+		}
+		s.warningIndex[s.Warnings[i]] = i
+	}
+}
+
+func (s *ConfigTypeScrapeSummary) AddWarning(warning string) {
+	s.initWarningIndex()
+	if _, ok := s.warningIndex[warning]; ok {
+		return
+	}
+	s.warningIndex[warning] = len(s.Warnings)
+	s.Warnings = append(s.Warnings, warning)
 }
 
 func (t ScrapeResults) Errors() []string {

--- a/api/v1/interface_test.go
+++ b/api/v1/interface_test.go
@@ -165,3 +165,26 @@ var _ = Describe("ScrapeSummary.AsMap", func() {
 		Expect(ScrapeSummary{}.AsMap()).NotTo(BeNil())
 	})
 })
+
+var _ = Describe("ScrapeSummary warnings", func() {
+	It("deduplicates structured warnings inline by error", func() {
+		summary := NewScrapeSummary()
+
+		summary.AddScrapeWarning(Warning{Error: "duplicate warning", Input: "first", Expr: "expr-a"})
+		summary.AddScrapeWarning(Warning{Error: "duplicate warning", Input: "second", Expr: "expr-b"})
+
+		Expect(summary.Warnings).To(HaveLen(1))
+		Expect(summary.Warnings[0].Count).To(Equal(2))
+		Expect(summary.Warnings[0].Input).To(Equal("first"))
+		Expect(summary.Warnings[0].Expr).To(Equal("expr-a"))
+	})
+
+	It("deduplicates config type warnings inline", func() {
+		summary := NewScrapeSummary()
+
+		summary.AddWarning("AWS::EC2::Instance", "duplicate warning")
+		summary.AddWarning("AWS::EC2::Instance", "duplicate warning")
+
+		Expect(summary.ConfigTypes["AWS::EC2::Instance"].Warnings).To(Equal([]string{"duplicate warning"}))
+	})
+})

--- a/db/change_traversal.go
+++ b/db/change_traversal.go
@@ -8,10 +8,29 @@ import (
 	v1 "github.com/flanksource/config-db/api/v1"
 	"github.com/flanksource/config-db/db/models"
 	"github.com/flanksource/duty"
+	dutyModels "github.com/flanksource/duty/models"
 	"github.com/samber/lo"
 )
 
 const maxTraversalDepth = 50
+
+func resolveChange(change *v1.ChangeResult, action string, targetConfigID string) {
+	change.Resolved = &dutyModels.ConfigChange{
+		ConfigID:          targetConfigID,
+		ChangeType:        change.ChangeType,
+		Severity:          dutyModels.Severity(change.Severity),
+		Source:            change.Source,
+		Summary:           change.Summary,
+		Patches:           change.Patches,
+		ExternalCreatedBy: change.CreatedBy,
+		CreatedAt:         change.CreatedAt,
+		Action:            action,
+	}
+
+	if change.Diff != nil {
+		change.Resolved.Diff = *change.Diff
+	}
+}
 
 // findAncestor walks the parent_id chain from ci and returns the first
 // ancestor whose Type matches ancestorType. If ancestorType is empty,
@@ -79,6 +98,7 @@ func processMoveUpCopyUp(ctx api.ScrapeContext, result *v1.ScrapeResult, ci *mod
 		}
 
 		if change.Action == v1.MoveUp {
+			resolveChange(change, string(v1.MoveUp), ancestor.ID)
 			change.ConfigID = ancestor.ID
 			change.Action = ""
 		} else {
@@ -88,7 +108,6 @@ func processMoveUpCopyUp(ctx api.ScrapeContext, result *v1.ScrapeResult, ci *mod
 			if change.ExternalChangeID != "" {
 				copied.ExternalChangeID = change.ExternalChangeID + ":copy-up:" + ancestor.ID
 			}
-			// Deep copy the Details map to prevent shared-map mutation
 			if change.Details != nil {
 				copiedDetails := make(map[string]any, len(change.Details))
 				for k, v := range change.Details {
@@ -96,7 +115,9 @@ func processMoveUpCopyUp(ctx api.ScrapeContext, result *v1.ScrapeResult, ci *mod
 				}
 				copied.Details = copiedDetails
 			}
+			resolveChange(&copied, string(v1.CopyUp), ancestor.ID)
 			additional = append(additional, copied)
+			resolveChange(change, string(v1.CopyUp), ci.ID)
 			change.Action = ""
 		}
 	}
@@ -172,6 +193,7 @@ func applyCopyMove(change *v1.ChangeResult, targetIDs []string, action v1.Change
 	var additional []v1.ChangeResult
 
 	if action == v1.Move {
+		resolveChange(change, string(v1.Move), targetIDs[0])
 		change.ConfigID = targetIDs[0]
 		change.Action = ""
 		for _, id := range targetIDs[1:] {
@@ -180,7 +202,6 @@ func applyCopyMove(change *v1.ChangeResult, targetIDs []string, action v1.Change
 			if change.ExternalChangeID != "" {
 				copied.ExternalChangeID = change.ExternalChangeID + ":copy:" + id
 			}
-			// Deep copy the Details map to prevent shared-map mutation
 			if change.Details != nil {
 				copiedDetails := make(map[string]any, len(change.Details))
 				for k, v := range change.Details {
@@ -188,10 +209,12 @@ func applyCopyMove(change *v1.ChangeResult, targetIDs []string, action v1.Change
 				}
 				copied.Details = copiedDetails
 			}
+			resolveChange(&copied, string(v1.Move), id)
 			copied.FlushMap()
 			additional = append(additional, copied)
 		}
 	} else {
+		resolveChange(change, string(v1.Copy), change.ConfigID)
 		change.Action = ""
 		for _, id := range targetIDs {
 			copied := *change
@@ -199,7 +222,6 @@ func applyCopyMove(change *v1.ChangeResult, targetIDs []string, action v1.Change
 			if change.ExternalChangeID != "" {
 				copied.ExternalChangeID = change.ExternalChangeID + ":copy:" + id
 			}
-			// Deep copy the Details map to prevent shared-map mutation
 			if change.Details != nil {
 				copiedDetails := make(map[string]any, len(change.Details))
 				for k, v := range change.Details {
@@ -207,6 +229,7 @@ func applyCopyMove(change *v1.ChangeResult, targetIDs []string, action v1.Change
 				}
 				copied.Details = copiedDetails
 			}
+			resolveChange(&copied, string(v1.Copy), id)
 			copied.FlushMap()
 			additional = append(additional, copied)
 		}

--- a/db/external_cache.go
+++ b/db/external_cache.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
+	"gorm.io/gorm"
 )
 
 var CACHE_TIMEOUT = properties.Duration(time.Hour*24, "external.cache.timeout")
@@ -59,6 +60,21 @@ func getEntityCache[T externalEntityWithID]() *cache.Cache {
 	}
 }
 
+// getEntityIDCache returns the id-keyed cache for an external entity type.
+func getEntityIDCache[T externalEntityWithID]() *cache.Cache {
+	var zero T
+	switch any(zero).(type) {
+	case dutyModels.ExternalUser:
+		return ExternalUserIDCache
+	case dutyModels.ExternalRole:
+		return ExternalRoleIDCache
+	case dutyModels.ExternalGroup:
+		return ExternalGroupIDCache
+	default:
+		return nil
+	}
+}
+
 // WarmExternalEntityCaches pre-fills the user/role/group alias caches from the database.
 func WarmExternalEntityCaches(ctx context.Context) {
 	type idAliases struct {
@@ -67,29 +83,27 @@ func WarmExternalEntityCaches(ctx context.Context) {
 	}
 
 	for _, table := range []struct {
-		name  string
-		cache *cache.Cache
+		name        string
+		aliasCache  *cache.Cache
+		idCache     *cache.Cache
 	}{
-		{"external_users", ExternalUserCache},
-		{"external_roles", ExternalRoleCache},
-		{"external_groups", ExternalGroupCache},
+		{"external_users", ExternalUserCache, ExternalUserIDCache},
+		{"external_roles", ExternalRoleCache, ExternalRoleIDCache},
+		{"external_groups", ExternalGroupCache, ExternalGroupIDCache},
 	} {
 		var rows []idAliases
 		if err := ctx.DB().Table(table.name).
 			Select("id, aliases").
 			Where("deleted_at IS NULL").
-			Where("aliases IS NOT NULL AND array_length(aliases, 1) > 0").
 			Find(&rows).Error; err != nil {
 			logger.Errorf("failed to warm %s cache: %v", table.name, err)
 			continue
 		}
 		for _, row := range rows {
 			for _, alias := range row.Aliases {
-				table.cache.Set(alias, row.ID, cache.DefaultExpiration)
+				table.aliasCache.Set(alias, row.ID, cache.DefaultExpiration)
 			}
-			if table.name == "external_users" {
-				ExternalUserIDCache.Set(row.ID.String(), row.ID, cache.DefaultExpiration)
-			}
+			table.idCache.Set(row.ID.String(), row.ID, cache.DefaultExpiration)
 		}
 		logger.Infof("warmed %s cache with %d entities", table.name, len(rows))
 	}
@@ -106,6 +120,60 @@ func findExternalEntityIDByAliases[T externalEntityWithID](ctx api.ScrapeContext
 		return nil, nil
 	}
 	return lo.ToPtr(ids[0]), nil
+}
+
+// findExternalEntityByID resolves an external entity by canonical id. It checks
+// the id-cache first, then queries `id =` on the live table. If the row is
+// not found by id, it falls back to alias overlap — covering the case where
+// the entity was previously merged into a winner whose `aliases` array now
+// contains the original (loser) id.
+//
+// `entity.aliases` is invariant-free of `entity.id` for live entities, so the
+// alias fallback only fires for historical/loser ids — never for the entity's
+// current canonical id.
+func findExternalEntityByID[T externalEntityWithID](ctx api.ScrapeContext, id uuid.UUID) (*uuid.UUID, error) {
+	if id == uuid.Nil {
+		return nil, nil
+	}
+
+	idCache := getEntityIDCache[T]()
+	if idCache != nil {
+		if cached, ok := idCache.Get(id.String()); ok {
+			if winner, valid := cached.(uuid.UUID); valid {
+				return &winner, nil
+			}
+		}
+	}
+
+	var zero T
+	var foundIDs []uuid.UUID
+	err := ctx.DB().Table(zero.TableName()).
+		Select("id").
+		Where("id = ? AND deleted_at IS NULL", id).
+		Limit(1).
+		Pluck("id", &foundIDs).Error
+	if err != nil && err != gorm.ErrRecordNotFound {
+		return nil, fmt.Errorf("failed to query %s by id: %w", zero.TableName(), err)
+	}
+	var found uuid.UUID
+	if len(foundIDs) > 0 {
+		found = foundIDs[0]
+	}
+	if found != uuid.Nil {
+		if idCache != nil {
+			idCache.Set(id.String(), found, cache.DefaultExpiration)
+		}
+		return &found, nil
+	}
+
+	winner, err := findExternalEntityIDByAliases[T](ctx, []string{id.String()})
+	if err != nil {
+		return nil, err
+	}
+	if winner != nil && idCache != nil {
+		idCache.Set(id.String(), *winner, cache.DefaultExpiration)
+	}
+	return winner, nil
 }
 
 // findAllExternalEntityIDsByAliases returns all distinct entity IDs that share any alias with the given set.

--- a/db/external_entities.go
+++ b/db/external_entities.go
@@ -2,12 +2,15 @@ package db
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"slices"
 	"sort"
 	"time"
 
 	"github.com/flanksource/commons/hash"
 	v1 "github.com/flanksource/config-db/api/v1"
+	"github.com/flanksource/duty"
 	dutyModels "github.com/flanksource/duty/models"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
@@ -143,9 +146,6 @@ func resolveExternalUsers(ctx api.ScrapeContext, users []dutyModels.ExternalUser
 			skipped++
 			continue
 		}
-		if u.ID != uuid.Nil {
-			u.Aliases = appendUnique(u.Aliases, u.ID.String())
-		}
 		if u.ID == uuid.Nil {
 			sort.Strings(u.Aliases)
 			hid, err := hash.DeterministicUUID(u.Aliases)
@@ -175,9 +175,6 @@ func resolveExternalGroups(ctx api.ScrapeContext, groups []dutyModels.ExternalGr
 			ctx.Logger.Warnf("skipping external group %q with no ID and no aliases", g.Name)
 			skipped++
 			continue
-		}
-		if g.ID != uuid.Nil {
-			g.Aliases = appendUnique(g.Aliases, g.ID.String())
 		}
 		if g.ID == uuid.Nil {
 			sort.Strings(g.Aliases)
@@ -294,9 +291,6 @@ func resolveExternalRoles(ctx api.ScrapeContext, roles []dutyModels.ExternalRole
 			skipped++
 			continue
 		}
-		if r.ID != uuid.Nil {
-			r.Aliases = appendUnique(r.Aliases, r.ID.String())
-		}
 		if r.ID == uuid.Nil {
 			sort.Strings(r.Aliases)
 			hid, err := hash.DeterministicUUID(r.Aliases)
@@ -340,6 +334,136 @@ func remapExternalUserGroups(userGroups []dutyModels.ExternalUserGroup, userIDMa
 	return remapped
 }
 
+// liveTableForMergeFunc returns the live table name targeted by the named
+// merge_and_upsert_external_* SQL function. Used by the dump helper to
+// query overlapping live rows when the merge fails.
+func liveTableForMergeFunc(funcName string) string {
+	switch funcName {
+	case "merge_and_upsert_external_users":
+		return "external_users"
+	case "merge_and_upsert_external_groups":
+		return "external_groups"
+	case "merge_and_upsert_external_roles":
+		return "external_roles"
+	default:
+		return ""
+	}
+}
+
+// runMergeFunctionWithDump invokes one of the merge_and_upsert_external_*
+// SQL functions inside a savepoint. On error (e.g. a unique constraint
+// violation), it rolls back to the savepoint, dumps the temp table contents
+// AND any live rows that overlap with the temp table by alias or id, as
+// JSON to a file under <cwd>/traces/, and logs the file path so the
+// offending rows can be inspected. The original error is returned so the
+// caller can decide whether to abort the outer transaction.
+//
+// The savepoint is necessary because Postgres aborts the transaction on
+// error, making any further query on the same tx fail. Rolling back to a
+// savepoint resets the abort state without losing the temp table (which is
+// transaction-scoped via ON COMMIT DROP, so it survives savepoint rollback).
+func runMergeFunctionWithDump(
+	ctx api.ScrapeContext,
+	tx *gorm.DB,
+	funcName string,
+	tempTable string,
+	merges any,
+) error {
+	// Postgres caps identifiers at 63 bytes; keep the savepoint name short.
+	savepoint := "sp_merge_" + sanitizeForTempTable(tempTable)
+	if spErr := tx.Exec("SAVEPOINT " + savepoint).Error; spErr != nil {
+		// If we can't even create the savepoint, just run the merge directly.
+		return tx.Raw(fmt.Sprintf("SELECT * FROM %s(?::TEXT)", funcName), tempTable).Scan(merges).Error
+	}
+
+	mergeErr := tx.Raw(fmt.Sprintf("SELECT * FROM %s(?::TEXT)", funcName), tempTable).Scan(merges).Error
+	if mergeErr == nil {
+		tx.Exec("RELEASE SAVEPOINT " + savepoint) //nolint:errcheck
+		return nil
+	}
+
+	// Roll back the savepoint so the temp table query below can run.
+	if rbErr := tx.Exec("ROLLBACK TO SAVEPOINT " + savepoint).Error; rbErr != nil {
+		ctx.Logger.Warnf("%s failed (%v) and savepoint rollback also failed (%v); cannot dump temp table", funcName, mergeErr, rbErr)
+		return mergeErr
+	}
+
+	// Dump the temp table contents as JSON. Use jsonb_agg(to_jsonb(t)) to get
+	// a single JSON array of all rows in one round-trip.
+	var tempDump string
+	tempDumpQuery := fmt.Sprintf("SELECT COALESCE(jsonb_agg(to_jsonb(t) ORDER BY t.id), '[]'::jsonb)::text FROM %s t", tempTable)
+	if err := tx.Raw(tempDumpQuery).Scan(&tempDump).Error; err != nil {
+		ctx.Logger.Warnf("%s failed (%v); failed to dump temp table %s: %v", funcName, mergeErr, tempTable, err)
+		return mergeErr
+	}
+
+	// Also dump any live rows that overlap with the temp table — by alias OR
+	// by id — including soft-deleted rows. This is the data needed to
+	// diagnose temp↔live collisions that the merge function's edge build
+	// missed (e.g. soft-deleted rows whose aliases collide with new temp
+	// rows after the live row is resurrected by the ON CONFLICT branch).
+	liveDump := "[]"
+	if liveTable := liveTableForMergeFunc(funcName); liveTable != "" {
+		liveDumpQuery := fmt.Sprintf(`
+			SELECT COALESCE(jsonb_agg(to_jsonb(live) ORDER BY live.id), '[]'::jsonb)::text
+			FROM %s live
+			WHERE EXISTS (
+				SELECT 1 FROM %s tmp
+				WHERE tmp.id = live.id
+					OR (live.aliases IS NOT NULL AND tmp.aliases IS NOT NULL AND live.aliases && tmp.aliases)
+			)
+		`, liveTable, tempTable)
+		if err := tx.Raw(liveDumpQuery).Scan(&liveDump).Error; err != nil {
+			ctx.Logger.Warnf("%s failed (%v); failed to dump overlapping live rows from %s: %v", funcName, mergeErr, liveTable, err)
+			liveDump = fmt.Sprintf("\"<dump failed: %s>\"", err.Error())
+		}
+	}
+
+	if path, writeErr := writeMergeFailureDump(funcName, tempTable, mergeErr, tempDump, liveDump); writeErr != nil {
+		ctx.Logger.Warnf("%s failed: %v; failed to write dump file: %v", funcName, mergeErr, writeErr)
+		ctx.Logger.Tracef("temp table %s contents: %s\noverlapping live rows: %s", tempTable, tempDump, liveDump)
+	} else {
+		ctx.Logger.Warnf("%s failed: %v — dumped %s rows + overlapping live rows to %s", funcName, mergeErr, tempTable, path)
+	}
+	return mergeErr
+}
+
+// writeMergeFailureDump writes the JSON dump of a failed merge's temp table
+// and any overlapping live rows to <cwd>/traces/<funcName>-<timestamp>.json.
+// Returns the absolute path of the written file.
+func writeMergeFailureDump(funcName, tempTable string, mergeErr error, tempDump, liveDump string) (string, error) {
+	dir := "traces"
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create traces dir: %w", err)
+	}
+
+	ts := time.Now().Format("20060102-150405.000000000")
+	name := fmt.Sprintf("%s-%s.json", funcName, ts)
+	path := filepath.Join(dir, name)
+
+	// Wrap the raw jsonb dumps with a small envelope so the file records the
+	// failing function, the original error message, the temp table rows, and
+	// any live rows whose id or aliases overlap with the temp table.
+	envelope := fmt.Sprintf(`{
+  "function": %q,
+  "temp_table": %q,
+  "error": %q,
+  "rows": %s,
+  "live_overlapping_rows": %s
+}
+`, funcName, tempTable, mergeErr.Error(), tempDump, liveDump)
+
+	if err := os.WriteFile(path, []byte(envelope), 0o644); err != nil {
+		return "", fmt.Errorf("write %s: %w", path, err)
+	}
+
+	abs, absErr := filepath.Abs(path)
+	if absErr != nil {
+		return path, nil
+	}
+	return abs, nil
+}
+
 func upsertExternalEntities(
 	ctx api.ScrapeContext,
 	users []dutyModels.ExternalUser,
@@ -369,6 +493,15 @@ func upsertExternalEntities(
 		}
 	}()
 
+	// Apply any `postgres.session.*` properties as `SET LOCAL` settings so
+	// values like `postgres.session.eu_debug.enabled=on` take effect for the
+	// upcoming merge_and_upsert_external_* calls (their RAISE NOTICE output
+	// is gated on that GUC).
+	if err := duty.ApplySessionProperties(ctx.DutyContext(), tx); err != nil {
+		tx.Rollback()
+		return counts, nil, fmt.Errorf("failed to apply session properties: %w", err)
+	}
+
 	tempUsers := fmt.Sprintf("_ext_users_%s", suffix)
 	tempGroups := fmt.Sprintf("_ext_groups_%s", suffix)
 	tempRoles := fmt.Sprintf("_ext_roles_%s", suffix)
@@ -395,13 +528,15 @@ func upsertExternalEntities(
 		}
 	}
 
-	// Call stored procedures that handle merge + upsert atomically
+	// Call stored procedures that handle merge + upsert atomically. Each
+	// merge runs inside a savepoint so we can dump the temp table contents on
+	// failure (e.g. unique-constraint violation on aliases) for diagnosis.
 	if len(users) > 0 {
 		var merges []struct {
 			LoserID  uuid.UUID `gorm:"column:loser_id"`
 			WinnerID uuid.UUID `gorm:"column:winner_id"`
 		}
-		if err := tx.Raw("SELECT * FROM merge_and_upsert_external_users(?::TEXT)", tempUsers).Scan(&merges).Error; err != nil {
+		if err := runMergeFunctionWithDump(ctx, tx, "merge_and_upsert_external_users", tempUsers, &merges); err != nil {
 			tx.Rollback()
 			return counts, nil, fmt.Errorf("failed to merge and upsert external users: %w", err)
 		}
@@ -416,7 +551,7 @@ func upsertExternalEntities(
 			LoserID  uuid.UUID `gorm:"column:loser_id"`
 			WinnerID uuid.UUID `gorm:"column:winner_id"`
 		}
-		if err := tx.Raw("SELECT * FROM merge_and_upsert_external_groups(?::TEXT)", tempGroups).Scan(&merges).Error; err != nil {
+		if err := runMergeFunctionWithDump(ctx, tx, "merge_and_upsert_external_groups", tempGroups, &merges); err != nil {
 			tx.Rollback()
 			return counts, nil, fmt.Errorf("failed to merge and upsert external groups: %w", err)
 		}
@@ -431,22 +566,75 @@ func upsertExternalEntities(
 			LoserID  uuid.UUID `gorm:"column:loser_id"`
 			WinnerID uuid.UUID `gorm:"column:winner_id"`
 		}
-		if err := tx.Raw("SELECT * FROM merge_and_upsert_external_roles(?::TEXT)", tempRoles).Scan(&merges).Error; err != nil {
+		if err := runMergeFunctionWithDump(ctx, tx, "merge_and_upsert_external_roles", tempRoles, &merges); err != nil {
 			tx.Rollback()
 			return counts, nil, fmt.Errorf("failed to merge and upsert external roles: %w", err)
 		}
 		counts.rolesSaved = len(roles)
 	}
 
+	// The user_groups + stale-deletion block runs inside its own savepoint so
+	// a failure here (most commonly a foreign-key violation from
+	// scraper-emitted user/group refs that don't resolve to entities we
+	// actually have) does NOT abort the already-successful user/group/role
+	// upserts above. On failure we roll back just this savepoint, log a
+	// warning, and fall through to tx.Commit() so the partial data still
+	// lands in the DB.
+	ugSavepoint := "sp_ext_user_groups_" + suffix
+	if err := tx.Exec("SAVEPOINT " + ugSavepoint).Error; err != nil {
+		ctx.Logger.Warnf("failed to create user_groups savepoint (%v); proceeding without isolation", err)
+		ugSavepoint = ""
+	}
+
+	userGroupsErr := upsertExternalUserGroupsBlock(ctx, tx, tempUserGroups, userGroups, users, groups, userIDMap, groupIDMap, scraperID)
+	if userGroupsErr != nil {
+		if ugSavepoint != "" {
+			if rbErr := tx.Exec("ROLLBACK TO SAVEPOINT " + ugSavepoint).Error; rbErr != nil {
+				// If we can't even roll back the savepoint, the outer
+				// transaction is hosed — abort everything.
+				tx.Rollback()
+				return counts, nil, fmt.Errorf("failed to upsert external user groups (%v) and savepoint rollback also failed: %w", userGroupsErr, rbErr)
+			}
+			ctx.Logger.Warnf("external_user_groups upsert failed, rolled back to savepoint so users/groups/roles still persist: %v", userGroupsErr)
+		} else {
+			// No savepoint to roll back to — the outer tx is aborted.
+			tx.Rollback()
+			return counts, nil, fmt.Errorf("failed to upsert external user groups: %w", userGroupsErr)
+		}
+	} else if ugSavepoint != "" {
+		tx.Exec("RELEASE SAVEPOINT " + ugSavepoint) //nolint:errcheck
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		return counts, nil, fmt.Errorf("failed to commit external entities transaction: %w", err)
+	}
+
+	return counts, userIDMap, nil
+}
+
+// upsertExternalUserGroupsBlock runs the user_groups temp-table insert, the
+// real-table upsert, and the stale-membership cleanup. Split out of
+// upsertExternalEntities so the savepoint isolation logic in the caller stays
+// readable — any error returned from here bubbles up and triggers a savepoint
+// rollback rather than an outer-transaction rollback, preserving the already-
+// committed user/group/role writes.
+func upsertExternalUserGroupsBlock(
+	ctx api.ScrapeContext,
+	tx *gorm.DB,
+	tempUserGroups string,
+	userGroups []dutyModels.ExternalUserGroup,
+	users []dutyModels.ExternalUser,
+	groups []dutyModels.ExternalGroup,
+	userIDMap map[uuid.UUID]uuid.UUID,
+	groupIDMap map[uuid.UUID]uuid.UUID,
+	scraperID *uuid.UUID,
+) error {
 	if len(userGroups) > 0 {
 		remappedUserGroups := remapExternalUserGroups(userGroups, userIDMap, groupIDMap)
 		if err := createTempAndInsert(tx, tempUserGroups, "external_user_groups", remappedUserGroups); err != nil {
-			tx.Rollback()
-			return counts, nil, fmt.Errorf("failed to setup temp user groups: %w", err)
+			return fmt.Errorf("failed to setup temp user groups: %w", err)
 		}
-	}
 
-	if len(userGroups) > 0 {
 		r := tx.Exec(fmt.Sprintf(`
 			INSERT INTO external_user_groups (external_user_id, external_group_id, created_at)
 			SELECT external_user_id, external_group_id, created_at FROM %s
@@ -454,8 +642,7 @@ func upsertExternalEntities(
 			WHERE external_user_groups.deleted_at IS NOT NULL
 		`, tempUserGroups))
 		if r.Error != nil {
-			tx.Rollback()
-			return counts, nil, fmt.Errorf("failed to upsert external user groups: %w", r.Error)
+			return fmt.Errorf("failed to upsert external user groups: %w", r.Error)
 		}
 	}
 
@@ -470,8 +657,7 @@ func upsertExternalEntities(
 						WHERE t.external_user_id = external_user_groups.external_user_id
 							AND t.external_group_id = external_user_groups.external_group_id)
 			`, tempUserGroups), *scraperID).Error; err != nil {
-				tx.Rollback()
-				return counts, nil, fmt.Errorf("failed to delete stale external user groups: %w", err)
+				return fmt.Errorf("failed to delete stale external user groups: %w", err)
 			}
 		} else if len(users) > 0 || len(groups) > 0 {
 			if err := tx.Exec(`
@@ -479,17 +665,11 @@ func upsertExternalEntities(
 				WHERE deleted_at IS NULL
 					AND external_user_id IN (SELECT id FROM external_users WHERE scraper_id = ?)
 			`, *scraperID).Error; err != nil {
-				tx.Rollback()
-				return counts, nil, fmt.Errorf("failed to delete stale external user groups: %w", err)
+				return fmt.Errorf("failed to delete stale external user groups: %w", err)
 			}
 		}
 	}
-
-	if err := tx.Commit().Error; err != nil {
-		return counts, nil, fmt.Errorf("failed to commit external entities transaction: %w", err)
-	}
-
-	return counts, userIDMap, nil
+	return nil
 }
 
 func ensureExternalUserFromAliases(ctx api.ScrapeContext, aliases []string, scraperID *uuid.UUID) error {
@@ -547,26 +727,115 @@ func dedupeByID[T any](
 	getAliases func(T) []string,
 	setAliases func(*T, []string),
 ) []T {
-	seen := make(map[uuid.UUID]int)
-	var out []T
-	for _, item := range items {
-		id := getID(item)
-		if id == uuid.Nil {
-			out = append(out, item)
-			continue
+	out, _ := dedupeByIDWithIndex(items, getID, getAliases, setAliases)
+	return out
+}
+
+// dedupeByIDWithIndex behaves like dedupeByID but additionally returns a slice
+// `indexMap` parallel to `items` where indexMap[i] is the position of the
+// deduped survivor of items[i] in the returned slice.
+//
+// Entries with non-nil IDs are deduped by exact ID match.
+// Entries with nil IDs (e.g. those from scrapers that intentionally do not
+// synthesize IDs and rely on the SQL merge to assign canonical UUIDs) are
+// deduped by alias overlap using union-find: any chain of items connected
+// by shared aliases collapses into a single survivor entry whose alias set
+// is the union of the chain. This is required because the upstream
+// merge_and_upsert_external_* SQL functions enforce a unique constraint on
+// the aliases column (partial index where deleted_at IS NULL), so distinct
+// temp-table rows that share any alias would violate it.
+func dedupeByIDWithIndex[T any](
+	items []T,
+	getID func(T) uuid.UUID,
+	getAliases func(T) []string,
+	setAliases func(*T, []string),
+) ([]T, []int) {
+	// First pass: group all items into clusters by alias overlap (union-find)
+	// for nil-ID entries, and by exact ID match for non-nil entries.
+	parent := make([]int, len(items))
+	for i := range parent {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		if parent[x] != x {
+			parent[x] = find(parent[x])
 		}
-		if idx, exists := seen[id]; exists {
-			for _, alias := range getAliases(item) {
-				if !slices.Contains(getAliases(out[idx]), alias) {
-					setAliases(&out[idx], append(getAliases(out[idx]), alias))
-				}
-			}
-		} else {
-			seen[id] = len(out)
-			out = append(out, item)
+		return parent[x]
+	}
+	union := func(a, b int) {
+		ra, rb := find(a), find(b)
+		if ra != rb {
+			parent[ra] = rb
 		}
 	}
-	return out
+
+	idToIdx := make(map[uuid.UUID]int)
+	aliasToIdx := make(map[string]int)
+	for i, item := range items {
+		id := getID(item)
+		if id != uuid.Nil {
+			if existing, ok := idToIdx[id]; ok {
+				union(existing, i)
+			} else {
+				idToIdx[id] = i
+			}
+		}
+		// Index by alias too — overlapping aliases unite both nil-ID and
+		// non-nil-ID entries (the merge SQL function would otherwise reject
+		// them anyway because the aliases unique index spans the whole table).
+		for _, alias := range getAliases(item) {
+			if existing, ok := aliasToIdx[alias]; ok {
+				union(existing, i)
+			} else {
+				aliasToIdx[alias] = i
+			}
+		}
+	}
+
+	// Second pass: pick a survivor per cluster. Prefer items with a non-nil
+	// ID (they carry the authoritative canonical ID, e.g. an AAD-supplied
+	// Azure object UUID) over nil-ID items from descriptor-only scrapers like
+	// Azure DevOps. Fall back to the first item in the cluster.
+	survivor := make(map[int]int) // root -> input index
+	for i := range items {
+		root := find(i)
+		cur, ok := survivor[root]
+		if !ok {
+			survivor[root] = i
+			continue
+		}
+		if getID(items[cur]) == uuid.Nil && getID(items[i]) != uuid.Nil {
+			survivor[root] = i
+		}
+	}
+
+	// Third pass: build the output, merging aliases from every cluster member
+	// into its survivor.
+	rootToOutIdx := make(map[int]int)
+	var out []T
+	indexMap := make([]int, len(items))
+	for i := range items {
+		root := find(i)
+		survivorIdx := survivor[root]
+		outIdx, ok := rootToOutIdx[root]
+		if !ok {
+			outIdx = len(out)
+			rootToOutIdx[root] = outIdx
+			out = append(out, items[survivorIdx])
+		}
+		// Merge this item's aliases into the survivor (if it isn't itself the
+		// survivor entry which is already in `out`).
+		if i != survivorIdx {
+			for _, alias := range getAliases(items[i]) {
+				if !slices.Contains(getAliases(out[outIdx]), alias) {
+					setAliases(&out[outIdx], append(getAliases(out[outIdx]), alias))
+				}
+			}
+		}
+		indexMap[i] = outIdx
+	}
+	return out, indexMap
 }
 
 func createTempAndInsert[T any](tx *gorm.DB, tempTable, sourceTable string, items []T) error {
@@ -577,11 +846,4 @@ func createTempAndInsert[T any](tx *gorm.DB, tempTable, sourceTable string, item
 		return fmt.Errorf("failed to insert into temp table %s: %w", tempTable, err)
 	}
 	return nil
-}
-
-func appendUnique(slice []string, item string) []string {
-	if !slices.Contains(slice, item) {
-		return append(slice, item)
-	}
-	return slice
 }

--- a/db/external_entities_test.go
+++ b/db/external_entities_test.go
@@ -1,11 +1,208 @@
 package db
 
 import (
+	gocontext "context"
+
+	"github.com/flanksource/config-db/api"
+	v1 "github.com/flanksource/config-db/api/v1"
+	dutycontext "github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("dedupeByIDWithIndex", func() {
+	getID := func(g models.ExternalGroup) uuid.UUID { return g.ID }
+	getAliases := func(g models.ExternalGroup) []string { return g.Aliases }
+	setAliases := func(g *models.ExternalGroup, a []string) { g.Aliases = pq.StringArray(a) }
+
+	mk := func(id string, aliases ...string) models.ExternalGroup {
+		var u uuid.UUID
+		if id != "" {
+			u = uuid.MustParse(id)
+		}
+		return models.ExternalGroup{ID: u, Aliases: pq.StringArray(aliases)}
+	}
+
+	It("dedupes nil-ID entries by alias overlap and merges aliases", func() {
+		// A: [a1, a2]    B: [a3, a4]    C: [a2, a3]
+		// → A and C overlap on a2, B and C overlap on a3, so all three collapse.
+		items := []models.ExternalGroup{
+			mk("", "a1", "a2"),
+			mk("", "a3", "a4"),
+			mk("", "a2", "a3"),
+		}
+		out, idx := dedupeByIDWithIndex(items, getID, getAliases, setAliases)
+		Expect(out).To(HaveLen(1))
+		Expect([]string(out[0].Aliases)).To(ConsistOf("a1", "a2", "a3", "a4"))
+		Expect(idx).To(Equal([]int{0, 0, 0}))
+	})
+
+	It("collapses non-nil ID entries by exact ID match", func() {
+		id := "00000000-0000-0000-0000-000000000001"
+		items := []models.ExternalGroup{
+			mk(id, "a1"),
+			mk(id, "a2"),
+		}
+		out, idx := dedupeByIDWithIndex(items, getID, getAliases, setAliases)
+		Expect(out).To(HaveLen(1))
+		Expect([]string(out[0].Aliases)).To(ConsistOf("a1", "a2"))
+		Expect(idx).To(Equal([]int{0, 0}))
+	})
+
+	It("prefers non-nil ID survivor when merging with nil-ID entries by alias", func() {
+		// AAD scrape (with real ID) and ADO scrape (no ID) for the same group,
+		// linked by a shared alias. Output should keep the AAD ID.
+		aadID := "00000000-0000-0000-0000-0000000000aa"
+		items := []models.ExternalGroup{
+			mk("", "ado-descriptor", "shared@example.com"),
+			mk(aadID, "shared@example.com"),
+		}
+		out, _ := dedupeByIDWithIndex(items, getID, getAliases, setAliases)
+		Expect(out).To(HaveLen(1))
+		Expect(out[0].ID.String()).To(Equal(aadID))
+		Expect([]string(out[0].Aliases)).To(ConsistOf("ado-descriptor", "shared@example.com"))
+	})
+
+	It("keeps disjoint nil-ID entries separate", func() {
+		items := []models.ExternalGroup{
+			mk("", "a1"),
+			mk("", "b1"),
+			mk("", "c1"),
+		}
+		out, idx := dedupeByIDWithIndex(items, getID, getAliases, setAliases)
+		Expect(out).To(HaveLen(3))
+		Expect(idx).To(Equal([]int{0, 1, 2}))
+	})
+
+	It("returns an indexMap parallel to the input", func() {
+		items := []models.ExternalGroup{
+			mk("", "x", "y"),
+			mk("", "z"),
+			mk("", "y", "w"),
+		}
+		_, idx := dedupeByIDWithIndex(items, getID, getAliases, setAliases)
+		Expect(idx).To(HaveLen(3))
+		// items[0] and items[2] share "y" → same survivor
+		Expect(idx[0]).To(Equal(idx[2]))
+		// items[1] is disjoint
+		Expect(idx[1]).NotTo(Equal(idx[0]))
+	})
+
+})
+
+var _ = Describe("resolveExternalUserGroups", func() {
+	var ctx api.ScrapeContext
+	BeforeEach(func() {
+		ctx = api.NewScrapeContext(dutycontext.NewContext(gocontext.Background()))
+	})
+
+	// Canonical IDs that live entities will carry.
+	userA := uuid.MustParse("00000000-0000-0000-0000-0000000000a1")
+	userB := uuid.MustParse("00000000-0000-0000-0000-0000000000a2")
+	groupX := uuid.MustParse("00000000-0000-0000-0000-0000000000b1")
+	groupY := uuid.MustParse("00000000-0000-0000-0000-0000000000b2")
+	// Raw upstream IDs that the scraper sent on user_group refs but that
+	// don't match the final canonical IDs the entity upsert uses.
+	rawGroupX := uuid.MustParse("00000000-0000-0000-0000-0000000000c1")
+
+	mkUsers := func() []models.ExternalUser {
+		return []models.ExternalUser{
+			{ID: userA, Aliases: pq.StringArray{"alice@example.com"}},
+			{ID: userB, Aliases: pq.StringArray{"bob@example.com"}},
+		}
+	}
+	mkGroups := func() []models.ExternalGroup {
+		return []models.ExternalGroup{
+			// rawGroupX is an upstream raw id the scraper attached as an alias —
+			// not the entity's own canonical id, which never lives in Aliases.
+			{ID: groupX, Aliases: pq.StringArray{"group-x", rawGroupX.String()}},
+			{ID: groupY, Aliases: pq.StringArray{"group-y"}},
+		}
+	}
+
+	It("accepts a direct UUID that points at a real entity", func() {
+		in := []v1.ExternalUserGroup{
+			{ExternalUserID: &userA, ExternalGroupID: &groupX},
+		}
+		out := resolveExternalUserGroups(ctx, in, mkUsers(), mkGroups())
+		Expect(out).To(HaveLen(1))
+		Expect(out[0].ExternalUserID).To(Equal(userA))
+		Expect(out[0].ExternalGroupID).To(Equal(groupX))
+	})
+
+	It("drops a direct-UUID row that references a non-existent user", func() {
+		bogus := uuid.MustParse("00000000-0000-0000-0000-0000000000ff")
+		in := []v1.ExternalUserGroup{
+			{ExternalUserID: &bogus, ExternalGroupID: &groupX},
+		}
+		out := resolveExternalUserGroups(ctx, in, mkUsers(), mkGroups())
+		Expect(out).To(BeEmpty())
+	})
+
+	It("falls through from a bogus direct UUID to an alias resolution", func() {
+		// Simulates the entra.yaml case: scraper sent the raw Graph group.id
+		// as external_group_id, but the group was upserted with a hash-based
+		// canonical ID. The alias list of the upserted group still contains
+		// the raw id, so we can recover.
+		in := []v1.ExternalUserGroup{
+			{
+				ExternalUserID:       &userA,
+				ExternalGroupID:      &rawGroupX,
+				ExternalGroupAliases: []string{rawGroupX.String()},
+			},
+		}
+		out := resolveExternalUserGroups(ctx, in, mkUsers(), mkGroups())
+		Expect(out).To(HaveLen(1))
+		Expect(out[0].ExternalUserID).To(Equal(userA))
+		Expect(out[0].ExternalGroupID).To(Equal(groupX))
+	})
+
+	It("resolves alias-only entries", func() {
+		in := []v1.ExternalUserGroup{
+			{
+				ExternalUserAliases:  []string{"alice@example.com"},
+				ExternalGroupAliases: []string{"group-y"},
+			},
+		}
+		out := resolveExternalUserGroups(ctx, in, mkUsers(), mkGroups())
+		Expect(out).To(HaveLen(1))
+		Expect(out[0].ExternalUserID).To(Equal(userA))
+		Expect(out[0].ExternalGroupID).To(Equal(groupY))
+	})
+
+	It("drops rows where neither the direct UUID nor aliases resolve", func() {
+		bogusUser := uuid.MustParse("00000000-0000-0000-0000-0000000000fe")
+		in := []v1.ExternalUserGroup{
+			{
+				ExternalUserID:       &bogusUser,
+				ExternalUserAliases:  []string{"ghost@example.com"},
+				ExternalGroupAliases: []string{"group-x"},
+			},
+		}
+		out := resolveExternalUserGroups(ctx, in, mkUsers(), mkGroups())
+		Expect(out).To(BeEmpty())
+	})
+
+	It("processes a mixed batch independently — valid rows survive, invalid rows drop", func() {
+		bogusUser := uuid.MustParse("00000000-0000-0000-0000-0000000000fd")
+		in := []v1.ExternalUserGroup{
+			{ExternalUserID: &userA, ExternalGroupID: &groupX},
+			{ExternalUserID: &bogusUser, ExternalGroupID: &groupX},
+			{ExternalUserID: &userB, ExternalGroupID: &rawGroupX, ExternalGroupAliases: []string{rawGroupX.String()}},
+		}
+		out := resolveExternalUserGroups(ctx, in, mkUsers(), mkGroups())
+		Expect(out).To(HaveLen(2))
+		Expect(out[0]).To(Equal(models.ExternalUserGroup{ExternalUserID: userA, ExternalGroupID: groupX}))
+		Expect(out[1]).To(Equal(models.ExternalUserGroup{ExternalUserID: userB, ExternalGroupID: groupX}))
+	})
+
+	It("returns nil for empty input", func() {
+		Expect(resolveExternalUserGroups(ctx, nil, mkUsers(), mkGroups())).To(BeNil())
+	})
+})
 
 var _ = Describe("remapExternalUserGroups", func() {
 	It("remaps user and group ids independently", func() {

--- a/db/external_loser_alias_test.go
+++ b/db/external_loser_alias_test.go
@@ -1,0 +1,107 @@
+package db
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/flanksource/config-db/api"
+	dutymodels "github.com/flanksource/duty/models"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+)
+
+var _ = Describe("merge_and_upsert_external_users loser id alias migration", func() {
+	It("folds the loser id into the winner's aliases and exposes it via findExternalEntityByID", func() {
+		ctx := api.NewScrapeContext(DefaultContext)
+
+		now := time.Now().UTC().Truncate(time.Microsecond)
+		winnerID := uuid.New()
+		loserID := uuid.New()
+		bridgeID := uuid.New()
+		sharedAlias := fmt.Sprintf("loser-alias-%s", uuid.NewString()[:8])
+		winnerAlias := fmt.Sprintf("winner-alias-%s", uuid.NewString()[:8])
+
+		winner := dutymodels.ExternalUser{
+			ID:        winnerID,
+			Name:      "winner",
+			Aliases:   pq.StringArray{winnerAlias},
+			UserType:  "user",
+			CreatedAt: now,
+			UpdatedAt: lo.ToPtr(now),
+		}
+		loser := dutymodels.ExternalUser{
+			ID:        loserID,
+			Name:      "loser",
+			Aliases:   pq.StringArray{sharedAlias},
+			UserType:  "user",
+			CreatedAt: now,
+			UpdatedAt: lo.ToPtr(now),
+		}
+		Expect(DefaultContext.DB().Create(&winner).Error).NotTo(HaveOccurred())
+		Expect(DefaultContext.DB().Create(&loser).Error).NotTo(HaveOccurred())
+
+		defer func() {
+			DefaultContext.DB().Unscoped().Delete(&dutymodels.ExternalUser{}, "id IN ?", []uuid.UUID{winnerID, loserID, bridgeID})
+		}()
+
+		tx := DefaultContext.DB().Begin()
+		Expect(tx.Error).NotTo(HaveOccurred())
+
+		tempTable := fmt.Sprintf("_merge_users_%s", strings.ReplaceAll(uuid.NewString(), "-", "_"))
+		Expect(tx.Exec(fmt.Sprintf(
+			`CREATE TEMP TABLE %s (LIKE external_users INCLUDING ALL) ON COMMIT DROP`,
+			tempTable,
+		)).Error).NotTo(HaveOccurred())
+
+		bridge := dutymodels.ExternalUser{
+			ID:        bridgeID,
+			Name:      "bridge",
+			Aliases:   pq.StringArray{winnerAlias, sharedAlias},
+			UserType:  "user",
+			CreatedAt: now,
+			UpdatedAt: lo.ToPtr(now),
+		}
+		Expect(tx.Table(tempTable).Create(&bridge).Error).NotTo(HaveOccurred())
+
+		var merges []struct {
+			LoserID  uuid.UUID `gorm:"column:loser_id"`
+			WinnerID uuid.UUID `gorm:"column:winner_id"`
+		}
+		Expect(tx.Raw("SELECT * FROM merge_and_upsert_external_users(?)", tempTable).Scan(&merges).Error).NotTo(HaveOccurred())
+		Expect(tx.Commit().Error).NotTo(HaveOccurred())
+
+		// All three rows form one connected component, so the merges all share
+		// the same survivor; everything else is a loser.
+		Expect(merges).NotTo(BeEmpty(), "expected at least one merge")
+		survivorID := merges[0].WinnerID
+		var losers []uuid.UUID
+		for _, m := range merges {
+			Expect(m.WinnerID).To(Equal(survivorID), "all merges must share one survivor")
+			losers = append(losers, m.LoserID)
+		}
+
+		var survivor dutymodels.ExternalUser
+		Expect(DefaultContext.DB().First(&survivor, "id = ?", survivorID).Error).NotTo(HaveOccurred())
+		Expect(survivor.DeletedAt).To(BeNil())
+		for _, lid := range losers {
+			Expect([]string(survivor.Aliases)).To(
+				ContainElement(lid.String()),
+				"loser id %s must appear in survivor.aliases after merge", lid,
+			)
+		}
+
+		// And the helper should resolve the loser id back to the survivor.
+		// Bypass the id-cache by deleting any stale entry for the loser.
+		for _, lid := range losers {
+			ExternalUserIDCache.Delete(lid.String())
+			resolved, err := findExternalEntityByID[dutymodels.ExternalUser](ctx, lid)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resolved).NotTo(BeNil(), "findExternalEntityByID(loser=%s) must return a survivor", lid)
+			Expect(*resolved).To(Equal(survivorID))
+		}
+	})
+})

--- a/db/permission_changes.go
+++ b/db/permission_changes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/flanksource/commons/hash"
 	v1 "github.com/flanksource/config-db/api/v1"
 	"github.com/flanksource/config-db/db/models"
+	dutydb "github.com/flanksource/duty/db"
 	dutyModels "github.com/flanksource/duty/models"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -15,9 +16,10 @@ import (
 )
 
 type permissionChangeResult struct {
-	added   []*models.ConfigChange
-	removed []*models.ConfigChange
-	saved   int
+	added            []*models.ConfigChange
+	removed          []*models.ConfigChange
+	saved            int
+	foreignKeyErrors int
 }
 
 type staleAccessResult struct {
@@ -74,6 +76,70 @@ func upsertConfigAccess(ctx api.ScrapeContext, accesses []v1.ExternalConfigAcces
 		return result, fmt.Errorf("failed to setup temp config access: %w", err)
 	}
 
+	// Insert stub entities for any missing user/role/group references so the
+	// config_access FK insert doesn't fail. Each stub insert runs inside a
+	// savepoint so an error doesn't abort the outer transaction.
+	//
+	// Notes on the SQL below:
+	//   - scraper_id uses `?::uuid` for all three tables. external_roles.scraper_id
+	//     is nominally nullable, but its check constraint
+	//     (application_id IS NOT NULL OR scraper_id IS NOT NULL) forces one to be set.
+	//   - aliases is inserted as NULL, not ARRAY[]::text[], because all three
+	//     tables have a partial unique index on aliases WHERE deleted_at IS NULL,
+	//     and an empty array would collide across multiple stub rows. NULLs are
+	//     distinct under that index.
+	//   - ON CONFLICT DO NOTHING (no target) so any future unique index, not just
+	//     the PK, is tolerated.
+	for _, stub := range []struct {
+		entity    string
+		table     string
+		column    string
+		extraCols string
+		extraVals string
+	}{
+		{
+			entity: "user", table: "external_users", column: "external_user_id",
+			extraCols: ", account_id, user_type", extraVals: ", '', 'Stub'",
+		},
+		{
+			entity: "role", table: "external_roles", column: "external_role_id",
+			extraCols: ", account_id, role_type, description", extraVals: ", '', 'Stub', ''",
+		},
+		{
+			entity: "group", table: "external_groups", column: "external_group_id",
+			extraCols: ", account_id, group_type", extraVals: ", '', 'Stub'",
+		},
+	} {
+		stubSQL := fmt.Sprintf(`
+			INSERT INTO %s (id, name, aliases, scraper_id, created_at, updated_at %s)
+			SELECT DISTINCT t.%s, t.%s::text, NULL::text[], ?::uuid, ?::timestamptz, ?::timestamptz %s
+			FROM %s t
+			WHERE t.%s IS NOT NULL
+			  AND NOT EXISTS (SELECT 1 FROM %s e WHERE e.id = t.%s)
+			ON CONFLICT DO NOTHING
+		`, stub.table, stub.extraCols,
+			stub.column, stub.column, stub.extraVals,
+			tempTable,
+			stub.column, stub.table, stub.column)
+
+		savepoint := fmt.Sprintf("stub_%s", stub.entity)
+		if err := tx.Exec("SAVEPOINT " + savepoint).Error; err != nil {
+			ctx.Logger.Warnf("failed to create savepoint for stub %s: %v", stub.entity, err)
+			continue
+		}
+
+		r := tx.Exec(stubSQL, scraperID.String(), now, now)
+		if r.Error != nil {
+			ctx.Logger.Warnf("failed to create stub %ss: %v", stub.entity, r.Error)
+			tx.Exec("ROLLBACK TO SAVEPOINT " + savepoint)
+			continue
+		}
+		tx.Exec("RELEASE SAVEPOINT " + savepoint)
+		if r.RowsAffected > 0 {
+			ctx.Logger.Warnf("created %d stub %s(s) for missing config_access references", r.RowsAffected, stub.entity)
+		}
+	}
+
 	// Upsert: insert new records, restore soft-deleted ones
 	if len(items) > 0 {
 		var newRows []struct {
@@ -94,9 +160,54 @@ func upsertConfigAccess(ctx api.ScrapeContext, accesses []v1.ExternalConfigAcces
 			RETURNING id, config_id, external_user_id, external_role_id, external_group_id
 		`, tempTable)
 
+		tx.Exec("SAVEPOINT bulk_insert")
+
 		if err := tx.Raw(newSQL).Scan(&newRows).Error; err != nil {
-			tx.Rollback()
-			return result, fmt.Errorf("failed to upsert config access: %w", err)
+			if !dutydb.IsForeignKeyError(err) {
+				tx.Rollback()
+				return result, fmt.Errorf("failed to upsert config access: %w", err)
+			}
+
+			// Restore transaction state; temp table is preserved.
+			tx.Exec("ROLLBACK TO SAVEPOINT bulk_insert")
+
+			// Row-by-row with exception handling: successfully inserted rows
+			// are deleted from the temp table; FK violations stay.
+			fallbackSQL := fmt.Sprintf(`
+				DO $$
+				DECLARE
+					v_rec RECORD;
+				BEGIN
+					FOR v_rec IN SELECT * FROM %s LOOP
+						BEGIN
+							INSERT INTO config_access (id, config_id, external_user_id, external_role_id,
+								external_group_id, scraper_id, application_id, source, created_at)
+							VALUES (v_rec.id, v_rec.config_id, v_rec.external_user_id, v_rec.external_role_id,
+								v_rec.external_group_id, v_rec.scraper_id, v_rec.application_id, v_rec.source, v_rec.created_at)
+							ON CONFLICT (id) DO UPDATE SET deleted_at = NULL
+							WHERE config_access.deleted_at IS NOT NULL;
+							DELETE FROM %s WHERE id = v_rec.id;
+						EXCEPTION WHEN foreign_key_violation THEN
+							NULL;
+						END;
+					END LOOP;
+				END $$;
+			`, tempTable, tempTable)
+
+			if err := tx.Exec(fallbackSQL).Error; err != nil {
+				tx.Rollback()
+				return result, fmt.Errorf("failed to fallback upsert config access: %w", err)
+			}
+
+			var fkErrorCount int64
+			tx.Raw(fmt.Sprintf("SELECT count(*) FROM %s", tempTable)).Scan(&fkErrorCount)
+			result.foreignKeyErrors = int(fkErrorCount)
+			result.saved -= result.foreignKeyErrors
+
+			if fkErrorCount > 0 {
+				ctx.Logger.Warnf("config_access: %d rows with FK violations (scraper=%s)", fkErrorCount, scraperIDStr)
+				logFKDiagnostics(ctx, tx, tempTable)
+			}
 		}
 
 		for _, row := range newRows {
@@ -238,6 +349,67 @@ func joinParts(parts []string) string {
 		result += ", " + parts[i]
 	}
 	return result
+}
+
+func logFKDiagnostics(ctx api.ScrapeContext, tx *gorm.DB, tempTable string) {
+	type diagRow struct {
+		ExternalUserID  *uuid.UUID `gorm:"column:external_user_id"`
+		ExternalGroupID *uuid.UUID `gorm:"column:external_group_id"`
+		ExternalRoleID  *uuid.UUID `gorm:"column:external_role_id"`
+		Reason          string     `gorm:"column:reason"`
+	}
+
+	diagSQL := fmt.Sprintf(`
+		SELECT t.external_user_id, t.external_group_id, t.external_role_id,
+			CASE
+				WHEN t.external_user_id IS NOT NULL AND eu.id IS NULL THEN 'user_missing'
+				WHEN t.external_user_id IS NOT NULL AND eu.deleted_at IS NOT NULL THEN 'user_deleted'
+				WHEN t.external_group_id IS NOT NULL AND eg.id IS NULL THEN 'group_missing'
+				WHEN t.external_group_id IS NOT NULL AND eg.deleted_at IS NOT NULL THEN 'group_deleted'
+				WHEN t.external_role_id IS NOT NULL AND er.id IS NULL THEN 'role_missing'
+				WHEN t.external_role_id IS NOT NULL AND er.deleted_at IS NOT NULL THEN 'role_deleted'
+				WHEN NOT EXISTS (SELECT 1 FROM config_items ci WHERE ci.id = t.config_id) THEN 'config_missing'
+				ELSE 'unknown'
+			END AS reason
+		FROM %s t
+		LEFT JOIN external_users eu ON eu.id = t.external_user_id
+		LEFT JOIN external_groups eg ON eg.id = t.external_group_id
+		LEFT JOIN external_roles er ON er.id = t.external_role_id
+		LIMIT 100
+	`, tempTable)
+
+	var rows []diagRow
+	if err := tx.Raw(diagSQL).Scan(&rows).Error; err != nil {
+		ctx.Logger.Warnf("  failed to diagnose FK errors: %v", err)
+		return
+	}
+
+	type groupKey struct {
+		Reason string
+		FKID   string
+	}
+	counts := make(map[groupKey]int)
+	for _, row := range rows {
+		fkID := "unknown"
+		switch row.Reason {
+		case "user_missing", "user_deleted":
+			fkID = uuidPtrStr(row.ExternalUserID)
+		case "group_missing", "group_deleted":
+			fkID = uuidPtrStr(row.ExternalGroupID)
+		case "role_missing", "role_deleted":
+			fkID = uuidPtrStr(row.ExternalRoleID)
+		}
+		counts[groupKey{Reason: row.Reason, FKID: fkID}]++
+	}
+
+	logged := 0
+	for key, count := range counts {
+		if logged >= 10 {
+			break
+		}
+		ctx.Logger.Warnf("  reason=%s id=%s count=%d", key.Reason, key.FKID, count)
+		logged++
+	}
 }
 
 func sanitizeForTempTable(s string) string {

--- a/db/update.go
+++ b/db/update.go
@@ -723,6 +723,7 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 
 	summary.AccessLogs.Scraped = len(extractResult.configAccessLogs)
 	var resolvedAccessLogs []dutyModels.ConfigAccessLog
+	resolvedConfigTypes := make(map[uuid.UUID]string) // ConfigID → ConfigType for resolved logs
 	for _, accessLog := range extractResult.configAccessLogs {
 		if accessLog.ConfigID == uuid.Nil && accessLog.ConfigExternalID.ExternalID != "" {
 			config, err := ctx.TempCache().FindExternalID(ctx, accessLog.ConfigExternalID)
@@ -786,12 +787,16 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 		}
 
 		resolvedAccessLogs = append(resolvedAccessLogs, accessLog.ConfigAccessLog)
+		if ct := accessLog.ConfigExternalID.ConfigType; ct != "" {
+			resolvedConfigTypes[accessLog.ConfigID] = ct
+		}
 	}
 
-	// Track max created_at per config type from access logs
+	// Track max created_at per config type from validated access logs only,
+	// so the cursor doesn't advance past rows that failed validation.
 	accessLogMaxTime := map[string]time.Time{}
-	for _, al := range extractResult.configAccessLogs {
-		configType := al.ConfigExternalID.ConfigType
+	for _, al := range resolvedAccessLogs {
+		configType := resolvedConfigTypes[al.ConfigID]
 		if configType == "" || al.CreatedAt.IsZero() {
 			continue
 		}

--- a/db/update.go
+++ b/db/update.go
@@ -148,10 +148,10 @@ func updateCI(ctx api.ScrapeContext, summary *v1.ScrapeSummary, result *v1.Scrap
 
 		}
 		result.Changes = []v1.ChangeResult{*changeResult}
-		if newChanges, _, _, err := extractChanges(ctx, result, ci); err != nil {
+		if chResult, err := extractChanges(ctx, result, ci); err != nil {
 			return false, nil, err
 		} else {
-			changes = append(changes, newChanges...)
+			changes = append(changes, chResult.newChanges...)
 		}
 
 		if lo.IsEmpty(ci.Config) || lo.FromPtr(ci.Config) == "null" {
@@ -277,9 +277,18 @@ func shouldExcludeChange(ctx api.ScrapeContext, result *v1.ScrapeResult, changeR
 	return false, nil
 }
 
-func extractChanges(ctx api.ScrapeContext, result *v1.ScrapeResult, ci *models.ConfigItem) ([]*models.ConfigChange, []*models.ConfigChange, v1.ChangeSummary, error) {
+type extractChangesResult struct {
+	newChanges      []*models.ConfigChange
+	changesToUpdate []*models.ConfigChange
+	changeSummary   v1.ChangeSummary
+	orphanedChanges []v1.ChangeResult
+	// fkErrorChanges  []v1.ChangeResult
+}
+
+func extractChanges(ctx api.ScrapeContext, result *v1.ScrapeResult, ci *models.ConfigItem) (*extractChangesResult, error) {
 	var (
-		changeSummary v1.ChangeSummary
+		changeSummary   v1.ChangeSummary
+		orphanedChanges []v1.ChangeResult
 
 		newOnes = []*models.ConfigChange{}
 		updates = []*models.ConfigChange{}
@@ -295,13 +304,15 @@ func extractChanges(ctx api.ScrapeContext, result *v1.ScrapeResult, ci *models.C
 	result.Changes = append(result.Changes, processMoveUpCopyUp(ctx, result, ci)...)
 	result.Changes = append(result.Changes, processCopyMove(ctx, result, ci)...)
 
-	for _, changeResult := range result.Changes {
+	for i := range result.Changes {
+		changeResult := &result.Changes[i]
 		if changeResult.Action == v1.Ignore {
+			resolveChange(changeResult, string(v1.Ignore), changeResult.ConfigID)
 			changeSummary.AddIgnoredByAction(string(changeResult.Action), changeResult.ChangeType)
 			continue
 		}
 
-		if exclude, err := shouldExcludeChange(ctx, result, changeResult); err != nil {
+		if exclude, err := shouldExcludeChange(ctx, result, *changeResult); err != nil {
 			ctx.JobHistory().AddError(fmt.Sprintf("error running change exclusion: %v", err))
 		} else if exclude {
 			changeSummary.AddIgnored(changeResult.ChangeType)
@@ -314,6 +325,7 @@ func extractChanges(ctx api.ScrapeContext, result *v1.ScrapeResult, ci *models.C
 		if changeResult.ConfigID != "" {
 			if _, ok := OrphanCache.Get(changeResult.ConfigID); ok {
 				changeSummary.AddOrphaned(changeResult.ChangeType, changeResult.ConfigID)
+				orphanedChanges = append(orphanedChanges, *changeResult)
 				continue
 			}
 		}
@@ -321,17 +333,19 @@ func extractChanges(ctx api.ScrapeContext, result *v1.ScrapeResult, ci *models.C
 		if changeResult.ExternalID != "" {
 			if _, ok := OrphanCache.Get(changeResult.ExternalID); ok {
 				changeSummary.AddOrphaned(changeResult.ChangeType, changeResult.ExternalID)
+				orphanedChanges = append(orphanedChanges, *changeResult)
 				continue
 			}
 		}
 
 		if changeResult.Action == v1.Delete {
-			if err := deleteChangeHandler(ctx, changeResult); err != nil {
-				return nil, nil, changeSummary, fmt.Errorf("failed to delete config from change: %w", err)
+			resolveChange(changeResult, string(v1.Delete), changeResult.ConfigID)
+			if err := deleteChangeHandler(ctx, *changeResult); err != nil {
+				return nil, fmt.Errorf("failed to delete config from change: %w", err)
 			}
 		}
 
-		change := models.NewConfigChangeFromV1(*result, changeResult)
+		change := models.NewConfigChangeFromV1(*result, *changeResult)
 		if fingerprint, err := pkgChanges.Fingerprint(change); err != nil {
 			logger.Errorf("failed to fingerprint change: %v", err)
 		} else if fingerprint != "" {
@@ -341,7 +355,7 @@ func extractChanges(ctx api.ScrapeContext, result *v1.ScrapeResult, ci *models.C
 		if change.CreatedBy != nil {
 			person, err := FindPersonByEmail(ctx, ptr.ToString(change.CreatedBy))
 			if err != nil {
-				return nil, nil, changeSummary, fmt.Errorf("error finding person by email: %w", err)
+				return nil, fmt.Errorf("error finding person by email: %w", err)
 			} else if person != nil {
 				change.CreatedBy = ptr.String(person.ID.String())
 			} else {
@@ -355,7 +369,7 @@ func extractChanges(ctx api.ScrapeContext, result *v1.ScrapeResult, ci *models.C
 				change.ConfigID = ci.ID
 			} else if !change.GetExternalID().IsEmpty() {
 				if ci, err := ctx.TempCache().FindExternalID(ctx, change.GetExternalID()); err != nil {
-					return nil, nil, changeSummary, fmt.Errorf("failed to get config from change (externalID=%s): %w", change.GetExternalID(), err)
+					return nil, fmt.Errorf("failed to get config from change (externalID=%s): %w", change.GetExternalID(), err)
 				} else if ci != "" {
 					change.ConfigID = ci
 				}
@@ -377,6 +391,7 @@ func extractChanges(ctx api.ScrapeContext, result *v1.ScrapeResult, ci *models.C
 				missingID = change.ExternalID
 			}
 			changeSummary.AddOrphaned(changeResult.ChangeType, missingID)
+			orphanedChanges = append(orphanedChanges, *changeResult)
 
 			if change.ExternalID != "" {
 				OrphanCache.Set(change.ExternalID, true, 0)
@@ -396,7 +411,12 @@ func extractChanges(ctx api.ScrapeContext, result *v1.ScrapeResult, ci *models.C
 		}
 	}
 
-	return newOnes, updates, changeSummary, nil
+	return &extractChangesResult{
+		newChanges:      newOnes,
+		changesToUpdate: updates,
+		changeSummary:   changeSummary,
+		orphanedChanges: orphanedChanges,
+	}, nil
 }
 
 // validateExistingUsers checks which external user IDs exist in the database
@@ -549,6 +569,11 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 	if err != nil {
 		return summary, ctx.Oops().Wrapf(err, "failed to extract configs & changes from results")
 	}
+	summary.OrphanedChanges = append(summary.OrphanedChanges, extractResult.orphanedChanges...)
+	summary.FKErrorChanges = append(summary.FKErrorChanges, extractResult.fkErrorChanges...)
+	for _, w := range extractResult.warnings {
+		summary.AddScrapeWarning(w)
+	}
 	for configType, cs := range extractResult.changeSummary {
 		summary.AddChangeSummary(configType, cs)
 	}
@@ -599,7 +624,6 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 	}
 
 	summary.ConfigAccess.Scraped = len(extractResult.configAccesses)
-	missingConfigs := map[string]int{}
 	var resolvedAccesses []v1.ExternalConfigAccess
 	for i := range extractResult.configAccesses {
 		configAccess := &extractResult.configAccesses[i]
@@ -633,9 +657,22 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 			configAccess.ExternalGroupID = id
 		}
 
-		if configAccess.ExternalUserID == nil &&
-			configAccess.ExternalRoleID == nil &&
-			configAccess.ExternalGroupID == nil {
+		// A valid config_access requires a principal (user or group) and a role
+		if configAccess.ExternalUserID == nil && configAccess.ExternalGroupID == nil {
+			summary.ConfigAccess.Skipped++
+			continue
+		}
+
+		if configAccess.ExternalRoleID == nil && len(configAccess.ExternalRoleAliases) == 0 {
+			ctx.Logger.Warnf("skipping config access: missing role (config=%s user=%v group=%v)",
+				configAccess.ConfigExternalID.Pretty().ANSI(),
+				configAccess.ExternalUserAliases, configAccess.ExternalGroupAliases)
+			summary.ConfigAccess.Skipped++
+			continue
+		}
+		if configAccess.ExternalRoleID == nil {
+			ctx.Logger.Warnf("skipping config access: role not found (aliases=%v config=%s)",
+				configAccess.ExternalRoleAliases, configAccess.ConfigExternalID.Pretty().ANSI())
 			summary.ConfigAccess.Skipped++
 			continue
 		}
@@ -643,11 +680,16 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 		if configAccess.ConfigID == uuid.Nil && configAccess.ConfigExternalID.ExternalID != "" {
 			config, err := ctx.TempCache().FindExternalID(ctx, configAccess.ConfigExternalID)
 			if err != nil {
-				summary.AddWarning("ConfigAccess", fmt.Sprintf("failed to find config for config access (type=%s external_id=%s): %v", configAccess.ConfigExternalID.ConfigType, configAccess.ConfigExternalID.ExternalID, err))
+				summary.AddWarning("ConfigAccess", fmt.Sprintf("failed to find config (%s) for config access : %v", configAccess.ConfigExternalID.Pretty().ANSI(), err))
 				summary.ConfigAccess.Skipped++
 				continue
 			} else if config == "" {
-				missingConfigs[configAccess.ConfigExternalID.Key()]++
+				summary.AddScrapeWarning(v1.Warning{
+					Error:  fmt.Sprintf("config access references unknown config %s", configAccess.ConfigExternalID.Pretty().ANSI()),
+					Input:  extractResult.transformInput,
+					Expr:   extractResult.transformExpr,
+					Result: configAccess,
+				})
 				summary.ConfigAccess.Skipped++
 				continue
 			}
@@ -666,16 +708,13 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 		resolvedAccesses = append(resolvedAccesses, *configAccess)
 	}
 
-	for key, count := range missingConfigs {
-		ctx.Logger.V(2).Infof("config access references unknown config %s (scraper=%s, count=%d)", key, ctx.ScrapeConfig().Name, count)
-	}
-
 	if len(resolvedAccesses) > 0 {
 		permResult, err := upsertConfigAccess(ctx, resolvedAccesses, scraperID)
 		if err != nil {
 			summary.AddWarning("ConfigAccess", fmt.Sprintf("failed to upsert config access: %v", err))
 		} else {
 			summary.ConfigAccess.Saved += permResult.saved
+			summary.ConfigAccess.ForeignKeyErrors += permResult.foreignKeyErrors
 			extractResult.newChanges = append(extractResult.newChanges, permResult.added...)
 			extractResult.newChanges = append(extractResult.newChanges, permResult.removed...)
 			summary.ConfigAccess.Deleted += len(permResult.removed)
@@ -683,7 +722,6 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 	}
 
 	summary.AccessLogs.Scraped = len(extractResult.configAccessLogs)
-	missingAccessLogConfigs := map[string]int{}
 	var resolvedAccessLogs []dutyModels.ConfigAccessLog
 	for _, accessLog := range extractResult.configAccessLogs {
 		if accessLog.ConfigID == uuid.Nil && accessLog.ConfigExternalID.ExternalID != "" {
@@ -693,7 +731,12 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 				summary.AccessLogs.Skipped++
 				continue
 			} else if config == "" {
-				missingAccessLogConfigs[accessLog.ConfigExternalID.Key()]++
+				summary.AddScrapeWarning(v1.Warning{
+					Error:  fmt.Sprintf("access log references unknown config %s", accessLog.ConfigExternalID.Key()),
+					Input:  extractResult.transformInput,
+					Expr:   extractResult.transformExpr,
+					Result: accessLog,
+				})
 				summary.AccessLogs.Skipped++
 				continue
 			}
@@ -723,16 +766,18 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 		}
 
 		if accessLog.ExternalUserID != uuid.Nil {
-			if _, ok := ExternalUserIDCache.Get(accessLog.ExternalUserID.String()); !ok {
-				id, _ := findExternalEntityIDByAliases[dutyModels.ExternalUser](ctx, []string{accessLog.ExternalUserID.String()})
-				if id != nil {
-					accessLog.ExternalUserID = *id
-				} else {
-					summary.AddWarning("AccessLog", fmt.Sprintf("access log user_id=%s aliases=%v not found, skipping", accessLog.ExternalUserID, accessLog.ExternalUserAliases))
-					summary.AccessLogs.Skipped++
-					continue
-				}
+			id, err := findExternalEntityByID[dutyModels.ExternalUser](ctx, accessLog.ExternalUserID)
+			if err != nil {
+				summary.AddWarning("AccessLog", fmt.Sprintf("failed to look up access log user_id=%s: %v", accessLog.ExternalUserID, err))
+				summary.AccessLogs.Skipped++
+				continue
 			}
+			if id == nil {
+				summary.AddWarning("AccessLog", fmt.Sprintf("access log user_id=%s aliases=%v not found, skipping", accessLog.ExternalUserID, accessLog.ExternalUserAliases))
+				summary.AccessLogs.Skipped++
+				continue
+			}
+			accessLog.ExternalUserID = *id
 		}
 
 		if accessLog.ExternalUserID == uuid.Nil {
@@ -743,8 +788,28 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 		resolvedAccessLogs = append(resolvedAccessLogs, accessLog.ConfigAccessLog)
 	}
 
-	for key, count := range missingAccessLogConfigs {
-		ctx.Logger.V(2).Infof("access log references unknown config %s (scraper=%s, count=%d)", key, ctx.ScrapeConfig().Name, count)
+	// Track max created_at per config type from access logs
+	accessLogMaxTime := map[string]time.Time{}
+	for _, al := range extractResult.configAccessLogs {
+		configType := al.ConfigExternalID.ConfigType
+		if configType == "" || al.CreatedAt.IsZero() {
+			continue
+		}
+		if existing, ok := accessLogMaxTime[configType]; !ok || al.CreatedAt.After(existing) {
+			accessLogMaxTime[configType] = al.CreatedAt
+		}
+	}
+	for configType, maxTime := range accessLogMaxTime {
+		if summary.ConfigTypes == nil {
+			summary.ConfigTypes = make(map[string]v1.ConfigTypeScrapeSummary)
+		}
+		v := summary.ConfigTypes[configType]
+		t := maxTime
+		v.AccessLogs.LastCreatedAt = &t
+		summary.ConfigTypes[configType] = v
+		if summary.AccessLogs.LastCreatedAt == nil || maxTime.After(*summary.AccessLogs.LastCreatedAt) {
+			summary.AccessLogs.LastCreatedAt = &t
+		}
 	}
 
 	// Deduplicate by (config_id, external_user_id, scraper_id) to avoid
@@ -766,10 +831,11 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 		resolvedAccessLogs = append(resolvedAccessLogs, log)
 	}
 
-	if err := SaveConfigAccessLogs(ctx, resolvedAccessLogs); err != nil {
+	if logResult, err := SaveConfigAccessLogs(ctx, resolvedAccessLogs); err != nil {
 		summary.AddWarning("AccessLogs", fmt.Sprintf("failed to save access logs: %v", err))
 	} else {
-		summary.AccessLogs.Saved = len(resolvedAccessLogs)
+		summary.AccessLogs.Saved = logResult.saved
+		summary.AccessLogs.ForeignKeyErrors = logResult.foreignKeyErrors
 	}
 
 	// updatedConfigIDs are configs that were not new in this scrape.
@@ -963,8 +1029,25 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 		}
 	}
 
-	if summary.HasUpdates() {
+	// Retain last_created_at from the previous scrape when no new access logs were seen for a type
+	prev := ctx.LastScrapeSummary()
+	for configType, prevType := range prev.ConfigTypes {
+		if prevType.AccessLogs.LastCreatedAt != nil {
+			if summary.ConfigTypes == nil {
+				summary.ConfigTypes = make(map[string]v1.ConfigTypeScrapeSummary)
+			}
+			cur := summary.ConfigTypes[configType]
+			if cur.AccessLogs.LastCreatedAt == nil {
+				cur.AccessLogs.LastCreatedAt = prevType.AccessLogs.LastCreatedAt
+			}
+			summary.ConfigTypes[configType] = cur
+		}
+	}
+	if prev.AccessLogs.LastCreatedAt != nil && summary.AccessLogs.LastCreatedAt == nil {
+		summary.AccessLogs.LastCreatedAt = prev.AccessLogs.LastCreatedAt
+	}
 
+	if summary.HasUpdates() {
 		ctx.Logger.Debugf("Updates %s", summary)
 	} else {
 		ctx.Logger.V(4).Infof("No Update: %s", summary)
@@ -1251,23 +1334,254 @@ type configExternalKey struct {
 	parentType string
 }
 
-func SaveConfigAccessLogs(ctx api.ScrapeContext, accessLogs []dutyModels.ConfigAccessLog) error {
+type accessLogUpsertResult struct {
+	saved            int
+	foreignKeyErrors int
+}
+
+// SaveConfigAccessLogs upserts access-log rows into config_access_logs with
+// FK-violation recovery. Matches the pattern in upsertConfigAccess: temp
+// table, stub-user backfill for missing external_user_id FKs, bulk upsert
+// inside a savepoint, and a row-by-row fallback that isolates rows whose
+// FK still can't be satisfied. Rows that remain unresolvable are counted
+// in result.foreignKeyErrors and diagnostics are logged via
+// logAccessLogFKDiagnostics.
+//
+// All input rows are expected to belong to the current scraper. Any row
+// with a mismatched ScraperID is dropped with a warning (single
+// enforcement point for scraper isolation — subsequent SQL trusts it).
+func SaveConfigAccessLogs(ctx api.ScrapeContext, accessLogs []dutyModels.ConfigAccessLog) (accessLogUpsertResult, error) {
+	var result accessLogUpsertResult
 	if len(accessLogs) == 0 {
-		return nil
+		return result, nil
 	}
 
-	return ctx.DB().Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "config_id"}, {Name: "external_user_id"}, {Name: "scraper_id"}},
-		DoUpdates: clause.Set{
-			{Column: clause.Column{Name: "created_at"}, Value: gorm.Expr("excluded.created_at")},
-			{Column: clause.Column{Name: "mfa"}, Value: gorm.Expr("excluded.mfa")},
-			{Column: clause.Column{Name: "properties"}, Value: gorm.Expr("excluded.properties")},
-			{Column: clause.Column{Name: "count"}, Value: gorm.Expr(`config_access_logs."count" + 1`)},
-		},
-		Where: clause.Where{Exprs: []clause.Expression{
-			clause.Expr{SQL: "excluded.created_at > config_access_logs.created_at"},
-		}},
-	}).CreateInBatches(&accessLogs, configItemsBulkInsertSize).Error
+	scraperIDPtr := ctx.ScrapeConfig().GetPersistedID()
+	if scraperIDPtr == nil || *scraperIDPtr == uuid.Nil {
+		// No persisted scraper id ⇒ no stub-user path (stubs need a
+		// scraper_id on their rows). Fall back to the simple single-
+		// statement upsert and surface any error directly.
+		if err := ctx.DB().Clauses(clause.OnConflict{
+			Columns: []clause.Column{{Name: "config_id"}, {Name: "external_user_id"}, {Name: "scraper_id"}},
+			DoUpdates: clause.Set{
+				{Column: clause.Column{Name: "created_at"}, Value: gorm.Expr("excluded.created_at")},
+				{Column: clause.Column{Name: "mfa"}, Value: gorm.Expr("excluded.mfa")},
+				{Column: clause.Column{Name: "properties"}, Value: gorm.Expr("excluded.properties")},
+				{Column: clause.Column{Name: "count"}, Value: gorm.Expr(`config_access_logs."count" + 1`)},
+			},
+			Where: clause.Where{Exprs: []clause.Expression{
+				clause.Expr{SQL: "excluded.created_at > config_access_logs.created_at"},
+			}},
+		}).CreateInBatches(&accessLogs, configItemsBulkInsertSize).Error; err != nil {
+			return result, err
+		}
+		result.saved = len(accessLogs)
+		return result, nil
+	}
+	scraperID := *scraperIDPtr
+
+	// Pre-filter to the current scraper. Any mismatched row would indicate
+	// an upstream bug; drop and warn so it surfaces.
+	filtered := accessLogs[:0:0]
+	var dropped int
+	for _, log := range accessLogs {
+		if log.ScraperID != scraperID {
+			dropped++
+			continue
+		}
+		filtered = append(filtered, log)
+	}
+	if dropped > 0 {
+		ctx.Logger.Warnf("SaveConfigAccessLogs: dropped %d access-log row(s) whose scraper_id did not match the current scraper %s", dropped, scraperID)
+	}
+	if len(filtered) == 0 {
+		return result, nil
+	}
+	result.saved = len(filtered)
+
+	now := time.Now()
+	scraperIDStr := scraperID.String()
+	tempTable := fmt.Sprintf("_scrape_config_access_logs_%s", sanitizeForTempTable(scraperIDStr))
+
+	tx := ctx.DB().Begin()
+	if tx.Error != nil {
+		return result, fmt.Errorf("failed to begin transaction: %w", tx.Error)
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			tx.Rollback()
+			panic(r)
+		}
+	}()
+
+	if err := duty.ApplySessionProperties(ctx.DutyContext(), tx); err != nil {
+		tx.Rollback()
+		return result, fmt.Errorf("failed to apply session properties: %w", err)
+	}
+
+	if err := createTempAndInsert(tx, tempTable, "config_access_logs", filtered); err != nil {
+		tx.Rollback()
+		return result, fmt.Errorf("failed to setup temp access logs: %w", err)
+	}
+
+	// Stub external_users for any missing user references so the
+	// config_access_logs FK insert doesn't fail. Savepoint-guarded so a
+	// stub insert error doesn't abort the outer tx. Mirrors the user
+	// branch in upsertConfigAccess.
+	stubSQL := fmt.Sprintf(`
+		INSERT INTO external_users (id, name, aliases, scraper_id, created_at, updated_at, account_id, user_type)
+		SELECT DISTINCT t.external_user_id, t.external_user_id::text, NULL::text[], ?::uuid, ?::timestamptz, ?::timestamptz, '', 'Stub'
+		FROM %s t
+		WHERE t.external_user_id IS NOT NULL
+		  AND NOT EXISTS (SELECT 1 FROM external_users e WHERE e.id = t.external_user_id)
+		ON CONFLICT DO NOTHING
+	`, tempTable)
+	if err := tx.Exec("SAVEPOINT stub_user_access_logs").Error; err != nil {
+		ctx.Logger.Warnf("failed to create savepoint for access-log stub users: %v", err)
+	} else {
+		r := tx.Exec(stubSQL, scraperIDStr, now, now)
+		if r.Error != nil {
+			ctx.Logger.Warnf("failed to create stub users for access logs: %v", r.Error)
+			tx.Exec("ROLLBACK TO SAVEPOINT stub_user_access_logs")
+		} else {
+			tx.Exec("RELEASE SAVEPOINT stub_user_access_logs")
+			if r.RowsAffected > 0 {
+				ctx.Logger.Warnf("created %d stub user(s) for missing access_log references", r.RowsAffected)
+			}
+		}
+	}
+
+	// Bulk upsert from temp to live. Wrapped in a savepoint so an FK
+	// violation can be caught and recovered with a row-by-row retry.
+	bulkSQL := fmt.Sprintf(`
+		INSERT INTO config_access_logs (config_id, external_user_id, scraper_id, created_at, mfa, properties, count)
+		SELECT config_id, external_user_id, scraper_id, created_at, mfa, properties, COALESCE(count, 1)
+		FROM %s
+		ON CONFLICT (config_id, external_user_id, scraper_id) DO UPDATE SET
+			created_at = excluded.created_at,
+			mfa = excluded.mfa,
+			properties = excluded.properties,
+			count = config_access_logs."count" + 1
+		WHERE excluded.created_at > config_access_logs.created_at
+	`, tempTable)
+
+	tx.Exec("SAVEPOINT bulk_insert_access_logs")
+	if err := tx.Exec(bulkSQL).Error; err != nil {
+		if !dutydb.IsForeignKeyError(err) {
+			tx.Rollback()
+			return result, fmt.Errorf("failed to upsert config access logs: %w", err)
+		}
+
+		// Recover the tx from the aborted bulk insert; temp table is
+		// preserved across savepoint rollback.
+		tx.Exec("ROLLBACK TO SAVEPOINT bulk_insert_access_logs")
+
+		// Row-by-row fallback with per-row exception handling. Rows that
+		// succeed are deleted from the temp table; rows that still trip
+		// the FK remain and are counted below.
+		fallbackSQL := fmt.Sprintf(`
+			DO $$
+			DECLARE
+				v_rec RECORD;
+			BEGIN
+				FOR v_rec IN SELECT * FROM %s LOOP
+					BEGIN
+						INSERT INTO config_access_logs (config_id, external_user_id, scraper_id, created_at, mfa, properties, count)
+						VALUES (v_rec.config_id, v_rec.external_user_id, v_rec.scraper_id, v_rec.created_at, v_rec.mfa, v_rec.properties, COALESCE(v_rec.count, 1))
+						ON CONFLICT (config_id, external_user_id, scraper_id) DO UPDATE SET
+							created_at = excluded.created_at,
+							mfa = excluded.mfa,
+							properties = excluded.properties,
+							count = config_access_logs."count" + 1
+						WHERE excluded.created_at > config_access_logs.created_at;
+						DELETE FROM %s
+						WHERE config_id = v_rec.config_id
+							AND external_user_id = v_rec.external_user_id
+							AND scraper_id = v_rec.scraper_id;
+					EXCEPTION WHEN foreign_key_violation THEN
+						NULL;
+					END;
+				END LOOP;
+			END $$;
+		`, tempTable, tempTable)
+
+		if err := tx.Exec(fallbackSQL).Error; err != nil {
+			tx.Rollback()
+			return result, fmt.Errorf("failed to fallback upsert config access logs: %w", err)
+		}
+
+		var fkErrorCount int64
+		tx.Raw(fmt.Sprintf("SELECT count(*) FROM %s", tempTable)).Scan(&fkErrorCount)
+		result.foreignKeyErrors = int(fkErrorCount)
+		result.saved -= result.foreignKeyErrors
+
+		if fkErrorCount > 0 {
+			ctx.Logger.Warnf("config_access_logs: %d rows with FK violations (scraper=%s)", fkErrorCount, scraperIDStr)
+			logAccessLogFKDiagnostics(ctx, tx, tempTable)
+		}
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		return result, fmt.Errorf("failed to commit config access logs transaction: %w", err)
+	}
+
+	return result, nil
+}
+
+// logAccessLogFKDiagnostics mirrors logFKDiagnostics (permission_changes.go)
+// but scoped to config_access_logs: only external_user_id and config_id are
+// relevant (access logs don't reference roles or groups). Classifies the
+// remaining unresolvable rows and logs a grouped breakdown.
+func logAccessLogFKDiagnostics(ctx api.ScrapeContext, tx *gorm.DB, tempTable string) {
+	type diagRow struct {
+		ExternalUserID *uuid.UUID `gorm:"column:external_user_id"`
+		ConfigID       *uuid.UUID `gorm:"column:config_id"`
+		Reason         string     `gorm:"column:reason"`
+	}
+
+	diagSQL := fmt.Sprintf(`
+		SELECT t.external_user_id, t.config_id,
+			CASE
+				WHEN t.external_user_id IS NOT NULL AND eu.id IS NULL THEN 'user_missing'
+				WHEN t.external_user_id IS NOT NULL AND eu.deleted_at IS NOT NULL THEN 'user_deleted'
+				WHEN NOT EXISTS (SELECT 1 FROM config_items ci WHERE ci.id = t.config_id) THEN 'config_missing'
+				ELSE 'unknown'
+			END AS reason
+		FROM %s t
+		LEFT JOIN external_users eu ON eu.id = t.external_user_id
+		LIMIT 100
+	`, tempTable)
+
+	var rows []diagRow
+	if err := tx.Raw(diagSQL).Scan(&rows).Error; err != nil {
+		ctx.Logger.Warnf("  failed to diagnose access-log FK errors: %v", err)
+		return
+	}
+
+	type groupKey struct {
+		Reason string
+		FKID   string
+	}
+	counts := make(map[groupKey]int)
+	for _, row := range rows {
+		fkID := "unknown"
+		switch row.Reason {
+		case "user_missing", "user_deleted":
+			fkID = uuidPtrStr(row.ExternalUserID)
+		case "config_missing":
+			fkID = uuidPtrStr(row.ConfigID)
+		}
+		counts[groupKey{Reason: row.Reason, FKID: fkID}]++
+	}
+
+	logged := 0
+	for key, count := range counts {
+		if logged >= 10 {
+			break
+		}
+		ctx.Logger.Warnf("  reason=%s id=%s count=%d", key.Reason, key.FKID, count)
+		logged++
+	}
 }
 
 // extractResult holds the extracted configs & changes from the scrape result
@@ -1286,7 +1600,13 @@ type extractResult struct {
 	configAccesses   []v1.ExternalConfigAccess
 	configAccessLogs []v1.ExternalConfigAccessLog
 
-	changeSummary v1.ChangeSummaryByType
+	changeSummary   v1.ChangeSummaryByType
+	orphanedChanges []v1.ChangeResult
+	fkErrorChanges  []v1.ChangeResult
+	warnings        []v1.Warning
+
+	transformInput any
+	transformExpr  string
 }
 
 func NewExtractResult() *extractResult {
@@ -1334,6 +1654,15 @@ func extractConfigsAndChangesFromResults(ctx api.ScrapeContext, results []v1.Scr
 
 		if len(result.ExternalUserGroups) > 0 {
 			extractResult.externalUserGroups = append(extractResult.externalUserGroups, result.ExternalUserGroups...)
+		}
+
+		if len(result.Warnings) > 0 {
+			extractResult.warnings = append(extractResult.warnings, result.Warnings...)
+		}
+
+		if result.TransformInput != nil && extractResult.transformInput == nil {
+			extractResult.transformInput = result.TransformInput
+			extractResult.transformExpr = result.TransformExpr
 		}
 
 		if result.Name == "" {
@@ -1399,10 +1728,10 @@ func extractConfigsAndChangesFromResults(ctx api.ScrapeContext, results []v1.Scr
 			ctx.TempCache().Insert(*ci)
 		}
 
-		if toCreate, toUpdate, changeSummary, err := extractChanges(ctx, result, ci); err != nil {
+		if chResult, err := extractChanges(ctx, result, ci); err != nil {
 			return nil, err
 		} else {
-			if !changeSummary.IsEmpty() {
+			if !chResult.changeSummary.IsEmpty() {
 				var configType string
 				if ci != nil {
 					configType = ci.Type
@@ -1414,11 +1743,12 @@ func extractConfigsAndChangesFromResults(ctx api.ScrapeContext, results []v1.Scr
 					configType = "None"
 				}
 
-				extractResult.changeSummary.Merge(configType, changeSummary)
+				extractResult.changeSummary.Merge(configType, chResult.changeSummary)
 			}
 
-			extractResult.newChanges = append(extractResult.newChanges, toCreate...)
-			extractResult.changesToUpdate = append(extractResult.changesToUpdate, toUpdate...)
+			extractResult.newChanges = append(extractResult.newChanges, chResult.newChanges...)
+			extractResult.changesToUpdate = append(extractResult.changesToUpdate, chResult.changesToUpdate...)
+			extractResult.orphanedChanges = append(extractResult.orphanedChanges, chResult.orphanedChanges...)
 		}
 	}
 

--- a/db/update.go
+++ b/db/update.go
@@ -1356,7 +1356,10 @@ func SaveConfigAccessLogs(ctx api.ScrapeContext, accessLogs []dutyModels.ConfigA
 		return result, nil
 	}
 
-	scraperIDPtr := ctx.ScrapeConfig().GetPersistedID()
+	var scraperIDPtr *uuid.UUID
+	if sc := ctx.ScrapeConfig(); sc != nil {
+		scraperIDPtr = sc.GetPersistedID()
+	}
 	if scraperIDPtr == nil || *scraperIDPtr == uuid.Nil {
 		// No persisted scraper id ⇒ no stub-user path (stubs need a
 		// scraper_id on their rows). Fall back to the simple single-

--- a/fixtures/data/config_access_test.json
+++ b/fixtures/data/config_access_test.json
@@ -20,6 +20,15 @@
       "aliases": ["bob-jones", "bob@example.com"]
     }
   ],
+  "external_roles": [
+    {
+      "name": "Reader",
+      "account_id": "org-456",
+      "role_type": "builtin",
+      "description": "Read-only access",
+      "aliases": ["reader-role"]
+    }
+  ],
   "config_access": [
     {
       "id": "access-001",
@@ -27,7 +36,8 @@
         "config_type": "Organization",
         "external_id": "test-org-config-access"
       },
-      "external_user_aliases": ["alice-smith"]
+      "external_user_aliases": ["alice-smith"],
+      "external_role_aliases": ["reader-role"]
     },
     {
       "id": "access-002",
@@ -35,7 +45,8 @@
         "config_type": "Organization",
         "external_id": "test-org-config-access"
       },
-      "external_user_aliases": ["bob-jones", "bob@example.com"]
+      "external_user_aliases": ["bob-jones", "bob@example.com"],
+      "external_role_aliases": ["reader-role"]
     }
   ]
 }

--- a/fixtures/data/incremental_rbac_full_test.json
+++ b/fixtures/data/incremental_rbac_full_test.json
@@ -20,20 +20,31 @@
       "aliases": ["bob-inc", "bob-inc@example.com"]
     }
   ],
+  "external_roles": [
+    {
+      "name": "Viewer",
+      "account_id": "org-inc",
+      "role_type": "builtin",
+      "description": "View-only access",
+      "aliases": ["viewer-role-inc"]
+    }
+  ],
   "config_access": [
     {
       "external_config_id": {
         "config_type": "Organization",
         "external_id": "test-org-incremental-rbac"
       },
-      "external_user_aliases": ["alice-inc"]
+      "external_user_aliases": ["alice-inc"],
+      "external_role_aliases": ["viewer-role-inc"]
     },
     {
       "external_config_id": {
         "config_type": "Organization",
         "external_id": "test-org-incremental-rbac"
       },
-      "external_user_aliases": ["bob-inc"]
+      "external_user_aliases": ["bob-inc"],
+      "external_role_aliases": ["viewer-role-inc"]
     }
   ]
 }

--- a/fixtures/data/incremental_rbac_partial_test.json
+++ b/fixtures/data/incremental_rbac_partial_test.json
@@ -13,13 +13,23 @@
       "aliases": ["alice-inc", "alice-inc@example.com"]
     }
   ],
+  "external_roles": [
+    {
+      "name": "Viewer",
+      "account_id": "org-inc",
+      "role_type": "builtin",
+      "description": "View-only access",
+      "aliases": ["viewer-role-inc"]
+    }
+  ],
   "config_access": [
     {
       "external_config_id": {
         "config_type": "Organization",
         "external_id": "test-org-incremental-rbac"
       },
-      "external_user_aliases": ["alice-inc"]
+      "external_user_aliases": ["alice-inc"],
+      "external_role_aliases": ["viewer-role-inc"]
     }
   ]
 }

--- a/fixtures/data/permission_change_reduced_test.json
+++ b/fixtures/data/permission_change_reduced_test.json
@@ -20,13 +20,23 @@
       "aliases": ["perm-user-2", "permuser2@example.com"]
     }
   ],
+  "external_roles": [
+    {
+      "name": "Editor",
+      "account_id": "perm-org",
+      "role_type": "builtin",
+      "description": "Edit access",
+      "aliases": ["editor-role-perm"]
+    }
+  ],
   "config_access": [
     {
       "external_config_id": {
         "config_type": "Organization",
         "external_id": "test-org-permission-changes"
       },
-      "external_user_aliases": ["perm-user-1"]
+      "external_user_aliases": ["perm-user-1"],
+      "external_role_aliases": ["editor-role-perm"]
     }
   ]
 }

--- a/fixtures/data/permission_change_test.json
+++ b/fixtures/data/permission_change_test.json
@@ -20,20 +20,31 @@
       "aliases": ["perm-user-2", "permuser2@example.com"]
     }
   ],
+  "external_roles": [
+    {
+      "name": "Editor",
+      "account_id": "perm-org",
+      "role_type": "builtin",
+      "description": "Edit access",
+      "aliases": ["editor-role-perm"]
+    }
+  ],
   "config_access": [
     {
       "external_config_id": {
         "config_type": "Organization",
         "external_id": "test-org-permission-changes"
       },
-      "external_user_aliases": ["perm-user-1"]
+      "external_user_aliases": ["perm-user-1"],
+      "external_role_aliases": ["editor-role-perm"]
     },
     {
       "external_config_id": {
         "config_type": "Organization",
         "external_id": "test-org-permission-changes"
       },
-      "external_user_aliases": ["perm-user-2"]
+      "external_user_aliases": ["perm-user-2"],
+      "external_role_aliases": ["editor-role-perm"]
     }
   ]
 }

--- a/scrapers/config_access_test.go
+++ b/scrapers/config_access_test.go
@@ -484,7 +484,7 @@ var _ = Describe("Config access logs upsert", Ordered, func() {
 			MFA:            false,
 		}
 
-		err := db.SaveConfigAccessLogs(scraperCtx, []dutymodels.ConfigAccessLog{olderLog})
+		_, err := db.SaveConfigAccessLogs(scraperCtx, []dutymodels.ConfigAccessLog{olderLog})
 		Expect(err).NotTo(HaveOccurred())
 
 		newerLog := dutymodels.ConfigAccessLog{
@@ -495,7 +495,7 @@ var _ = Describe("Config access logs upsert", Ordered, func() {
 			MFA:            true,
 		}
 
-		err = db.SaveConfigAccessLogs(scraperCtx, []dutymodels.ConfigAccessLog{newerLog})
+		_, err = db.SaveConfigAccessLogs(scraperCtx, []dutymodels.ConfigAccessLog{newerLog})
 		Expect(err).NotTo(HaveOccurred())
 
 		var storedLog dutymodels.ConfigAccessLog
@@ -522,7 +522,7 @@ var _ = Describe("Config access logs upsert", Ordered, func() {
 			MFA:            true,
 		}
 
-		err := db.SaveConfigAccessLogs(scraperCtx, []dutymodels.ConfigAccessLog{latestLog})
+		_, err := db.SaveConfigAccessLogs(scraperCtx, []dutymodels.ConfigAccessLog{latestLog})
 		Expect(err).NotTo(HaveOccurred())
 
 		olderTime := time.Now().Add(-3 * time.Hour)
@@ -534,7 +534,7 @@ var _ = Describe("Config access logs upsert", Ordered, func() {
 			MFA:            false,
 		}
 
-		err = db.SaveConfigAccessLogs(scraperCtx, []dutymodels.ConfigAccessLog{olderLog})
+		_, err = db.SaveConfigAccessLogs(scraperCtx, []dutymodels.ConfigAccessLog{olderLog})
 		Expect(err).NotTo(HaveOccurred())
 
 		var storedLog dutymodels.ConfigAccessLog

--- a/scrapers/config_access_test.go
+++ b/scrapers/config_access_test.go
@@ -45,6 +45,9 @@ var _ = Describe("Config access with external_user_aliases test", Ordered, func(
 		err = DefaultContext.DB().Where("scraper_id = ?", scraperModel.ID).Delete(&dutymodels.ExternalUser{}).Error
 		Expect(err).NotTo(HaveOccurred(), "failed to delete external users")
 
+		err = DefaultContext.DB().Where("scraper_id = ?", scraperModel.ID).Delete(&dutymodels.ExternalRole{}).Error
+		Expect(err).NotTo(HaveOccurred(), "failed to delete external roles")
+
 		err = DefaultContext.DB().Where("scraper_id = ?", scraperModel.ID).Delete(&models.ConfigItem{}).Error
 		Expect(err).NotTo(HaveOccurred(), "failed to delete config items")
 

--- a/scrapers/external_entities_test.go
+++ b/scrapers/external_entities_test.go
@@ -169,6 +169,9 @@ var _ = Describe("Stale external entities deletion test", Ordered, func() {
 		err = DefaultContext.DB().Unscoped().Where("scraper_id = ?", scraperModel.ID).Delete(&dutymodels.ExternalUser{}).Error
 		Expect(err).NotTo(HaveOccurred(), "failed to delete external users")
 
+		err = DefaultContext.DB().Unscoped().Where("scraper_id = ?", scraperModel.ID).Delete(&dutymodels.ExternalRole{}).Error
+		Expect(err).NotTo(HaveOccurred(), "failed to delete external roles")
+
 		err = DefaultContext.DB().Where("scraper_id = ?", scraperModel.ID).Delete(&models.ConfigItem{}).Error
 		Expect(err).NotTo(HaveOccurred(), "failed to delete config items")
 

--- a/scrapers/incremental_rbac_test.go
+++ b/scrapers/incremental_rbac_test.go
@@ -37,6 +37,7 @@ var _ = Describe("Incremental scrape preserves RBAC data", Ordered, func() {
 	AfterAll(func() {
 		Expect(DefaultContext.DB().Unscoped().Where("scraper_id = ?", scraperModel.ID).Delete(&dutymodels.ConfigAccess{}).Error).NotTo(HaveOccurred())
 		Expect(DefaultContext.DB().Unscoped().Where("scraper_id = ?", scraperModel.ID).Delete(&dutymodels.ExternalUser{}).Error).NotTo(HaveOccurred())
+		Expect(DefaultContext.DB().Unscoped().Where("scraper_id = ?", scraperModel.ID).Delete(&dutymodels.ExternalRole{}).Error).NotTo(HaveOccurred())
 		Expect(DefaultContext.DB().Where("scraper_id = ?", scraperModel.ID).Delete(&models.ConfigItem{}).Error).NotTo(HaveOccurred())
 		Expect(DefaultContext.DB().Delete(&scraperModel).Error).NotTo(HaveOccurred())
 	})

--- a/scrapers/permission_changes_test.go
+++ b/scrapers/permission_changes_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Permission change tracking", Ordered, func() {
 	AfterAll(func() {
 		Expect(DefaultContext.DB().Unscoped().Where("scraper_id = ?", scraperModel.ID).Delete(&dutymodels.ConfigAccess{}).Error).NotTo(HaveOccurred())
 		Expect(DefaultContext.DB().Unscoped().Where("scraper_id = ?", scraperModel.ID).Delete(&dutymodels.ExternalUser{}).Error).NotTo(HaveOccurred())
+		Expect(DefaultContext.DB().Unscoped().Where("scraper_id = ?", scraperModel.ID).Delete(&dutymodels.ExternalRole{}).Error).NotTo(HaveOccurred())
 		if configItemID != "" {
 			Expect(DefaultContext.DB().Where("config_id = ? AND change_type IN (?, ?)", configItemID, v1.ChangeTypePermissionAdded, v1.ChangeTypePermissionRemoved).
 				Delete(&models.ConfigChange{}).Error).NotTo(HaveOccurred())


### PR DESCRIPTION
Deduplication:
  - Replace naive ID-match dedup with union-find over alias overlap so entries from different scrapers (e.g. Azure AD with real UUIDs and Azure DevOps with descriptor-only aliases) collapse into one survivor. Prefer non-nil ID survivors when merging with nil-ID entries.
  - Remove logic that added entity ID to aliases (no longer needed with union-find grouping).

  FK violation recovery (config_access + config_access_logs):
  - Wrap bulk inserts in savepoints; on FK violation, roll back the savepoint (preserving the temp table) and retry row-by-row with per-row exception handling so valid rows still persist.
  - Create stub external_users/roles/groups for missing references before the bulk insert to minimize FK fallback hits.
  - Add logFKDiagnostics and logAccessLogFKDiagnostics to classify and summarize unresolvable rows (user_missing, role_deleted, etc.).
  - Rewrite SaveConfigAccessLogs to use the same temp-table + savepoint + stub-user + row-by-row fallback pattern as upsertConfigAccess.

  Entity resolution:
  - Add findExternalEntityByID: resolves by canonical ID, falls back to alias overlap for merged/loser IDs.
  - Add ID-keyed caches for all three entity types (previously only users had one) and populate them in WarmExternalEntityCaches.

  Merge function resilience:
  - Wrap merge_and_upsert_external_* calls in savepoints via runMergeFunctionWithDump; on failure, dump temp + overlapping live rows to traces/ as JSON for post-mortem diagnosis.
  - Isolate user_groups upsert in its own savepoint so a failure there does not roll back already-successful user/group/role upserts.

  Config access validation:
  - Require both a principal (user or group) AND a role; skip rows missing either with a warning instead of silently passing through.

  Scrape summary improvements:
  - Track orphaned changes and FK error changes on ScrapeSummary.
  - Add warning deduplication (AddScrapeWarning with warningIndex).
  - Track access log last_created_at per config type; retain from previous scrape when no new logs are seen.
  - Add resolveChange to populate ChangeResult.Resolved with the final ConfigChange state after the change mapping pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced change tracking with resolved, orphaned, and FK error changes now visible in API responses
  * Comprehensive warnings aggregation and deduplication for clearer reporting
  * Improved access logging with automatic recovery from missing entity references

* **Bug Fixes**
  * Better external entity resolution and caching mechanisms
  * FK error recovery with fallback mechanisms to prevent data loss

<!-- end of auto-generated comment: release notes by coderabbit.ai -->