### PR TITLE
feat(github): support repository pattern

### DIFF
--- a/api/v1/github.go
+++ b/api/v1/github.go
@@ -58,7 +58,7 @@ type GitHubRepository struct {
 	Owner string `yaml:"owner" json:"owner"`
 
 	// Repo can be an exact repository name or comma-separated collections.MatchItems patterns.
-	// Pattern selectors discover matching non-archived repositories for Owner and must be the only repository entry.
+	// Pattern selectors discover matching non-archived repositories for Owner.
 	Repo string `yaml:"repo" json:"repo"`
 }
 

--- a/api/v1/github.go
+++ b/api/v1/github.go
@@ -53,10 +53,13 @@ type GitHub struct {
 	SecurityFilters GitHubSecurityFilters `yaml:"securityFilters,omitempty" json:"securityFilters,omitempty"`
 }
 
-// GitHubRepository specifies a repository to scrape
+// GitHubRepository specifies a repository or repository selector to scrape.
 type GitHubRepository struct {
 	Owner string `yaml:"owner" json:"owner"`
-	Repo  string `yaml:"repo" json:"repo"`
+
+	// Repo can be an exact repository name or comma-separated collections.MatchItems patterns.
+	// Pattern selectors discover matching non-archived repositories for Owner and must be the only repository entry.
+	Repo string `yaml:"repo" json:"repo"`
 }
 
 // GitHubSecurityFilters defines filtering options for security alerts

--- a/chart/crds/configs.flanksource.com_scrapeconfigs.yaml
+++ b/chart/crds/configs.flanksource.com_scrapeconfigs.yaml
@@ -5924,11 +5924,17 @@ spec:
                     repositories:
                       description: Repositories is the list of repositories to scrape
                       items:
-                        description: GitHubRepository specifies a repository to scrape
+                        description: GitHubRepository specifies a repository or repository
+                          selector to scrape.
                         properties:
                           owner:
                             type: string
                           repo:
+                            description: Exact repository name or comma-separated
+                              collections.MatchItems patterns (`*`, `prefix*`, `*suffix`,
+                              `!name`). Pattern selectors discover matching non-archived
+                              repositories for owner and must be the only repository
+                              entry.
                             type: string
                         required:
                         - owner

--- a/chart/crds/configs.flanksource.com_scrapeconfigs.yaml
+++ b/chart/crds/configs.flanksource.com_scrapeconfigs.yaml
@@ -5933,8 +5933,7 @@ spec:
                             description: Exact repository name or comma-separated
                               collections.MatchItems patterns (`*`, `prefix*`, `*suffix`,
                               `!name`). Pattern selectors discover matching non-archived
-                              repositories for owner and must be the only repository
-                              entry.
+                              repositories for owner.
                             type: string
                         required:
                         - owner

--- a/config/schemas/config_github.schema.json
+++ b/config/schemas/config_github.schema.json
@@ -294,7 +294,8 @@
           "type": "string"
         },
         "repo": {
-          "type": "string"
+          "type": "string",
+          "description": "Exact repository name or comma-separated collections.MatchItems patterns (`*`, `prefix*`, `*suffix`, `!name`). Pattern selectors discover matching non-archived repositories for owner and must be the only repository entry."
         }
       },
       "additionalProperties": false,
@@ -303,7 +304,7 @@
         "owner",
         "repo"
       ],
-      "description": "GitHubRepository specifies a repository to scrape"
+      "description": "GitHubRepository specifies a repository or repository selector to scrape."
     },
     "GitHubSecurityFilters": {
       "properties": {

--- a/config/schemas/config_github.schema.json
+++ b/config/schemas/config_github.schema.json
@@ -295,7 +295,7 @@
         },
         "repo": {
           "type": "string",
-          "description": "Exact repository name or comma-separated collections.MatchItems patterns (`*`, `prefix*`, `*suffix`, `!name`). Pattern selectors discover matching non-archived repositories for owner and must be the only repository entry."
+          "description": "Exact repository name or comma-separated collections.MatchItems patterns (`*`, `prefix*`, `*suffix`, `!name`). Pattern selectors discover matching non-archived repositories for owner."
         }
       },
       "additionalProperties": false,

--- a/config/schemas/scrape_config.schema.json
+++ b/config/schemas/scrape_config.schema.json
@@ -2096,7 +2096,8 @@
           "type": "string"
         },
         "repo": {
-          "type": "string"
+          "type": "string",
+          "description": "Exact repository name or comma-separated collections.MatchItems patterns (`*`, `prefix*`, `*suffix`, `!name`). Pattern selectors discover matching non-archived repositories for owner and must be the only repository entry."
         }
       },
       "additionalProperties": false,
@@ -2105,7 +2106,7 @@
         "owner",
         "repo"
       ],
-      "description": "GitHubRepository specifies a repository to scrape"
+      "description": "GitHubRepository specifies a repository or repository selector to scrape."
     },
     "GitHubSecurityFilters": {
       "properties": {

--- a/config/schemas/scrape_config.schema.json
+++ b/config/schemas/scrape_config.schema.json
@@ -2097,7 +2097,7 @@
         },
         "repo": {
           "type": "string",
-          "description": "Exact repository name or comma-separated collections.MatchItems patterns (`*`, `prefix*`, `*suffix`, `!name`). Pattern selectors discover matching non-archived repositories for owner and must be the only repository entry."
+          "description": "Exact repository name or comma-separated collections.MatchItems patterns (`*`, `prefix*`, `*suffix`, `!name`). Pattern selectors discover matching non-archived repositories for owner."
         }
       },
       "additionalProperties": false,

--- a/fixtures/github-repo-selectors.yaml
+++ b/fixtures/github-repo-selectors.yaml
@@ -1,0 +1,18 @@
+apiVersion: configs.flanksource.com/v1
+kind: ScrapeConfig
+metadata:
+  name: github-repo-selectors
+spec:
+  schedule: '@every 6h'
+  github:
+    - repositories:
+        # Repo selectors use collections.MatchItems syntax and are resolved
+        # against all visible, non-archived repositories for the owner.
+        - owner: flanksource
+          repo: config-db,mission-control
+        # Overlapping selectors are deduped per GitHub scraper config.
+        - owner: flanksource
+          repo: '*control'
+        # Exact repositories can be mixed with selectors.
+        - owner: flanksource
+          repo: duty

--- a/scrapers/github/client.go
+++ b/scrapers/github/client.go
@@ -22,8 +22,12 @@ const defaultWorkflowRunMaxAge = 7 * 24 * time.Hour
 type GitHubClient struct {
 	*github.Client
 	api.ScrapeContext
-	owner         string
-	repo          string
+	owner string
+	repo  string
+
+	// authenticated is true when this client was created with a GitHub token.
+	// It lets user-owner selectors use /user/repos for private repos owned by
+	// the authenticated user instead of the public-only /users/{user}/repos API.
 	authenticated bool
 }
 

--- a/scrapers/github/client.go
+++ b/scrapers/github/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	gohttp "net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/go-github/v73/github"
@@ -21,8 +22,9 @@ const defaultWorkflowRunMaxAge = 7 * 24 * time.Hour
 type GitHubClient struct {
 	*github.Client
 	api.ScrapeContext
-	owner string
-	repo  string
+	owner         string
+	repo          string
+	authenticated bool
 }
 
 func NewGitHubClient(ctx api.ScrapeContext, config v1.GitHub, owner, repo string) (*GitHubClient, error) {
@@ -58,6 +60,7 @@ func NewGitHubClient(ctx api.ScrapeContext, config v1.GitHub, owner, repo string
 		Client:        client,
 		owner:         owner,
 		repo:          repo,
+		authenticated: token != "",
 	}, nil
 }
 
@@ -171,6 +174,115 @@ func (c *GitHubClient) ShouldPauseForRateLimit(ctx context.Context) (bool, time.
 	}
 
 	return false, 0, nil
+}
+
+func (c *GitHubClient) ListRepositoriesForOwner(ctx context.Context, owner string) ([]*github.Repository, error) {
+	ownerInfo, _, err := c.Client.Users.Get(ctx, owner)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get GitHub owner %s: %w", owner, err)
+	}
+
+	if ownerInfo.GetType() == "Organization" {
+		return c.ListOrganizationRepositories(ctx, owner)
+	}
+
+	if c.authenticated && c.isAuthenticatedOwner(ctx, owner) {
+		return c.ListAuthenticatedOwnerRepositories(ctx)
+	}
+
+	return c.ListUserRepositories(ctx, owner)
+}
+
+func (c *GitHubClient) ListOrganizationRepositories(ctx context.Context, owner string) ([]*github.Repository, error) {
+	var allRepos []*github.Repository
+	opts := &github.RepositoryListByOrgOptions{
+		Type:      "all",
+		Sort:      "full_name",
+		Direction: "asc",
+		ListOptions: github.ListOptions{
+			PerPage: 100,
+		},
+	}
+
+	for {
+		repos, resp, err := c.Client.Repositories.ListByOrg(ctx, owner, opts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list repositories for organization %s: %w", owner, err)
+		}
+
+		allRepos = append(allRepos, repos...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return allRepos, nil
+}
+
+func (c *GitHubClient) ListUserRepositories(ctx context.Context, owner string) ([]*github.Repository, error) {
+	var allRepos []*github.Repository
+	opts := &github.RepositoryListByUserOptions{
+		Type:      "owner",
+		Sort:      "full_name",
+		Direction: "asc",
+		ListOptions: github.ListOptions{
+			PerPage: 100,
+		},
+	}
+
+	for {
+		repos, resp, err := c.Client.Repositories.ListByUser(ctx, owner, opts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list repositories for user %s: %w", owner, err)
+		}
+
+		allRepos = append(allRepos, repos...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return allRepos, nil
+}
+
+func (c *GitHubClient) ListAuthenticatedOwnerRepositories(ctx context.Context) ([]*github.Repository, error) {
+	var allRepos []*github.Repository
+	opts := &github.RepositoryListByAuthenticatedUserOptions{
+		Visibility:  "all",
+		Affiliation: "owner",
+		Sort:        "full_name",
+		Direction:   "asc",
+		ListOptions: github.ListOptions{
+			PerPage: 100,
+		},
+	}
+
+	for {
+		repos, resp, err := c.Client.Repositories.ListByAuthenticatedUser(ctx, opts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list repositories for authenticated user: %w", err)
+		}
+
+		allRepos = append(allRepos, repos...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return allRepos, nil
+}
+
+func (c *GitHubClient) isAuthenticatedOwner(ctx context.Context, owner string) bool {
+	user, _, err := c.Client.Users.Get(ctx, "")
+	if err != nil {
+		c.ScrapeContext.Logger.V(3).Infof("failed to get authenticated GitHub user: %v", err)
+		return false
+	}
+
+	return strings.EqualFold(user.GetLogin(), owner)
 }
 
 type GitHubActionsClient struct {

--- a/scrapers/github/scraper.go
+++ b/scrapers/github/scraper.go
@@ -107,59 +107,79 @@ func (gh GithubScraper) Scrape(ctx api.ScrapeContext) v1.ScrapeResults {
 }
 
 func resolveRepositoryConfigs(ctx api.ScrapeContext, config v1.GitHub, results *v1.ScrapeResults) ([]v1.GitHubRepository, bool) {
-	if !hasRepositorySelector(config.Repositories) {
-		return config.Repositories, false
-	}
+	var resolved []v1.GitHubRepository
+	seen := make(map[string]struct{})
+	ownerRepos := make(map[string][]*github.Repository)
 
-	if len(config.Repositories) != 1 {
-		results.Errorf(
-			fmt.Errorf("repository selector must be the only repository entry in a GitHub scraper"),
-			"invalid GitHub repository selector",
-		)
-		return nil, false
-	}
+	for _, repoConfig := range config.Repositories {
+		owner := strings.TrimSpace(repoConfig.Owner)
+		if owner == "" {
+			results.Errorf(fmt.Errorf("owner is required"), "invalid GitHub repository")
+			continue
+		}
 
-	repoConfig := config.Repositories[0]
-	owner := strings.TrimSpace(repoConfig.Owner)
-	if owner == "" {
-		results.Errorf(fmt.Errorf("owner is required"), "invalid GitHub repository selector")
-		return nil, false
-	}
+		repoConfig.Owner = owner
+		repoConfig.Repo = strings.TrimSpace(repoConfig.Repo)
 
-	client, err := NewGitHubClient(ctx, config, owner, "")
-	if err != nil {
-		results.Errorf(err, "failed to create GitHub client for %s", owner)
-		return nil, false
-	}
+		if !isRepositorySelector(repoConfig.Repo) {
+			resolved = appendRepositoryConfig(resolved, seen, repoConfig)
+			continue
+		}
 
-	if shouldPause, duration, err := client.ShouldPauseForRateLimit(ctx); err != nil {
-		results.Errorf(err, "failed to check rate limit for %s", owner)
-		return nil, false
-	} else if shouldPause {
-		resetAt := time.Now().Add(duration)
-		results.RateLimited(fmt.Sprintf("GitHub API rate limit for %s", owner), &resetAt)
-		return nil, true
-	}
+		ownerKey := strings.ToLower(owner)
+		repos, ok := ownerRepos[ownerKey]
+		if !ok {
+			client, err := NewGitHubClient(ctx, config, owner, "")
+			if err != nil {
+				results.Errorf(err, "failed to create GitHub client for %s", owner)
+				continue
+			}
 
-	repos, err := client.ListRepositoriesForOwner(ctx, owner)
-	if err != nil {
-		results.Errorf(err, "failed to list GitHub repositories for %s", owner)
-		return nil, false
-	}
+			if shouldPause, duration, err := client.ShouldPauseForRateLimit(ctx); err != nil {
+				results.Errorf(err, "failed to check rate limit for %s", owner)
+				continue
+			} else if shouldPause {
+				resetAt := time.Now().Add(duration)
+				results.RateLimited(fmt.Sprintf("GitHub API rate limit for %s", owner), &resetAt)
+				return nil, true
+			}
 
-	matched := matchingRepositoryConfigs(owner, repoConfig.Repo, repos)
-	ctx.Logger.V(2).Infof("resolved GitHub repository selector %s/%q to %d repositories", owner, repoConfig.Repo, len(matched))
-	return matched, false
-}
+			repos, err = client.ListRepositoriesForOwner(ctx, owner)
+			if err != nil {
+				results.Errorf(err, "failed to list GitHub repositories for %s", owner)
+				continue
+			}
+			ownerRepos[ownerKey] = repos
+		}
 
-func hasRepositorySelector(repositories []v1.GitHubRepository) bool {
-	for _, repo := range repositories {
-		if isRepositorySelector(repo.Repo) {
-			return true
+		matched := matchingRepositoryConfigs(owner, repoConfig.Repo, repos)
+		ctx.Logger.V(2).Infof("resolved GitHub repository selector %s/%q to %d repositories", owner, repoConfig.Repo, len(matched))
+		for _, repo := range matched {
+			resolved = appendRepositoryConfig(resolved, seen, repo)
 		}
 	}
 
-	return false
+	return resolved, false
+}
+
+func appendRepositoryConfig(repositories []v1.GitHubRepository, seen map[string]struct{}, repo v1.GitHubRepository) []v1.GitHubRepository {
+	repo.Owner = strings.TrimSpace(repo.Owner)
+	repo.Repo = strings.TrimSpace(repo.Repo)
+	if repo.Owner == "" || repo.Repo == "" {
+		return repositories
+	}
+
+	key := repositoryKey(repo.Owner, repo.Repo)
+	if _, ok := seen[key]; ok {
+		return repositories
+	}
+
+	seen[key] = struct{}{}
+	return append(repositories, repo)
+}
+
+func repositoryKey(owner, repo string) string {
+	return strings.ToLower(strings.TrimSpace(owner) + "/" + strings.TrimSpace(repo))
 }
 
 func isRepositorySelector(repo string) bool {

--- a/scrapers/github/scraper.go
+++ b/scrapers/github/scraper.go
@@ -28,7 +28,12 @@ func (gh GithubScraper) Scrape(ctx api.ScrapeContext) v1.ScrapeResults {
 	var results v1.ScrapeResults
 
 	for _, config := range ctx.ScrapeConfig().Spec.GitHub {
-		for _, repoConfig := range config.Repositories {
+		repositories, rateLimited := resolveRepositoryConfigs(ctx, config, &results)
+		if rateLimited {
+			return results
+		}
+
+		for _, repoConfig := range repositories {
 			if err := ctx.Err(); err != nil {
 				return results
 			}
@@ -99,6 +104,113 @@ func (gh GithubScraper) Scrape(ctx api.ScrapeContext) v1.ScrapeResults {
 	}
 
 	return results
+}
+
+func resolveRepositoryConfigs(ctx api.ScrapeContext, config v1.GitHub, results *v1.ScrapeResults) ([]v1.GitHubRepository, bool) {
+	if !hasRepositorySelector(config.Repositories) {
+		return config.Repositories, false
+	}
+
+	if len(config.Repositories) != 1 {
+		results.Errorf(
+			fmt.Errorf("repository selector must be the only repository entry in a GitHub scraper"),
+			"invalid GitHub repository selector",
+		)
+		return nil, false
+	}
+
+	repoConfig := config.Repositories[0]
+	owner := strings.TrimSpace(repoConfig.Owner)
+	if owner == "" {
+		results.Errorf(fmt.Errorf("owner is required"), "invalid GitHub repository selector")
+		return nil, false
+	}
+
+	client, err := NewGitHubClient(ctx, config, owner, "")
+	if err != nil {
+		results.Errorf(err, "failed to create GitHub client for %s", owner)
+		return nil, false
+	}
+
+	if shouldPause, duration, err := client.ShouldPauseForRateLimit(ctx); err != nil {
+		results.Errorf(err, "failed to check rate limit for %s", owner)
+		return nil, false
+	} else if shouldPause {
+		resetAt := time.Now().Add(duration)
+		results.RateLimited(fmt.Sprintf("GitHub API rate limit for %s", owner), &resetAt)
+		return nil, true
+	}
+
+	repos, err := client.ListRepositoriesForOwner(ctx, owner)
+	if err != nil {
+		results.Errorf(err, "failed to list GitHub repositories for %s", owner)
+		return nil, false
+	}
+
+	matched := matchingRepositoryConfigs(owner, repoConfig.Repo, repos)
+	ctx.Logger.V(2).Infof("resolved GitHub repository selector %s/%q to %d repositories", owner, repoConfig.Repo, len(matched))
+	return matched, false
+}
+
+func hasRepositorySelector(repositories []v1.GitHubRepository) bool {
+	for _, repo := range repositories {
+		if isRepositorySelector(repo.Repo) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isRepositorySelector(repo string) bool {
+	repo = strings.TrimSpace(repo)
+	return repo == "" || strings.Contains(repo, "*") || strings.Contains(repo, ",") || strings.HasPrefix(repo, "!")
+}
+
+func splitRepositoryPatterns(repo string) []string {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return []string{"*"}
+	}
+
+	var patterns []string
+	for _, pattern := range strings.Split(repo, ",") {
+		pattern = strings.TrimSpace(pattern)
+		if pattern != "" {
+			patterns = append(patterns, pattern)
+		}
+	}
+
+	if len(patterns) == 0 {
+		return []string{"*"}
+	}
+
+	return patterns
+}
+
+func matchingRepositoryConfigs(owner, repoPattern string, repos []*github.Repository) []v1.GitHubRepository {
+	patterns := splitRepositoryPatterns(repoPattern)
+	var matched []v1.GitHubRepository
+
+	for _, repo := range repos {
+		if repo.GetArchived() {
+			continue
+		}
+
+		repoName := repo.GetName()
+		if repoName == "" || !collections.MatchItems(repoName, patterns...) {
+			continue
+		}
+
+		repoOwner := owner
+		if apiOwner := repo.GetOwner().GetLogin(); apiOwner != "" {
+			repoOwner = apiOwner
+		}
+
+		matched = append(matched, v1.GitHubRepository{Owner: repoOwner, Repo: repoName})
+	}
+
+	return matched
 }
 
 func buildRepositoryResult(repo *github.Repository, repoConfig v1.GitHubRepository, alerts *allAlerts, scorecard *ScorecardResponse) v1.ScrapeResult {

--- a/scrapers/github/scraper_test.go
+++ b/scrapers/github/scraper_test.go
@@ -8,11 +8,45 @@ import (
 	v1 "github.com/flanksource/config-db/api/v1"
 	dutyCtx "github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
+	gogithub "github.com/google/go-github/v73/github"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("GitHubScraper", func() {
+	Context("repository selectors", func() {
+		DescribeTable("detects selector syntax",
+			func(repo string, expected bool) {
+				Expect(isRepositorySelector(repo)).To(Equal(expected))
+			},
+			Entry("exact repo", "duty", false),
+			Entry("wildcard", "*", true),
+			Entry("prefix wildcard", "config-*", true),
+			Entry("comma-separated allow-list", "duty,config-db", true),
+			Entry("exclusion-only", "!archive-*", true),
+		)
+
+		It("splits MatchItems repo patterns", func() {
+			Expect(splitRepositoryPatterns("duty, config-*, !config-test")).To(Equal([]string{"duty", "config-*", "!config-test"}))
+		})
+
+		It("selects matching repositories and ignores archived repositories", func() {
+			repos := []*gogithub.Repository{
+				{Name: gogithub.Ptr("config-db"), Owner: &gogithub.User{Login: gogithub.Ptr("flanksource")}},
+				{Name: gogithub.Ptr("config-test"), Owner: &gogithub.User{Login: gogithub.Ptr("flanksource")}},
+				{Name: gogithub.Ptr("duty"), Owner: &gogithub.User{Login: gogithub.Ptr("flanksource")}},
+				{Name: gogithub.Ptr("archived"), Owner: &gogithub.User{Login: gogithub.Ptr("flanksource")}, Archived: gogithub.Ptr(true)},
+			}
+
+			matched := matchingRepositoryConfigs("flanksource", "*,!config-test", repos)
+
+			Expect(matched).To(Equal([]v1.GitHubRepository{
+				{Owner: "flanksource", Repo: "config-db"},
+				{Owner: "flanksource", Repo: "duty"},
+			}))
+		})
+	})
+
 	Context("with security and OpenSSF enabled", func() {
 		It("should scrape repository config and analysis results", func() {
 			if os.Getenv("GITHUB_TOKEN") == "" {

--- a/scrapers/github/scraper_test.go
+++ b/scrapers/github/scraper_test.go
@@ -45,6 +45,30 @@ var _ = Describe("GitHubScraper", func() {
 				{Owner: "flanksource", Repo: "duty"},
 			}))
 		})
+
+		It("dedupes overlapping selectors and exact repositories", func() {
+			repos := []*gogithub.Repository{
+				{Name: gogithub.Ptr("mission-control"), Owner: &gogithub.User{Login: gogithub.Ptr("flanksource")}},
+				{Name: gogithub.Ptr("mission-control-ui"), Owner: &gogithub.User{Login: gogithub.Ptr("flanksource")}},
+			}
+
+			seen := make(map[string]struct{})
+			var resolved []v1.GitHubRepository
+			for _, repo := range matchingRepositoryConfigs("flanksource", "*control", repos) {
+				resolved = appendRepositoryConfig(resolved, seen, repo)
+			}
+			for _, repo := range matchingRepositoryConfigs("flanksource", "mission*", repos) {
+				resolved = appendRepositoryConfig(resolved, seen, repo)
+			}
+			resolved = appendRepositoryConfig(resolved, seen, v1.GitHubRepository{Owner: "flanksource", Repo: "duty"})
+			resolved = appendRepositoryConfig(resolved, seen, v1.GitHubRepository{Owner: "FlankSource", Repo: "MISSION-CONTROL"})
+
+			Expect(resolved).To(Equal([]v1.GitHubRepository{
+				{Owner: "flanksource", Repo: "mission-control"},
+				{Owner: "flanksource", Repo: "mission-control-ui"},
+				{Owner: "flanksource", Repo: "duty"},
+			}))
+		})
 	})
 
 	Context("with security and OpenSSF enabled", func() {


### PR DESCRIPTION
GitHub scraping previously required every repository to be listed explicitly.

Allow `repositories[].repo` to use comma-separated `collections.MatchItems` patterns, so one scraper can discover matching repositories for an owner without adding new CRD fields. Discovered archived repositories are skipped by default.

Multiple selector and exact repository entries can now coexist in a single GitHub config, with resolved repositories deduped per config.


```yaml
apiVersion: configs.flanksource.com/v1
kind: ScrapeConfig
metadata:
  name: github-repo-selectors
spec:
  schedule: '@every 6h'
  github:
    - repositories:
        # Repo selectors use collections.MatchItems syntax and are resolved
        # against all visible, non-archived repositories for the owner.
        - owner: flanksource
          repo: config-db,mission-control
        # Overlapping selectors are deduped per GitHub scraper config.
        - owner: flanksource
          repo: '*control'
        # Exact repositories can be mixed with selectors.
        - owner: flanksource
          repo: duty
```