### PR TITLE
feat(kubernetes): Add missioncontrol/connectionType config label for

### DIFF
--- a/scrapers/kubernetes/kubernetes.go
+++ b/scrapers/kubernetes/kubernetes.go
@@ -38,6 +38,7 @@ const (
 	KindDeployment  = "Deployment"
 	KindDaemonSet   = "DaemonSet"
 	KindJob         = "Job"
+	KindConnection  = "Connection"
 )
 
 var ResourceIDMapPerCluster PerClusterResourceIDMap
@@ -342,6 +343,11 @@ func ExtractResults(ctx *KubernetesContext, objs []*unstructured.Unstructured) v
 		}
 
 		switch obj.GetKind() {
+		case KindConnection:
+			if obj.GetAPIVersion() == "mission-control.flanksource.com/v1" {
+				maps.Copy(labels, mcConnectionTypeLabel(obj))
+			}
+
 		case KindPod:
 			nodeName := getString(obj, "spec", "nodeName")
 

--- a/scrapers/kubernetes/mission_control.go
+++ b/scrapers/kubernetes/mission_control.go
@@ -1,0 +1,53 @@
+package kubernetes
+
+import (
+	"sort"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const connectionTypeLabel = "missioncontrol/connectionType"
+
+var nonConnectionTypeSpecFields = map[string]struct{}{
+	"properties":   {},
+	"url":          {},
+	"port":         {},
+	"type":         {},
+	"username":     {},
+	"password":     {},
+	"certificate":  {},
+	"insecure_tls": {},
+}
+
+// Takes in a mission-control connection object and returns the connection type as a label for the config item
+func mcConnectionTypeLabel(obj *unstructured.Unstructured) map[string]string {
+	labels := make(map[string]string)
+
+	spec, ok := obj.Object["spec"].(map[string]any)
+	if !ok {
+		return labels
+	}
+
+	// deprecated approach where the type is explicitly defined in the spec
+	if t, ok := spec["type"].(string); ok && t != "" {
+		labels[connectionTypeLabel] = t
+		return labels
+	}
+
+	keys := make([]string, 0, len(spec))
+	for key, value := range spec {
+		if _, ignored := nonConnectionTypeSpecFields[key]; ignored || value == nil {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	if len(keys) > 0 {
+		// Connection Objects are expected to have only one connection defined.
+		// If more than one is defined, we choose the first one.
+		labels[connectionTypeLabel] = keys[0]
+	}
+
+	return labels
+}


### PR DESCRIPTION
mission-control Connection custom resources.

This is to make it easier to select connections by type in resource selector.
* can be used by plugins to only attach themselves to certain type of connections. Example: postgres plugin
* can be used by playbooks for the same reason