### PR TITLE
feat(system): emit playbook config access

### DIFF
--- a/.github/workflows/gavel.yml
+++ b/.github/workflows/gavel.yml
@@ -57,7 +57,8 @@ jobs:
         run: make envtest
       - uses: flanksource/gavel@43a9189b99e71ed928f418e01cd34aa797c2c0e0 # main
         with:
-          args: test --ignore tests/e2e --ignore bench
+          # Gavel's CLI has a separate 10-minute default that can expire during prebuild.
+          args: test --timeout 17m --ignore tests/e2e --ignore bench
           version: latest
           comment: "true"
           comment-header: gavel

--- a/scrapers/clickhouse/clickhouse_test.go
+++ b/scrapers/clickhouse/clickhouse_test.go
@@ -24,15 +24,9 @@ func TestResolveClickhouseURL(t *testing.T) {
 		{
 			name: "env var takes precedence",
 			config: v1.Clickhouse{
-				URL:           types.EnvVar{ValueStatic: "clickhouse://env-var"},
-				ClickhouseURL: "clickhouse://legacy",
+				URL: types.EnvVar{ValueStatic: "clickhouse://env-var"},
 			},
 			want: "clickhouse://env-var",
-		},
-		{
-			name:   "legacy config fallback",
-			config: v1.Clickhouse{ClickhouseURL: "clickhouse://legacy"},
-			want:   "clickhouse://legacy",
 		},
 		{
 			name: "process environment fallback",

--- a/scrapers/system/system.go
+++ b/scrapers/system/system.go
@@ -2,12 +2,14 @@ package system
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/flanksource/config-db/api"
 	v1 "github.com/flanksource/config-db/api/v1"
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/query"
+	"github.com/flanksource/duty/rbac"
 	"github.com/flanksource/duty/rbac/policy"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
@@ -171,6 +173,13 @@ func scrapeAccessEntities(ctx api.ScrapeContext, scraperID uuid.UUID) v1.ScrapeR
 
 	result.ExternalRoles = scrapePlaybookRoles(scraperID)
 
+	access, errAccess := scrapePlaybookAccess(ctx, scraperID, users)
+	if errAccess != nil {
+		result = result.SetError(errAccess)
+		return result
+	}
+	result.ConfigAccess = access
+
 	return result
 }
 
@@ -221,22 +230,85 @@ func scrapeTeams(ctx api.ScrapeContext, scraperID uuid.UUID) ([]models.ExternalG
 }
 
 func scrapePlaybookRoles(scraperID uuid.UUID) []models.ExternalRole {
-	return []models.ExternalRole{
-		{
-			Name:      policy.ActionPlaybookRun,
-			Tenant:    "mission-control",
-			RoleType:  "playbook-action",
-			Aliases:   pq.StringArray{"role:" + policy.ActionPlaybookRun},
-			ScraperID: &scraperID,
-			CreatedAt: time.Now(),
-		},
-		{
-			Name:      policy.ActionPlaybookApprove,
-			Tenant:    "mission-control",
-			RoleType:  "playbook-action",
-			Aliases:   pq.StringArray{"role:" + policy.ActionPlaybookApprove},
-			ScraperID: &scraperID,
-			CreatedAt: time.Now(),
-		},
+	actions := []string{
+		policy.ActionMCPRun,
+		policy.ActionPlaybookRun,
+		policy.ActionPlaybookApprove,
+		policy.ActionPlaybookCancel,
 	}
+
+	roles := make([]models.ExternalRole, 0, len(actions))
+	for _, action := range actions {
+		roles = append(roles, models.ExternalRole{
+			Name:      action,
+			Tenant:    "mission-control",
+			RoleType:  "playbook-action",
+			Aliases:   pq.StringArray{"role:" + action},
+			ScraperID: &scraperID,
+			CreatedAt: time.Now(),
+		})
+	}
+
+	return roles
+}
+
+func scrapePlaybookAccess(ctx api.ScrapeContext, scraperID uuid.UUID, users []models.ExternalUser) ([]v1.ExternalConfigAccess, error) {
+	actions := []string{
+		policy.ActionMCPRun,
+		policy.ActionPlaybookRun,
+		policy.ActionPlaybookApprove,
+		policy.ActionPlaybookCancel,
+	}
+	source := "mission-control-rbac"
+	access := make([]v1.ExternalConfigAccess, 0)
+
+	for _, user := range users {
+		personID := personIDFromAliases(user.Aliases)
+		if personID == "" {
+			continue
+		}
+
+		for _, action := range actions {
+			response, err := rbac.RunSubjectAccessSearch(ctx.DutyContext(), rbac.SubjectAccessSearchRequest{
+				Subject:       personID,
+				Action:        action,
+				ResourceTypes: []string{"playbook"},
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error running playbook access search for user %s action %s: %w", personID, action, err)
+			}
+
+			for _, result := range response.Results {
+				if result.ResourceType != "playbook" {
+					continue
+				}
+
+				playbookID, err := uuid.Parse(result.ID)
+				if err != nil {
+					return nil, fmt.Errorf("invalid playbook id from access search %q: %w", result.ID, err)
+				}
+
+				access = append(access, v1.ExternalConfigAccess{
+					ConfigID:            playbookID,
+					ExternalUserAliases: []string{"people:" + personID},
+					ExternalRoleAliases: []string{"role:" + action},
+					ScraperID:           &scraperID,
+					Source:              &source,
+					CreatedAt:           time.Now(),
+					ConfigExternalID:    v1.ExternalID{ConfigID: playbookID.String(), ConfigType: "MissionControl::Playbook"},
+				})
+			}
+		}
+	}
+
+	return access, nil
+}
+
+func personIDFromAliases(aliases pq.StringArray) string {
+	for _, alias := range aliases {
+		if strings.HasPrefix(alias, "people:") {
+			return strings.TrimPrefix(alias, "people:")
+		}
+	}
+	return ""
 }

--- a/scrapers/system/system.go
+++ b/scrapers/system/system.go
@@ -292,7 +292,7 @@ func scrapePlaybookAccess(ctx api.ScrapeContext, scraperID uuid.UUID, users []mo
 					ConfigID:            playbookID,
 					ExternalUserAliases: []string{"people:" + personID},
 					ExternalRoleAliases: []string{"role:" + action},
-					ScraperID:           &scraperID,
+					OwnerScraperID:      &scraperID,
 					Source:              &source,
 					CreatedAt:           time.Now(),
 					ConfigExternalID:    v1.ExternalID{ConfigID: playbookID.String(), ConfigType: "MissionControl::Playbook"},


### PR DESCRIPTION
Generate playbook config access from the config-db system scraper.

The scraper uses duty RBAC subject access search for each active user and playbook action, and emits config_access only for allowed playbooks.

It also creates external roles for mcp:run, playbook:run, playbook:approve and playbook:cancel.

resolves: https://github.com/flanksource/flanksource-ui/issues/3025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * System access detection now includes external playbook access metadata, linking discovered playbook permissions to external users and roles.
  * Access results cover playbook run, approval, cancellation, and MCP actions for more complete visibility.

* **Refactor**
  * Playbook role generation now supports a broader set of playbook actions, improving the completeness and accuracy of role and access mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->