### PR TITLE
fix: invalid kubeconfig should return error

### DIFF
--- a/api/v1/interface.go
+++ b/api/v1/interface.go
@@ -803,6 +803,12 @@ func (t ScrapeResults) HasErr() bool {
 	return false
 }
 
+func (t ScrapeResults) NonErrorCount() int {
+	return lo.CountBy(t, func(r ScrapeResult) bool {
+		return r.Error == nil
+	})
+}
+
 func (s *ConfigTypeScrapeSummary) initWarningIndex() {
 	if s.warningIndex != nil {
 		return

--- a/scrapers/kubernetes/ketall.go
+++ b/scrapers/kubernetes/ketall.go
@@ -52,7 +52,7 @@ func scrape(ctx api.ScrapeContext, config v1.Kubernetes) ([]*unstructured.Unstru
 		return nil
 	})
 
-	return objs, nil
+	return objs, err
 }
 
 func updateOptions(ctx context.Context, opts *options.KetallOptions, config v1.Kubernetes) (*options.KetallOptions, error) {

--- a/scrapers/run.go
+++ b/scrapers/run.go
@@ -163,7 +163,7 @@ func RunScraper(ctx api.ScrapeContext, opts ...RunScraperOption) (*ScrapeOutput,
 	ctx.Logger.Debugf("Completed scrape with %s in %s", savedResult.PrettyShort(), timer.End())
 
 	out := &ScrapeOutput{
-		Total:        len(results),
+		Total:        results.NonErrorCount(),
 		Summary:      savedResult,
 		Results:      results,
 		SnapshotPair: snapshotPair,
@@ -205,7 +205,7 @@ func UpdateStaleConfigItems(ctx api.ScrapeContext, results v1.ScrapeResults) err
 }
 
 // Run ...
-func Run(ctx api.ScrapeContext) ([]v1.ScrapeResult, error) {
+func Run(ctx api.ScrapeContext) (v1.ScrapeResults, error) {
 	plugins, err := db.LoadAllPlugins(ctx.DutyContext())
 	if err != nil {
 		return nil, ctx.Oops().Wrapf(err, "failed to load plugins")
@@ -238,7 +238,7 @@ func Run(ctx api.ScrapeContext) ([]v1.ScrapeResult, error) {
 		}
 	}
 
-	return results, nil
+	return v1.ScrapeResults(results), nil
 }
 
 // processScrapeResult extracts possibly more configs from the result


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error propagation in the Kubernetes scraper so failures after retries are reported correctly.
* **New Features**
  * Scrape totals now reflect only successful results (failed entries are excluded) for more accurate reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->