### PR TITLE
chore: do not emit warning for missing k8s config access

### DIFF
--- a/db/update.go
+++ b/db/update.go
@@ -682,12 +682,16 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 				summary.ConfigAccess.Skipped++
 				continue
 			} else if config == "" {
-				summary.AddScrapeWarning(v1.Warning{
-					Error:  fmt.Sprintf("config access references unknown config %s", configAccess.ConfigExternalID.Pretty().ANSI()),
-					Input:  extractResult.transformInput,
-					Expr:   extractResult.transformExpr,
-					Result: configAccess,
-				})
+				// Certain kubernetes items are excluded, and sometimes accesses are for multiple configurations
+				// where certain entities might not exist
+				if ctx.ScrapeConfig().Type() != "kubernetes" {
+					summary.AddScrapeWarning(v1.Warning{
+						Error:  fmt.Sprintf("config access references unknown config %s", configAccess.ConfigExternalID.Pretty().ANSI()),
+						Input:  extractResult.transformInput,
+						Expr:   extractResult.transformExpr,
+						Result: configAccess,
+					})
+				}
 				summary.ConfigAccess.Skipped++
 				continue
 			}


### PR DESCRIPTION
These entities do not exist in kubernetes cluster

<img width="872" height="579" alt="image" src="https://github.com/user-attachments/assets/6183eb28-ad54-4333-accc-6d6911aca252" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary warning logs for Kubernetes environments during configuration access resolution, while maintaining proper tracking of skipped configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/config-db/pull/2209)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->