### PR TITLE
fix: run Go CodeQL on PRs and main pushes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,15 +11,10 @@
 #
 name: "CodeQL"
 on:
-  # FIXME disable codeql for now as it does not complete due to complile time of Azure SDK's
-  # push:
-  #   branches: ["main"]
-  #   paths:
-  #     - "**.go"
-  # pull_request:
-  #   branches: ["main"]
-  #   paths:
-  #     - "**.go"
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
Config DB's advanced CodeQL workflow only ran on a daily schedule, so Go findings were not refreshed on PRs or merges to main.

Match mission-control's behavior by running the Go CodeQL workflow on pull requests to main, pushes to main, and the existing daily schedule. This lets Go code scanning results refresh promptly once the GitHub default/advanced setup conflict is resolved.