### PR TITLE
fix: add filter for helm location in scrape plugin

### DIFF
--- a/chart/templates/plugins/k8s.yaml
+++ b/chart/templates/plugins/k8s.yaml
@@ -75,6 +75,7 @@ spec:
 
     - type: Kubernetes::*
       withParent: Kubernetes::HelmRelease
+      filter: "has(labels['helm.toolkit.fluxcd.io/name'])"
       values:
         - helm://$(tags.cluster)/$(.parent.tags.namespace)/$(.parent.name)
 {{- end }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of Kubernetes resource identification by implementing label-based filtering to ensure only relevant resources are processed.

* **Style**
  * Normalized template file formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->