### PR TITLE
fix: persist scraper run artifacts only for explicit /run_now runs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -162,12 +162,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kms v1.49.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.10 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bmatcuk/doublestar v1.3.4 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
-	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/casbin/casbin/v2 v2.135.0 // indirect
 	github.com/casbin/casbin/v3 v3.8.1 // indirect
 	github.com/casbin/gorm-adapter/v3 v3.41.0 // indirect
@@ -263,7 +261,6 @@ require (
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/henvic/httpretty v0.1.4 // indirect
 	github.com/hirochachacha/go-smb2 v1.1.0 // indirect
-	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/itchyny/gojq v0.12.19 // indirect
 	github.com/itchyny/timefmt-go v0.1.8 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
@@ -295,7 +292,6 @@ require (
 	github.com/lrita/cmap v0.0.0-20231108122212-cb084a67f554 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
-	github.com/mailru/easyjson v0.9.1 // indirect
 	github.com/microsoft/kiota-abstractions-go v1.9.3 // indirect
 	github.com/microsoft/kiota-authentication-azure-go v1.3.1 // indirect
 	github.com/microsoft/kiota-http-go v1.5.4 // indirect
@@ -357,12 +353,8 @@ require (
 	github.com/vadimi/go-http-ntlm v1.0.3 // indirect
 	github.com/vadimi/go-http-ntlm/v2 v2.5.0 // indirect
 	github.com/vadimi/go-ntlm v1.2.1 // indirect
-	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
-	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/xuri/efp v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -336,8 +336,6 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=
 github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
-github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
-github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -354,8 +352,6 @@ github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
 github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
-github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
-github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c/go.mod h1:l/bIBLeOl9eX+wxJAzxS4TveKRtAqlyDpHjhkfO0MEI=
 github.com/casbin/casbin/v2 v2.135.0 h1:6BLkMQiGotYyS5yYeWgW19vxqugUlvHFkFiLnLR/bxk=
 github.com/casbin/casbin/v2 v2.135.0/go.mod h1:FmcfntdXLTcYXv/hxgNntcRPqAbwOG9xsism0yXT+18=
@@ -801,8 +797,6 @@ github.com/hirochachacha/go-smb2 v1.1.0/go.mod h1:8F1A4d5EZzrGu5R7PU163UcMRDJQl4
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
-github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/itchyny/gojq v0.12.19 h1:ttXA0XCLEMoaLOz5lSeFOZ6u6Q3QxmG46vfgI4O0DEs=
 github.com/itchyny/gojq v0.12.19/go.mod h1:5galtVPDywX8SPSOrqjGxkBeDhSxEW1gSxoy7tn1iZY=
 github.com/itchyny/timefmt-go v0.1.8 h1:1YEo1JvfXeAHKdjelbYr/uCuhkybaHCeTkH8Bo791OI=
@@ -969,8 +963,6 @@ github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 h1:PwQumkgq4/acIi
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/mailru/easyjson v0.9.1 h1:LbtsOm5WAswyWbvTEOqhypdPeZzHavpZx96/n553mR8=
-github.com/mailru/easyjson v0.9.1/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
@@ -1285,8 +1277,6 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
-github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
-github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
@@ -1294,12 +1284,6 @@ github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
 github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
-github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
-github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
-github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
-github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
-github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
-github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xhit/go-str2duration v1.2.0/go.mod h1:3cPSlfZlUHVlneIVfePFWcJZsuwf+P1v2SRTV4cUmp4=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=

--- a/scrapers/cron.go
+++ b/scrapers/cron.go
@@ -328,17 +328,10 @@ func newScraperJob(sc api.ScrapeContext, overrides ...RunScraperOption) *job.Job
 			jr.History.AddDetails("scrape_summary", output.Summary)
 			ScraperSummaryCache.Store(sc.ScraperID(), output.Summary)
 
-			if shouldPersist, reason := shouldPersistRunArtifact(jr.Context, sc.ScraperID(), runScraperOpts...); shouldPersist {
-				runArtifact, err := persistRunArtifact(jr.Context, sc.ScraperID(), jr.History.ID, sc.ScrapeConfig().Name, start, output, lastSummary)
-				if err != nil {
+			if shouldPersistRunArtifact(jr.Context, sc.ScraperID(), runScraperOpts...) {
+				if _, err := persistRunArtifact(jr.Context, sc.ScraperID(), jr.History.ID, sc.ScrapeConfig().Name, start, output, lastSummary); err != nil {
 					jr.Logger.Warnf("failed to persist scrape run artifact: %v", err)
-				} else if runArtifact != nil {
-					jr.History.AddDetails("run_artifact_count", 1)
-					jr.History.AddDetails("run_artifact_prefix", runArtifactPrefix(sc.ScraperID(), jr.History.ID))
-					jr.History.AddDetails("run_artifact_path", runArtifact.Path)
 				}
-			} else {
-				jr.Logger.Infof("skipping scrape run artifact persistence: %s", reason)
 			}
 
 			source := sc.ScrapeConfig().GetAnnotations()["source"]
@@ -407,19 +400,21 @@ func persistRunArtifact(ctx context.Context, scraperID string, jobHistoryID uuid
 	return writeCompressedRunArtifact(blobs, artifactConnectionID, scraperUUID, jobHistoryID, prefix, "summary.json.gz", "summary.json.gz", summaryData)
 }
 
-func shouldPersistRunArtifact(ctx context.Context, scraperID string, runOpts ...RunScraperOption) (bool, string) {
+func shouldPersistRunArtifact(ctx context.Context, scraperID string, runOpts ...RunScraperOption) bool {
 	if scraperID == "" {
-		return false, "scraper has no persisted ID"
+		return false
 	}
 
 	opts := buildRunScraperOptions(runOpts...)
-	hasCaptureEnabled := opts.CaptureHAR || opts.CaptureLogs || opts.CaptureSnapshots
-	hasArtifactConnection := ctx.Properties().String("artifacts.connection", "") != ""
-	if !hasCaptureEnabled && !hasArtifactConnection {
-		return false, "no artifact capture enabled and no artifacts.connection configured"
+	if !opts.PersistRunArtifact {
+		return false
 	}
 
-	return true, ""
+	if ctx.Properties().String("artifacts.connection", "") == "" {
+		return false
+	}
+
+	return true
 }
 
 func runArtifactPrefix(scraperID string, jobHistoryID uuid.UUID) string {

--- a/scrapers/cron.go
+++ b/scrapers/cron.go
@@ -250,12 +250,7 @@ func newScraperJob(sc api.ScrapeContext, overrides ...RunScraperOption) *job.Job
 	schedule, _ := lo.Coalesce(sc.Properties().String(fmt.Sprintf("scraper.%s.schedule", sc.ScrapeConfig().UID), sc.ScrapeConfig().Spec.Schedule), DefaultSchedule)
 	minScheduleAllowed := sc.Properties().Duration(fmt.Sprintf("scraper.%s.schedule.min", sc.ScrapeConfig().Type()), MinScraperSchedule)
 
-	runScraperOpts := []RunScraperOption{
-		WithCaptureHAR(sc.PropertyOn(false, "capture.har")),
-		WithCaptureLogs(sc.PropertyOn(false, "capture.logs")),
-		WithCaptureSnapshots(sc.PropertyOn(false, "capture.snapshots")),
-	}
-	runScraperOpts = append(runScraperOpts, overrides...)
+	runScraperOpts := append([]RunScraperOption(nil), overrides...)
 
 	// Attempt to get a fixed interval from the schedule.
 	// NOTE: Only works for fixed interval schedules.

--- a/scrapers/run.go
+++ b/scrapers/run.go
@@ -40,9 +40,10 @@ type ScrapeOutput struct {
 }
 
 type RunScraperOptions struct {
-	CaptureHAR       bool
-	CaptureSnapshots bool
-	CaptureLogs      bool
+	CaptureHAR         bool
+	CaptureSnapshots   bool
+	CaptureLogs        bool
+	PersistRunArtifact bool
 }
 
 type RunScraperOption func(*RunScraperOptions)
@@ -57,6 +58,10 @@ func WithCaptureSnapshots(enabled bool) RunScraperOption {
 
 func WithCaptureLogs(enabled bool) RunScraperOption {
 	return func(o *RunScraperOptions) { o.CaptureLogs = enabled }
+}
+
+func WithPersistRunArtifact(enabled bool) RunScraperOption {
+	return func(o *RunScraperOptions) { o.PersistRunArtifact = enabled }
 }
 
 func buildRunScraperOptions(opts ...RunScraperOption) RunScraperOptions {

--- a/scrapers/run_now.go
+++ b/scrapers/run_now.go
@@ -31,43 +31,10 @@ type runNowResponse struct {
 }
 
 type runNowRequest struct {
-	Async                 *bool `json:"async,omitempty"`
-	CaptureHAR            *bool `json:"capture_har,omitempty"`
-	CaptureHARCamel       *bool `json:"captureHAR,omitempty"`
-	CaptureLogs           *bool `json:"capture_logs,omitempty"`
-	CaptureLogsCamel      *bool `json:"captureLogs,omitempty"`
-	CaptureSnapshots      *bool `json:"capture_snapshots,omitempty"`
-	CaptureSnapshotsCamel *bool `json:"captureSnapshots,omitempty"`
-}
-
-func (r runNowRequest) captureHAR() (bool, bool) {
-	if r.CaptureHAR != nil {
-		return *r.CaptureHAR, true
-	}
-	if r.CaptureHARCamel != nil {
-		return *r.CaptureHARCamel, true
-	}
-	return false, false
-}
-
-func (r runNowRequest) captureLogs() (bool, bool) {
-	if r.CaptureLogs != nil {
-		return *r.CaptureLogs, true
-	}
-	if r.CaptureLogsCamel != nil {
-		return *r.CaptureLogsCamel, true
-	}
-	return false, false
-}
-
-func (r runNowRequest) captureSnapshots() (bool, bool) {
-	if r.CaptureSnapshots != nil {
-		return *r.CaptureSnapshots, true
-	}
-	if r.CaptureSnapshotsCamel != nil {
-		return *r.CaptureSnapshotsCamel, true
-	}
-	return false, false
+	Async            *bool `json:"async,omitempty"`
+	CaptureHAR       *bool `json:"captureHAR,omitempty"`
+	CaptureLogs      *bool `json:"captureLogs,omitempty"`
+	CaptureSnapshots *bool `json:"captureSnapshots,omitempty"`
 }
 
 func RunNowHandler(c echo.Context) error {
@@ -248,16 +215,23 @@ func parseRunNowRequest(c echo.Context) (runNowRequest, error) {
 
 func runScraperOptsFromRunNowRequest(req runNowRequest) []RunScraperOption {
 	opts := make([]RunScraperOption, 0, 4)
-	opts = append(opts, WithPersistRunArtifact(true))
+	persistRunArtifact := false
 
-	if enabled, ok := req.captureHAR(); ok {
-		opts = append(opts, WithCaptureHAR(enabled))
+	if req.CaptureHAR != nil {
+		opts = append(opts, WithCaptureHAR(*req.CaptureHAR))
+		persistRunArtifact = persistRunArtifact || *req.CaptureHAR
 	}
-	if enabled, ok := req.captureLogs(); ok {
-		opts = append(opts, WithCaptureLogs(enabled))
+	if req.CaptureLogs != nil {
+		opts = append(opts, WithCaptureLogs(*req.CaptureLogs))
+		persistRunArtifact = persistRunArtifact || *req.CaptureLogs
 	}
-	if enabled, ok := req.captureSnapshots(); ok {
-		opts = append(opts, WithCaptureSnapshots(enabled))
+	if req.CaptureSnapshots != nil {
+		opts = append(opts, WithCaptureSnapshots(*req.CaptureSnapshots))
+		persistRunArtifact = persistRunArtifact || *req.CaptureSnapshots
+	}
+
+	if persistRunArtifact {
+		opts = append(opts, WithPersistRunArtifact(true))
 	}
 
 	return opts

--- a/scrapers/run_now.go
+++ b/scrapers/run_now.go
@@ -247,7 +247,8 @@ func parseRunNowRequest(c echo.Context) (runNowRequest, error) {
 }
 
 func runScraperOptsFromRunNowRequest(req runNowRequest) []RunScraperOption {
-	opts := make([]RunScraperOption, 0, 3)
+	opts := make([]RunScraperOption, 0, 4)
+	opts = append(opts, WithPersistRunArtifact(true))
 
 	if enabled, ok := req.captureHAR(); ok {
 		opts = append(opts, WithCaptureHAR(enabled))


### PR DESCRIPTION
Scheduled scraper runs were writing run artifacts by default based on capture flags/config.
This made artifact persistence happen outside explicit on-demand runs

This change gates run artifact persistence behind an explicit run option, enabled only by /run_now.
Cron/scheduled runs now skip artifact writes unless explicitly triggered via /run_now, and only when artifacts.connection is configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PersistRunArtifact setting to explicitly control when run artifacts are persisted.

* **Updates**
  * Artifact persistence now only occurs when PersistRunArtifact is enabled and an artifact destination is configured.
  * Run-now requests that enable any capture option will also enable artifact persistence.
  * Skipped persistence no longer records artifact counts/paths or emits skip-reason entries; persistence errors remain logged as warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->