### PR TITLE
fix(chart): mount config-db.properties in the expected path

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -158,9 +158,9 @@ spec:
             {{- with .Values.volumeMounts }}
               {{- toYaml . | nindent 12}}
             {{- end }}
-            - mountPath: /app/config.properties
+            - mountPath: /app/config-db.properties
               name: config
-              subPath: config.properties
+              subPath: config-db.properties
             {{- if $embeddedDB}}
             - name: config-db-embedded-database
               mountPath: "/opt/database"


### PR DESCRIPTION
The Helm chart writes `.Values.properties` to the `config-db.properties` ConfigMap key.

The deployment mounted that ConfigMap as `config.properties`, while config-db loads `config-db.properties` at startup. That mismatch meant chart-supplied properties like `artifacts.connection` were not applied.

Mount the file at `/app/config-db.properties` with `subPath: config-db.properties` so Helm-provided properties are picked up correctly.

Closes #2149


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration file references in deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->