### PR TITLE
chore: add OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # config-db
 
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/flanksource/config-db/badge)](https://securityscorecards.dev/viewer/?uri=github.com/flanksource/config-db)
+
 **config-db** is developer first, JSON based configuration management database (CMDB)
 
 ## Setup


### PR DESCRIPTION
Add the OpenSSF Scorecard badge to the README so the repository security score is visible from the project homepage.