### PR TITLE
refactor: use duty config change dedupe

### DIFF
--- a/db/change_traversal.go
+++ b/db/change_traversal.go
@@ -25,10 +25,7 @@ func resolveChange(change *v1.ChangeResult, action string, targetConfigID string
 		ExternalCreatedBy: change.CreatedBy,
 		CreatedAt:         change.CreatedAt,
 		Action:            action,
-	}
-
-	if change.Diff != nil {
-		change.Resolved.Diff = change.Diff
+		Diff:              change.Diff,
 	}
 }
 

--- a/db/changes.go
+++ b/db/changes.go
@@ -1,76 +1,67 @@
 package db
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/flanksource/config-db/api"
 	"github.com/flanksource/config-db/db/models"
 	"github.com/flanksource/duty/context"
-	"github.com/patrickmn/go-cache"
+	dutyModels "github.com/flanksource/duty/models"
 )
 
-var ChangeCacheByFingerprint = cache.New(time.Hour, time.Hour)
-
-func changeFingeprintCacheKey(configID, fingerprint string) string {
-	return fmt.Sprintf("%s:%s", configID, fingerprint)
-}
-
 func InitChangeFingerprintCache(ctx context.Context, window time.Duration) error {
-	var changes []*models.ConfigChange
-	if err := ctx.DB().Where("fingerprint IS NOT NULL").Where(fmt.Sprintf("created_at >= NOW() - INTERVAL '%d SECOND'", int(window.Seconds()))).Find(&changes).Error; err != nil {
-		return err
-	}
-
-	ctx.Logger.Debugf("initializing changes cache with %d changes", len(changes))
-
-	for _, c := range changes {
-		key := changeFingeprintCacheKey(c.ConfigID, *c.Fingerprint)
-		ChangeCacheByFingerprint.Set(key, c.ID, time.Until(c.CreatedAt.Add(window)))
-	}
-
-	return nil
+	return dutyModels.InitChangeFingerprintCache(ctx.DB(), window, ctx.Logger.Debugf)
 }
 
-func dedupChanges(window time.Duration, changes []*models.ConfigChange) ([]*models.ConfigChange, []models.ConfigChangeUpdate) {
-	if len(changes) == 0 {
-		return nil, nil
-	}
+// configChangeUpdate keeps the rest of config-db working with its local
+// ConfigChange model while duty owns the dedupe decision/result shape.
+type configChangeUpdate struct {
+	Change         *models.ConfigChange
+	CountIncrement int
+	FirstInBatch   bool
+}
 
-	var nonDuped []*models.ConfigChange
-	var fingerprinted = map[string]models.ConfigChangeUpdate{}
+// dedupChanges is a temporary compatibility shim around duty's ConfigChange
+// deduper.
+//
+// duty now owns fingerprint cache initialization and dedupe behavior, but
+// config-db still uses its local db/models.ConfigChange in the scrape pipeline.
+// Until that model is fully replaced with duty/models.ConfigChange, this helper
+// projects the fields required by duty's deduper (ID, ConfigID, Fingerprint),
+// calls dutyModels.DedupConfigChanges, then maps the dedupe decisions back onto
+// the original config-db change objects.
+func dedupChanges(window time.Duration, changes []*models.ConfigChange) ([]*models.ConfigChange, []configChangeUpdate) {
+	dutyChanges := make([]*dutyModels.ConfigChange, 0, len(changes))
+	originals := make(map[*dutyModels.ConfigChange]*models.ConfigChange, len(changes))
 
 	for _, change := range changes {
-		if change.Fingerprint == nil {
-			nonDuped = append(nonDuped, change)
-			continue
+		dutyChange := &dutyModels.ConfigChange{
+			ID:          change.ID,
+			ConfigID:    change.ConfigID,
+			Fingerprint: change.Fingerprint,
 		}
-
-		key := changeFingeprintCacheKey(change.ConfigID, *change.Fingerprint)
-		if existingChangeID, ok := ChangeCacheByFingerprint.Get(key); !ok {
-			ChangeCacheByFingerprint.Set(key, change.ID, window)
-			fingerprinted[change.ID] = models.ConfigChangeUpdate{Change: change, CountIncrement: 0, FirstInBatch: true}
-		} else {
-			change.ID = existingChangeID.(string)
-			ChangeCacheByFingerprint.Set(key, change.ID, window) // Refresh the cache expiry
-
-			if existing, ok := fingerprinted[change.ID]; ok {
-				// Preserve the original change, just increment the count
-				fingerprinted[change.ID] = models.ConfigChangeUpdate{Change: existing.Change, CountIncrement: existing.CountIncrement + 1, FirstInBatch: existing.FirstInBatch}
-			} else {
-				fingerprinted[change.ID] = models.ConfigChangeUpdate{Change: change, CountIncrement: 1, FirstInBatch: false}
-			}
-		}
+		dutyChanges = append(dutyChanges, dutyChange)
+		originals[dutyChange] = change
 	}
 
-	var deduped []models.ConfigChangeUpdate
-	for _, v := range fingerprinted {
-		if v.FirstInBatch || v.CountIncrement == 0 {
-			// First occurrence in the batch will be inserted
-			nonDuped = append(nonDuped, v.Change)
-		} else {
-			deduped = append(deduped, v)
-		}
+	nonDupedDuty, dedupedDuty := dutyModels.DedupConfigChanges(window, dutyChanges)
+
+	nonDuped := make([]*models.ConfigChange, 0, len(nonDupedDuty))
+	for _, dutyChange := range nonDupedDuty {
+		change := originals[dutyChange]
+		change.ID = dutyChange.ID
+		nonDuped = append(nonDuped, change)
+	}
+
+	deduped := make([]configChangeUpdate, 0, len(dedupedDuty))
+	for _, dutyUpdate := range dedupedDuty {
+		change := originals[dutyUpdate.Change]
+		change.ID = dutyUpdate.Change.ID
+		deduped = append(deduped, configChangeUpdate{
+			Change:         change,
+			CountIncrement: dutyUpdate.CountIncrement,
+			FirstInBatch:   dutyUpdate.FirstInBatch,
+		})
 	}
 
 	return nonDuped, deduped

--- a/db/changes.go
+++ b/db/changes.go
@@ -10,7 +10,7 @@ import (
 )
 
 func InitChangeFingerprintCache(ctx context.Context, window time.Duration) error {
-	return dutyModels.InitChangeFingerprintCache(ctx.DB(), window, ctx.Logger.Debugf)
+	return dutyModels.InitChangeFingerprintCache(ctx.DB(), window)
 }
 
 // configChangeUpdate keeps the rest of config-db working with its local

--- a/db/diff_test.go
+++ b/db/diff_test.go
@@ -7,13 +7,9 @@ import (
 	"runtime"
 	"runtime/debug"
 	"testing"
-	"time"
 
-	"github.com/flanksource/config-db/db/models"
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/samber/lo"
 	"github.com/shirou/gopsutil/v3/process"
 )
 
@@ -33,56 +29,6 @@ var _ = Describe("generateDiff", func() {
 		Entry("simple", "testdata/simple-new.json", "testdata/simple-old.json", "testdata/simple.diff"),
 		Entry("person", "testdata/person-new.json", "testdata/person-old.json", "testdata/person.diff"),
 	)
-})
-
-var _ = Describe("dedupChanges", func() {
-	It("deduplicates changes by fingerprint and separates non-duplicates", func() {
-		abcKey := changeFingeprintCacheKey("dae6b3f5-bc26-48ac-8ad4-06e5efbb2a7d", "abc")
-		ChangeCacheByFingerprint.Set(abcKey, "8b9d2659-7a11-46ff-bdff-1c4e8964c437", time.Hour)
-		defer func() {
-			// Clean up inserted cache keys so they don't leak into other specs
-			ChangeCacheByFingerprint.Delete(abcKey)
-			ChangeCacheByFingerprint.Delete(changeFingeprintCacheKey("dae6b3f5-bc26-48ac-8ad4-06e5efbb2a7d", "xyz"))
-		}()
-
-		changes := []*models.ConfigChange{
-			{ID: "8b9d2659-7a11-46ff-bdff-1c4e8964c437", CreatedAt: time.Date(2024, 01, 02, 0, 0, 0, 0, time.UTC), Fingerprint: lo.ToPtr("abc"), ConfigID: "dae6b3f5-bc26-48ac-8ad4-06e5efbb2a7d", Summary: "first", Count: 1},
-			{ID: uuid.NewString(), CreatedAt: time.Date(2024, 02, 02, 0, 0, 0, 0, time.UTC), Fingerprint: lo.ToPtr("abc"), ConfigID: "dae6b3f5-bc26-48ac-8ad4-06e5efbb2a7d", Summary: "second", Count: 1},
-			{ID: uuid.NewString(), CreatedAt: time.Date(2024, 03, 02, 0, 0, 0, 0, time.UTC), Fingerprint: lo.ToPtr("abc"), ConfigID: "dae6b3f5-bc26-48ac-8ad4-06e5efbb2a7d", Summary: "third", Count: 1},
-			{ID: uuid.NewString(), CreatedAt: time.Date(2024, 04, 02, 0, 0, 0, 0, time.UTC), Fingerprint: lo.ToPtr("abc"), ConfigID: "dae6b3f5-bc26-48ac-8ad4-06e5efbb2a7d", Summary: "fourth", Count: 1},
-			{ID: "01eda583-3f5e-4c44-851f-93ac73272b92", CreatedAt: time.Date(2024, 04, 02, 0, 0, 0, 0, time.UTC), Fingerprint: lo.ToPtr("xyz"), ConfigID: "dae6b3f5-bc26-48ac-8ad4-06e5efbb2a7d", Summary: "different", Count: 1},
-			{ID: uuid.NewString(), CreatedAt: time.Date(2024, 04, 03, 0, 0, 0, 0, time.UTC), Fingerprint: lo.ToPtr("xyz"), ConfigID: "dae6b3f5-bc26-48ac-8ad4-06e5efbb2a7d", Summary: "different two", Count: 1},
-		}
-
-		expectedDeduped := []models.ConfigChangeUpdate{
-			{
-				Change: &models.ConfigChange{
-					ID:          "8b9d2659-7a11-46ff-bdff-1c4e8964c437",
-					CreatedAt:   time.Date(2024, 01, 02, 0, 0, 0, 0, time.UTC),
-					Fingerprint: lo.ToPtr("abc"),
-					ConfigID:    "dae6b3f5-bc26-48ac-8ad4-06e5efbb2a7d",
-					Summary:     "first",
-					Count:       1,
-				},
-				CountIncrement: 4,
-			},
-		}
-
-		expectedNonDuped := []*models.ConfigChange{
-			{
-				ID:          "01eda583-3f5e-4c44-851f-93ac73272b92",
-				CreatedAt:   time.Date(2024, 04, 02, 0, 0, 0, 0, time.UTC),
-				Fingerprint: lo.ToPtr("xyz"),
-				ConfigID:    "dae6b3f5-bc26-48ac-8ad4-06e5efbb2a7d",
-				Summary:     "different",
-				Count:       1,
-			},
-		}
-
-		nonDuped, deduped := dedupChanges(time.Hour, changes)
-		Expect(deduped).To(Equal(expectedDeduped))
-		Expect(nonDuped).To(Equal(expectedNonDuped))
-	})
 })
 
 // go test -benchmem -run=^$ -bench ^BenchmarkDiffGenerator$ github.com/flanksource/config-db/db -count=5 -benchtime=10s -v -memprofile memprofile.out -cpuprofile profile.out

--- a/db/models/config_change.go
+++ b/db/models/config_change.go
@@ -14,12 +14,6 @@ import (
 	v1 "github.com/flanksource/config-db/api/v1"
 )
 
-type ConfigChangeUpdate struct {
-	Change         *ConfigChange
-	CountIncrement int
-	FirstInBatch   bool // First occurrence in current batch (not found in cache)
-}
-
 // ConfigChange represents the config change database table
 type ConfigChange struct {
 	ExternalID string `gorm:"-"`

--- a/db/update.go
+++ b/db/update.go
@@ -915,7 +915,7 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 
 	dedupWindow := ctx.Properties().Duration("changes.dedup.window", time.Hour)
 	var newChanges []*models.ConfigChange
-	var deduped []models.ConfigChangeUpdate
+	var deduped []configChangeUpdate
 
 	if ctx.Properties().On(false, "changes.dedup.disable") {
 		newChanges = extractResult.newChanges

--- a/debug.go
+++ b/debug.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flanksource/config-db/scrapers"
 	"github.com/flanksource/config-db/scrapers/kubernetes"
 	"github.com/flanksource/config-db/utils"
+	dutyModels "github.com/flanksource/duty/models"
 	"github.com/labstack/echo/v4"
 )
 
@@ -42,7 +43,7 @@ func init() {
 	utils.TrackObject("ScraperTempCache", &api.ScraperTempCache)
 	utils.TrackObject("IgnoreCache", &kubernetes.IgnoreCache)
 	utils.TrackObject("OrphanCache", &db.OrphanCache)
-	utils.TrackObject("ChangeCacheByFingerprint", &db.ChangeCacheByFingerprint)
+	utils.TrackObject("ChangeCacheByFingerprint", &dutyModels.ChangeCacheByFingerprint)
 	utils.TrackObject("ParentCache", &db.ParentCache)
 	utils.TrackObject("ResourceIDMapPerCluster", &kubernetes.ResourceIDMapPerCluster)
 }

--- a/go.mod
+++ b/go.mod
@@ -166,12 +166,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kms v1.49.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.10 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bmatcuk/doublestar v1.3.4 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
-	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/casbin/casbin/v2 v2.135.0 // indirect
 	github.com/casbin/casbin/v3 v3.8.1 // indirect
 	github.com/casbin/gorm-adapter/v3 v3.41.0 // indirect
@@ -273,7 +271,6 @@ require (
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/henvic/httpretty v0.1.4 // indirect
 	github.com/hirochachacha/go-smb2 v1.1.0 // indirect
-	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/itchyny/gojq v0.12.19 // indirect
 	github.com/itchyny/timefmt-go v0.1.8 // indirect
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6 // indirect
@@ -298,7 +295,6 @@ require (
 	github.com/lrita/cmap v0.0.0-20231108122212-cb084a67f554 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
-	github.com/mailru/easyjson v0.9.1 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/microsoft/kiota-serialization-form-go v1.1.3 // indirect
 	github.com/microsoft/kiota-serialization-json-go v1.1.2 // indirect
@@ -360,12 +356,8 @@ require (
 	github.com/vadimi/go-http-ntlm v1.0.3 // indirect
 	github.com/vadimi/go-http-ntlm/v2 v2.5.0 // indirect
 	github.com/vadimi/go-ntlm v1.2.1 // indirect
-	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
-	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/xuri/efp v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,6 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
-github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
-github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -357,8 +355,6 @@ github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
 github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
-github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
-github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c/go.mod h1:l/bIBLeOl9eX+wxJAzxS4TveKRtAqlyDpHjhkfO0MEI=
 github.com/casbin/casbin/v2 v2.135.0 h1:6BLkMQiGotYyS5yYeWgW19vxqugUlvHFkFiLnLR/bxk=
 github.com/casbin/casbin/v2 v2.135.0/go.mod h1:FmcfntdXLTcYXv/hxgNntcRPqAbwOG9xsism0yXT+18=
@@ -816,8 +812,6 @@ github.com/hirochachacha/go-smb2 v1.1.0/go.mod h1:8F1A4d5EZzrGu5R7PU163UcMRDJQl4
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
-github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/itchyny/gojq v0.12.19 h1:ttXA0XCLEMoaLOz5lSeFOZ6u6Q3QxmG46vfgI4O0DEs=
 github.com/itchyny/gojq v0.12.19/go.mod h1:5galtVPDywX8SPSOrqjGxkBeDhSxEW1gSxoy7tn1iZY=
 github.com/itchyny/timefmt-go v0.1.8 h1:1YEo1JvfXeAHKdjelbYr/uCuhkybaHCeTkH8Bo791OI=
@@ -930,8 +924,6 @@ github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 h1:PwQumkgq4/acIi
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/mailru/easyjson v0.9.1 h1:LbtsOm5WAswyWbvTEOqhypdPeZzHavpZx96/n553mR8=
-github.com/mailru/easyjson v0.9.1/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
@@ -1238,8 +1230,6 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
-github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
-github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
@@ -1247,12 +1237,6 @@ github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
 github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
-github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
-github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
-github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
-github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
-github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
-github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xhit/go-str2duration v1.2.0/go.mod h1:3cPSlfZlUHVlneIVfePFWcJZsuwf+P1v2SRTV4cUmp4=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=


### PR DESCRIPTION
Config change dedupe has moved to duty so the fingerprint cache and dedupe behavior can be shared.

Delegate cache initialization and dedupe decisions to duty, while keeping a temporary compatibility shim for config-db's local ConfigChange model.

Depends on flanksource/duty#1971.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed unused/indirect project dependencies.

* **Refactor**
  * Streamlined configuration change diff assignment.
  * Reworked change fingerprint cache and deduplication to use shared duty logic.
  * Updated change deduplication update shape to match the new dedupe flow.
  * Adjusted debug/memsize tracking to reference the centralized cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->