### PR TITLE
fix: benchmark CI failure handling

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -87,6 +87,7 @@ jobs:
 
       - name: Benchmark base
         run: |
+          set -euo pipefail
           cd .bench/base
           # benchstat recommends >= 10 runs for stronger significance.
           # We use -count=6 to keep PR runtime reasonable.
@@ -95,6 +96,7 @@ jobs:
 
       - name: Benchmark head
         run: |
+          set -euo pipefail
           # benchstat recommends >= 10 runs for stronger significance.
           # We use -count=6 to keep PR runtime reasonable.
           CONFIG_DB_BENCH_SIZES="${BENCH_SIZES}" \


### PR DESCRIPTION
08:18:40.382 INF starting embedded postgres on port 41429 failed to setup benchmark db: no version found matching 16.9.0 exit status 1
FAIL	github.com/flanksource/config-db/bench	0.172s FAIL

this failure wasn't caputred