### PR TITLE
fix(github): link OpenSSF vulnerabilities to code scanning

### DIFF
--- a/scrapers/github/openssf.go
+++ b/scrapers/github/openssf.go
@@ -209,7 +209,7 @@ func isRetryable(err error) bool {
 	return strings.Contains(err.Error(), "server error") || strings.Contains(err.Error(), "connection")
 }
 
-func createScorecardAnalyses(ctx api.ScrapeContext, results *v1.ScrapeResults, externalConfigID string, _ v1.GitHubRepository, scorecard *ScorecardResponse) {
+func createScorecardAnalyses(ctx api.ScrapeContext, results *v1.ScrapeResults, externalConfigID string, _ v1.GitHubRepository, scorecard *ScorecardResponse, codeScanningURLs map[string]string) {
 	for _, check := range scorecard.Checks {
 		a := results.Analysis(check.Name, ConfigTypeRepository, externalConfigID)
 		a.ExternalAnalysisID = fmt.Sprintf("%s::openssf/%s", v1.NormalizeExternalID(externalConfigID), check.Name)
@@ -231,6 +231,11 @@ func createScorecardAnalyses(ctx api.ScrapeContext, results *v1.ScrapeResults, e
 			a.Message(detail)
 		}
 
+		documentationURL := check.Documentation.URL
+		if url := codeScanningURLs[check.Name]; url != "" {
+			documentationURL = url
+			check.Documentation.URL = url
+		}
 		a.Analysis, _ = collections.ToJSONMap(check)
 
 		scoreVal := int64(check.Score)
@@ -242,12 +247,12 @@ func createScorecardAnalyses(ctx api.ScrapeContext, results *v1.ScrapeResults, e
 			Type:  "badge",
 			Color: badgeColor(scoreVal, maxScore),
 		})
-		if check.Documentation.URL != "" {
+		if documentationURL != "" {
 			a.Properties = append(a.Properties, &types.Property{
 				Name:  "Documentation",
 				Text:  check.Documentation.Short,
 				Type:  "url",
-				Links: []types.Link{{URL: check.Documentation.URL, Type: "documentation"}},
+				Links: []types.Link{{URL: documentationURL, Type: "documentation"}},
 			})
 		}
 	}

--- a/scrapers/github/openssf_test.go
+++ b/scrapers/github/openssf_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/flanksource/config-db/api"
+	v1 "github.com/flanksource/config-db/api/v1"
+	dutyCtx "github.com/flanksource/duty/context"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -53,5 +56,43 @@ var _ = Describe("FlexTime", func() {
 		Expect(resp.Date.Year()).To(Equal(2026))
 		Expect(resp.Date.Hour()).To(Equal(0))
 		Expect(resp.Date.Minute()).To(Equal(43))
+	})
+
+	It("uses matching GitHub code scanning URLs for OpenSSF documentation links", func() {
+		ctx := api.NewScrapeContext(dutyCtx.New())
+		var results v1.ScrapeResults
+		codeScanningURL := "https://github.com/flanksource/duty/security/code-scanning/32"
+		scorecard := &ScorecardResponse{
+			Date: FlexTime{Time: time.Date(2026, time.July, 2, 8, 10, 42, 0, time.UTC)},
+			Checks: []CheckResult{{
+				Name:   "Vulnerabilities",
+				Score:  3,
+				Reason: "7 existing vulnerabilities detected",
+				Documentation: Documentation{
+					Short: "Determines if the project has open, known unfixed vulnerabilities.",
+					URL:   "https://github.com/ossf/scorecard/blob/main/docs/checks.md#vulnerabilities",
+				},
+			}},
+		}
+
+		createScorecardAnalyses(ctx, &results, "github/flanksource/duty", v1.GitHubRepository{}, scorecard, map[string]string{
+			"Vulnerabilities": codeScanningURL,
+		})
+
+		Expect(results).To(HaveLen(1))
+		analysis := results[0].AnalysisResult
+		Expect(analysis).ToNot(BeNil())
+
+		documentation, ok := analysis.Analysis["documentation"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(documentation["url"]).To(Equal(codeScanningURL))
+
+		var propertyURL string
+		for _, property := range analysis.Properties {
+			if property.Name == "Documentation" && len(property.Links) > 0 {
+				propertyURL = property.Links[0].URL
+			}
+		}
+		Expect(propertyURL).To(Equal(codeScanningURL))
 	})
 })

--- a/scrapers/github/scraper.go
+++ b/scrapers/github/scraper.go
@@ -92,13 +92,14 @@ func (gh GithubScraper) Scrape(ctx api.ScrapeContext) v1.ScrapeResults {
 					openssfCheckNames[check.Name] = true
 				}
 			}
+			openssfCodeScanningURLs := codeScanningURLsByCheckName(externalConfigID, alerts, openssfCheckNames)
 
 			if alerts != nil {
 				createAlertAnalyses(ctx, &results, externalConfigID, alerts, openssfCheckNames)
 			}
 
 			if scorecard != nil {
-				createScorecardAnalyses(ctx, &results, externalConfigID, repoConfig, scorecard)
+				createScorecardAnalyses(ctx, &results, externalConfigID, repoConfig, scorecard, openssfCodeScanningURLs)
 			}
 		}
 	}
@@ -450,8 +451,7 @@ func createAlertAnalyses(ctx api.ScrapeContext, results *v1.ScrapeResults, exter
 		a.Message(alert.GetMostRecentInstance().GetMessage().GetText())
 		a.Analysis, _ = collections.ToJSONMap(alert)
 
-		repoFullName := strings.TrimPrefix(externalConfigID, "github/")
-		codeScanningURL := fmt.Sprintf("https://github.com/%s/security/code-scanning/%d", repoFullName, alert.GetNumber())
+		codeScanningURL := codeScanningAlertURL(externalConfigID, alert)
 		a.Properties = append(a.Properties, &types.Property{
 			Name:  "URL",
 			Text:  codeScanningURL,
@@ -542,6 +542,44 @@ func createAlertAnalyses(ctx api.ScrapeContext, results *v1.ScrapeResults, exter
 			})
 		}
 	}
+}
+
+func codeScanningURLsByCheckName(externalConfigID string, alerts *allAlerts, openssfCheckNames map[string]bool) map[string]string {
+	if alerts == nil || len(openssfCheckNames) == 0 {
+		return nil
+	}
+
+	urls := make(map[string]string)
+	for _, alert := range alerts.codeScanning {
+		if alert == nil || alert.Rule == nil {
+			continue
+		}
+
+		checkName := alert.Rule.GetDescription()
+		if !openssfCheckNames[checkName] {
+			continue
+		}
+		if _, exists := urls[checkName]; exists {
+			continue
+		}
+
+		if url := codeScanningAlertURL(externalConfigID, alert); url != "" {
+			urls[checkName] = url
+		}
+	}
+
+	return urls
+}
+
+func codeScanningAlertURL(externalConfigID string, alert *github.Alert) string {
+	if alert == nil {
+		return ""
+	}
+	if alert.GetNumber() > 0 {
+		repoFullName := strings.TrimPrefix(externalConfigID, "github/")
+		return fmt.Sprintf("https://github.com/%s/security/code-scanning/%d", repoFullName, alert.GetNumber())
+	}
+	return alert.GetHTMLURL()
 }
 
 // badgeColor returns muted Tailwind classes for a "higher is better" ratio.


### PR DESCRIPTION
OpenSSF vulnerability checks can overlap with GitHub code scanning alerts.

The scraper deduped the matching GitHub Code Scanning analysis, but the surviving OpenSSF analysis kept the generic Scorecard documentation URL.

Carry the matched repo-specific code scanning URL into the OpenSSF analysis documentation and rendered link property so vulnerability insights point at the GitHub alert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenSSF scorecard documentation links can now point to the corresponding GitHub code scanning alert when available.
  * GitHub alert links are now generated more consistently across findings.

* **Bug Fixes**
  * Improved link accuracy in analysis results so the displayed documentation URL matches the most relevant code scanning page.
  * Added coverage to confirm the updated link behavior works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->