### PR TITLE
chore: remove entities from summary by default

### DIFF
--- a/PROPERTIES.md
+++ b/PROPERTIES.md
@@ -117,6 +117,7 @@ Per-scraper feature flags, also resolved via `scraper.{uid}.{key}` / `scraper.{k
 | `scraper.disable`                  | Bool | `false` | Disable a scraper entirely                             |
 | `scraper.runNow`                   | Bool | `false` | Run the scraper immediately on schedule registration   |
 | `scraper.watch.disable`            | Bool | `false` | Disable Kubernetes watch/informer for a scraper        |
+| `scraper.history.external_entities` | Bool | `false` | Populate external_*.entities in scrape summaries      |
 | `scraper.azure.devops.incremental` | Bool | `true`  | Enable incremental scraping for Azure DevOps pipelines |
 
 ## Event Processing

--- a/db/external_entities.go
+++ b/db/external_entities.go
@@ -123,13 +123,15 @@ func syncExternalEntities(ctx api.ScrapeContext, extract *extractResult, scraper
 
 	result.Users.Saved = counts.usersSaved
 	result.Users.Deleted = counts.usersDeleted
-	result.Users.Entities = resolvedUsers
 	result.Groups.Saved = counts.groupsSaved
 	result.Groups.Deleted = counts.groupsDeleted
-	result.Groups.Entities = resolvedGroups
 	result.Roles.Saved = counts.rolesSaved
 	result.Roles.Deleted = counts.rolesDeleted
-	result.Roles.Entities = resolvedRoles
+	if ctx.PropertyOn(false, "scraper.history.external_entities") {
+		result.Users.Entities = resolvedUsers
+		result.Groups.Entities = resolvedGroups
+		result.Roles.Entities = resolvedRoles
+	}
 	return result, synced, nil
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to control whether external entities (users, groups, roles) are included in scrape summaries. This setting is disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->