### PR TITLE
fix: use valid mission control connection type label

### DIFF
--- a/scrapers/kubernetes/mission_control.go
+++ b/scrapers/kubernetes/mission_control.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-const connectionTypeLabel = "missioncontrol/connectionType"
+const connectionTypeLabel = "mission-control/connection-type"
 
 var nonConnectionTypeSpecFields = map[string]struct{}{
 	"properties":   {},


### PR DESCRIPTION
Kubernetes label selectors cannot use the existing `missioncontrol/connectionType` label key because the name segment contains uppercase characters.

Rename the label to `mission-control/connection-type` so mission-control connection configs can be selected using valid Kubernetes label selector syntax.