### PR TITLE
fix(kubernetes): use singe source of truth for cluster

### DIFF
--- a/scrapers/kubernetes/context.go
+++ b/scrapers/kubernetes/context.go
@@ -34,18 +34,9 @@ func newKubernetesContext(ctx api.ScrapeContext, isIncremental bool, config v1.K
 	}
 
 	return &KubernetesContext{
-		ScrapeContext: ctx,
-		config:        config,
-		cluster: v1.ScrapeResult{
-			BaseScraper: config.BaseScraper,
-			Name:        config.ClusterName,
-			ConfigClass: "Cluster",
-			Type:        ConfigTypePrefix + "Cluster",
-			Config:      make(map[string]any),
-			Labels:      make(v1.JSONStringMap),
-			ID:          "Kubernetes/Cluster/" + config.ClusterName,
-			Tags:        map[string]string{"cluster": config.ClusterName},
-		},
+		ScrapeContext:    ctx,
+		config:           config,
+		cluster:          getClusterAsScrapeResult(config),
 		labelsPerNode:    make(map[string]map[string]string),
 		labelsForAllNode: make(map[string]string),
 		globalLabels:     make(map[string]string),

--- a/scrapers/kubernetes/kubernetes.go
+++ b/scrapers/kubernetes/kubernetes.go
@@ -118,18 +118,12 @@ func (kubernetes KubernetesScraper) Scrape(ctx api.ScrapeContext) v1.ScrapeResul
 
 var IgnoredConfigsCache = sync.Map{}
 
-// ExtractResults extracts scrape results from the given list of kuberenetes objects.
-//   - withCluster: if true, will create & add a scrape result for the kubernetes cluster.
-func ExtractResults(ctx *KubernetesContext, objs []*unstructured.Unstructured) v1.ScrapeResults {
-	var (
-		results       v1.ScrapeResults
-		changeResults v1.ScrapeResults
-	)
-
-	clusterName := ctx.config.ClusterName
+func getClusterAsScrapeResult(config v1.Kubernetes) v1.ScrapeResult {
+	clusterName := config.ClusterName
 	extID := "Kubernetes/Cluster/" + clusterName
-	cluster := v1.ScrapeResult{
-		BaseScraper: ctx.config.BaseScraper,
+
+	return v1.ScrapeResult{
+		BaseScraper: config.BaseScraper,
 		Name:        clusterName,
 		ConfigClass: "Cluster",
 		Type:        ConfigTypePrefix + "Cluster",
@@ -139,8 +133,18 @@ func ExtractResults(ctx *KubernetesContext, objs []*unstructured.Unstructured) v
 		ConfigID:    lo.ToPtr(utils.IgnoreError(utils.LegacyDeterministicUUID(extID)).String()),
 		Tags:        map[string]string{"cluster": clusterName},
 	}
+}
 
-	results = append(results, cluster)
+// ExtractResults extracts scrape results from the given list of kuberenetes objects.
+//   - withCluster: if true, will create & add a scrape result for the kubernetes cluster.
+func ExtractResults(ctx *KubernetesContext, objs []*unstructured.Unstructured) v1.ScrapeResults {
+	var (
+		results       v1.ScrapeResults
+		changeResults v1.ScrapeResults
+	)
+
+	ctx.cluster = getClusterAsScrapeResult(ctx.config)
+	clusterName := ctx.config.ClusterName
 
 	// Initialize RBAC extractor for config access tracking
 	var rbac *rbacExtractor
@@ -583,9 +587,7 @@ func ExtractResults(ctx *KubernetesContext, objs []*unstructured.Unstructured) v
 	results = append(results, rbac.results(ctx.config.BaseScraper))
 
 	results = append(results, changeResults...)
-	if ctx.IsIncrementalScrape() {
-		results = append([]v1.ScrapeResult{ctx.cluster}, results...)
-	}
+	results = append([]v1.ScrapeResult{ctx.cluster}, results...)
 
 	for i := range results {
 		results[i].Labels = collections.MergeMap(map[string]string(results[i].Labels), ctx.globalLabels)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for cluster result handling by centralizing construction logic.

* **Behavior Change**
  * Cluster scrape results are now consistently included in all extraction outputs, rather than conditionally based on scrape mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->