### PR TITLE
 fix: allow GitHub scraper to work without a token

### DIFF
--- a/scrapers/github/client.go
+++ b/scrapers/github/client.go
@@ -155,18 +155,34 @@ func (c *GitHubClient) GetSecretScanningAlerts(ctx context.Context, opts AlertLi
 	return allAlerts, nil
 }
 
+func githubRateLimitPauseThreshold(limit int) int {
+	threshold := limit / 10
+	if threshold < 1 {
+		return 1
+	}
+	if threshold > 100 {
+		return 100
+	}
+	return threshold
+}
+
 func (c *GitHubClient) ShouldPauseForRateLimit(ctx context.Context) (bool, time.Duration, error) {
 	rateLimits, _, err := c.Client.RateLimit.Get(ctx)
 	if err != nil {
 		return false, 0, err
 	}
+	if rateLimits == nil || rateLimits.Core == nil {
+		return false, 0, nil
+	}
 
-	c.ScrapeContext.Logger.V(3).Infof("GitHub rate limit: remaining=%d, limit=%d",
-		rateLimits.Core.Remaining, rateLimits.Core.Limit)
+	core := rateLimits.Core
+	threshold := githubRateLimitPauseThreshold(core.Limit)
 
-	const threshold = 100
-	if rateLimits.Core.Remaining < threshold {
-		waitDuration := time.Until(rateLimits.Core.Reset.Time)
+	c.ScrapeContext.Logger.V(3).Infof("GitHub rate limit: remaining=%d, limit=%d, threshold=%d",
+		core.Remaining, core.Limit, threshold)
+
+	if core.Remaining < threshold {
+		waitDuration := time.Until(core.Reset.Time)
 		return true, waitDuration, nil
 	}
 

--- a/scrapers/github/client_test.go
+++ b/scrapers/github/client_test.go
@@ -1,0 +1,25 @@
+package github
+
+import "testing"
+
+func TestGithubRateLimitPauseThreshold(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit int
+		want  int
+	}{
+		{name: "unauthenticated", limit: 60, want: 6},
+		{name: "authenticated", limit: 5000, want: 100},
+		{name: "small limit", limit: 10, want: 1},
+		{name: "zero limit", limit: 0, want: 1},
+		{name: "negative limit", limit: -1, want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := githubRateLimitPauseThreshold(tt.limit); got != tt.want {
+				t.Fatalf("githubRateLimitPauseThreshold(%d) = %d, want %d", tt.limit, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Public GitHub repository scraping can run without a token, but unauthenticated clients only get 60 core requests/hour.

The scraper used a fixed 100-request pause threshold, so tokenless clients were treated as rate-limited immediately.

Compute the pause threshold from the actual core limit, clamped between 1 and 100, and handle missing rate-limit data defensively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub rate-limit handling so the app pauses more intelligently when API quota is running low.
  * Updated status logging to show the current limit, remaining requests, and the pause threshold for clearer visibility during syncs.

* **Tests**
  * Added coverage for several rate-limit scenarios, including unauthenticated, authenticated, and edge-case values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->