### PR TITLE
chore: simplify created_at update logic

### DIFF
--- a/db/update.go
+++ b/db/update.go
@@ -199,9 +199,7 @@ func updateCI(ctx api.ScrapeContext, summary *v1.ScrapeSummary, result *v1.Scrap
 		updates["path"] = ci.Path
 	}
 
-	if ci.CreatedAt.IsZero() && existing.CreatedAt.IsZero() {
-		updates["created_at"] = gorm.Expr("NOW()")
-	} else if !ci.CreatedAt.Equal(existing.CreatedAt) && !ci.CreatedAt.IsZero() {
+	if !ci.CreatedAt.IsZero() && !ci.CreatedAt.Equal(existing.CreatedAt) {
 		updates["created_at"] = ci.CreatedAt
 	}
 
@@ -1733,7 +1731,16 @@ func extractConfigsAndChangesFromResults(ctx api.ScrapeContext, results []v1.Scr
 				})
 			}
 
-			ctx.TempCache().Insert(*ci)
+			cacheItem := *ci
+			if cacheItem.CreatedAt.IsZero() {
+				if existing != nil && existing.ID != "" && !existing.CreatedAt.IsZero() {
+					cacheItem.CreatedAt = existing.CreatedAt
+				} else {
+					cacheItem.CreatedAt = time.Now().UTC()
+				}
+			}
+
+			ctx.TempCache().Insert(cacheItem)
 		}
 
 		if chResult, err := extractChanges(ctx, result, ci); err != nil {


### PR DESCRIPTION
DB has `not null default now()`, If existing CI was sometimes coming from cache directly before db lookup, we ended up firing `update ci set created_at = now() where id = ` which was redundant and messed up the actual created at.

Only update if it is non zero and not equal to existing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of creation timestamps for configuration items to enhance data consistency and reliability. The system now correctly manages timestamp normalization during cache operations and updates, ensuring that creation dates are accurately preserved and consistently tracked throughout system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->