### PR TITLE
fix(chart): aws location ec2 template

### DIFF
--- a/chart/templates/plugins/aws-locations.yaml
+++ b/chart/templates/plugins/aws-locations.yaml
@@ -64,7 +64,7 @@ spec:
         "topology.kubernetes.io/region" in labels &&
         "topology.kubernetes.io/zone" in labels
       values:
-        - zone://aws/$(.labels["topology.kubernetes.io/region"])/$(.labels["topology.kubernetes.io/zone"])
-        - region://aws/$(.labels["topology.kubernetes.io/region"])
+        - zone://aws/$(index .labels "topology.kubernetes.io/region")/$(index .labels "topology.kubernetes.io/zone")
+        - region://aws/$(index .labels "topology.kubernetes.io/region")
         - ec2instance://aws/$(.config.spec.providerID | strings.Split "/" | last)
 {{- end }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the extraction of AWS region and zone information from Kubernetes node labels in the monitoring plugin configuration, ensuring more reliable label lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->