### PR TITLE
fix: improve deduplication of GitHub code scanning findings from Scorecard findings

### DIFF
--- a/scrapers/github/openssf.go
+++ b/scrapers/github/openssf.go
@@ -209,7 +209,7 @@ func isRetryable(err error) bool {
 	return strings.Contains(err.Error(), "server error") || strings.Contains(err.Error(), "connection")
 }
 
-func createScorecardAnalyses(ctx api.ScrapeContext, results *v1.ScrapeResults, externalConfigID string, _ v1.GitHubRepository, scorecard *ScorecardResponse) {
+func createScorecardAnalyses(ctx api.ScrapeContext, results *v1.ScrapeResults, externalConfigID string, _ v1.GitHubRepository, scorecard *ScorecardResponse, codeScanningURLsByCheckName map[string]string) {
 	for _, check := range scorecard.Checks {
 		a := results.Analysis(check.Name, ConfigTypeRepository, externalConfigID)
 		a.ExternalAnalysisID = fmt.Sprintf("%s::openssf/%s", v1.NormalizeExternalID(externalConfigID), check.Name)
@@ -248,6 +248,14 @@ func createScorecardAnalyses(ctx api.ScrapeContext, results *v1.ScrapeResults, e
 				Text:  check.Documentation.Short,
 				Type:  "url",
 				Links: []types.Link{{URL: check.Documentation.URL, Type: "documentation"}},
+			})
+		}
+		if url := codeScanningURLsByCheckName[check.Name]; url != "" {
+			a.Properties = append(a.Properties, &types.Property{
+				Name:  "GitHub Code Scanning Alert",
+				Text:  url,
+				Type:  "url",
+				Links: []types.Link{{URL: url, Type: "url"}},
 			})
 		}
 	}

--- a/scrapers/github/scraper.go
+++ b/scrapers/github/scraper.go
@@ -85,20 +85,14 @@ func (gh GithubScraper) Scrape(ctx api.ScrapeContext) v1.ScrapeResults {
 			result := buildRepositoryResult(repo, repoConfig, alerts, scorecard)
 			results = append(results, result)
 
-			var openssfCheckNames map[string]bool
-			if scorecard != nil {
-				openssfCheckNames = make(map[string]bool, len(scorecard.Checks))
-				for _, check := range scorecard.Checks {
-					openssfCheckNames[check.Name] = true
-				}
-			}
+			openssfCodeScanningURLs := codeScanningURLsByOpenSSFCheckName(externalConfigID, alerts)
 
 			if alerts != nil {
-				createAlertAnalyses(ctx, &results, externalConfigID, alerts, openssfCheckNames)
+				createAlertAnalyses(ctx, &results, externalConfigID, alerts, scorecard != nil)
 			}
 
 			if scorecard != nil {
-				createScorecardAnalyses(ctx, &results, externalConfigID, repoConfig, scorecard)
+				createScorecardAnalyses(ctx, &results, externalConfigID, repoConfig, scorecard, openssfCodeScanningURLs)
 			}
 		}
 	}
@@ -250,8 +244,12 @@ func buildRepositoryResult(repo *github.Repository, repoConfig v1.GitHubReposito
 	healthStatus := health.HealthStatus{Health: health.HealthHealthy, Ready: true, Message: "No issues"}
 
 	if alerts != nil {
-		properties = append(properties, alertProperties(alerts)...)
-		healthStatus = calculateAlertHealthStatus(alerts)
+		counts := alerts.counts
+		if scorecard != nil {
+			counts = alerts.countsExcludingOpenSSFCodeScanning()
+		}
+		properties = append(properties, alertProperties(counts)...)
+		healthStatus = calculateAlertHealthStatus(counts)
 	}
 
 	if scorecard != nil {
@@ -278,12 +276,12 @@ func buildRepositoryResult(repo *github.Repository, repoConfig v1.GitHubReposito
 	return result.WithHealthStatus(healthStatus)
 }
 
-func alertProperties(alerts *allAlerts) []*types.Property {
+func alertProperties(counts alertCounts) []*types.Property {
 	return []*types.Property{
-		{Name: "Critical Alerts", Type: "number", Text: fmt.Sprintf("%d", alerts.counts.critical)},
-		{Name: "High Alerts", Type: "number", Text: fmt.Sprintf("%d", alerts.counts.high)},
-		{Name: "Medium Alerts", Type: "number", Text: fmt.Sprintf("%d", alerts.counts.medium)},
-		{Name: "Low Alerts", Type: "number", Text: fmt.Sprintf("%d", alerts.counts.low)},
+		{Name: "Critical Alerts", Type: "number", Text: fmt.Sprintf("%d", counts.critical)},
+		{Name: "High Alerts", Type: "number", Text: fmt.Sprintf("%d", counts.high)},
+		{Name: "Medium Alerts", Type: "number", Text: fmt.Sprintf("%d", counts.medium)},
+		{Name: "Low Alerts", Type: "number", Text: fmt.Sprintf("%d", counts.low)},
 	}
 }
 
@@ -306,7 +304,148 @@ func scorecardProperties(owner, repo string, scorecard *ScorecardResponse) []*ty
 	}
 }
 
-func createAlertAnalyses(ctx api.ScrapeContext, results *v1.ScrapeResults, externalConfigID string, alerts *allAlerts, openssfCheckNames map[string]bool) {
+func codeScanningURLsByOpenSSFCheckName(externalConfigID string, alerts *allAlerts) map[string]string {
+	if alerts == nil {
+		return nil
+	}
+
+	urls := make(map[string]string)
+	for _, alert := range alerts.codeScanning {
+		checkName, ok := openSSFCodeScanningCheckName(alert)
+		if !ok || checkName == "" {
+			continue
+		}
+		if _, exists := urls[checkName]; exists {
+			continue
+		}
+		if url := codeScanningAlertURL(externalConfigID, alert); url != "" {
+			urls[checkName] = url
+		}
+	}
+
+	if len(urls) == 0 {
+		return nil
+	}
+	return urls
+}
+
+func codeScanningAlertURL(externalConfigID string, alert *github.Alert) string {
+	if alert == nil {
+		return ""
+	}
+	if htmlURL := alert.GetHTMLURL(); htmlURL != "" {
+		return htmlURL
+	}
+
+	repoFullName := strings.TrimPrefix(externalConfigID, "github/")
+	if repoFullName == "" || alert.GetNumber() == 0 {
+		return ""
+	}
+	return fmt.Sprintf("https://github.com/%s/security/code-scanning/%d", repoFullName, alert.GetNumber())
+}
+
+func isOpenSSFCodeScanningAlert(alert *github.Alert) bool {
+	return isScorecardTool(alert.GetTool())
+}
+
+func isScorecardTool(tool *github.Tool) bool {
+	toolName := strings.ToLower(strings.TrimSpace(tool.GetName()))
+	return strings.Contains(toolName, "scorecard")
+}
+
+func openSSFCodeScanningCheckName(alert *github.Alert) (string, bool) {
+	if !isOpenSSFCodeScanningAlert(alert) {
+		return "", false
+	}
+
+	if checkName := openSSFCheckNameFromValue(codeScanningRuleDescription(alert)); checkName != "" {
+		return checkName, true
+	}
+	if checkName := openSSFCheckNameFromValue(codeScanningRuleID(alert)); checkName != "" {
+		return checkName, true
+	}
+	return "", false
+}
+
+func codeScanningRuleID(alert *github.Alert) string {
+	if alert == nil {
+		return ""
+	}
+	if rule := alert.GetRule(); rule != nil {
+		if id := strings.TrimSpace(rule.GetID()); id != "" {
+			return id
+		}
+	}
+	return strings.TrimSpace(alert.GetRuleID())
+}
+
+func codeScanningRuleDescription(alert *github.Alert) string {
+	if alert == nil {
+		return ""
+	}
+	if rule := alert.GetRule(); rule != nil {
+		if desc := strings.TrimSpace(rule.GetDescription()); desc != "" {
+			return desc
+		}
+	}
+	if desc := strings.TrimSpace(alert.GetRuleDescription()); desc != "" {
+		return desc
+	}
+	if rule := alert.GetRule(); rule != nil {
+		return strings.TrimSpace(rule.GetName())
+	}
+	return ""
+}
+
+func codeScanningSecuritySeverity(alert *github.Alert) string {
+	if alert == nil {
+		return ""
+	}
+	if rule := alert.GetRule(); rule != nil {
+		if severity := strings.TrimSpace(rule.GetSecuritySeverityLevel()); severity != "" {
+			return severity
+		}
+	}
+	return strings.TrimSpace(alert.GetRuleSeverity())
+}
+
+func codeScanningAlertSeverity(alert *github.Alert) string {
+	if alert == nil {
+		return ""
+	}
+	if rule := alert.GetRule(); rule != nil {
+		if severity := strings.TrimSpace(rule.GetSeverity()); severity != "" {
+			return severity
+		}
+	}
+	return strings.TrimSpace(alert.GetRuleSeverity())
+}
+
+func openSSFCheckNameFromValue(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if _, ok := checkRiskLevel[value]; ok {
+		return value
+	}
+
+	normalized := normalizeOpenSSFIdentifier(value)
+	for checkName := range checkRiskLevel {
+		checkNormalized := normalizeOpenSSFIdentifier(checkName)
+		if normalized == checkNormalized || normalized == checkNormalized+"id" {
+			return checkName
+		}
+	}
+	return ""
+}
+
+func normalizeOpenSSFIdentifier(value string) string {
+	replacer := strings.NewReplacer("-", "", "_", "", " ", "", ".", "", "/", "", ":", "")
+	return strings.ToLower(replacer.Replace(strings.TrimSpace(value)))
+}
+
+func createAlertAnalyses(ctx api.ScrapeContext, results *v1.ScrapeResults, externalConfigID string, alerts *allAlerts, hasOpenSSFScorecard bool) {
 	for _, alert := range alerts.dependabot {
 		a := results.Analysis(
 			fmt.Sprintf("dependabot/%d", alert.GetNumber()),
@@ -421,8 +560,17 @@ func createAlertAnalyses(ctx api.ScrapeContext, results *v1.ScrapeResults, exter
 	}
 
 	for _, alert := range alerts.codeScanning {
-		if openssfCheckNames[alert.Rule.GetDescription()] {
-			ctx.Debugf("skipping code scanning alert %d (covered by OpenSSF check %s)", alert.GetNumber(), alert.Rule.GetDescription())
+		ruleID := codeScanningRuleID(alert)
+		ruleDescription := codeScanningRuleDescription(alert)
+		if hasOpenSSFScorecard && isOpenSSFCodeScanningAlert(alert) {
+			checkName, _ := openSSFCodeScanningCheckName(alert)
+			ctx.Debugf(
+				"skipping OpenSSF Scorecard code scanning alert %d (covered by OpenSSF API): check=%s rule=%s tool=%s",
+				alert.GetNumber(),
+				checkName,
+				ruleDescription,
+				alert.GetTool().GetName(),
+			)
 			continue
 		}
 
@@ -434,10 +582,10 @@ func createAlertAnalyses(ctx api.ScrapeContext, results *v1.ScrapeResults, exter
 			a.ExternalAnalysisID = externalAnalysisID
 		}
 		a.AnalysisType = models.AnalysisTypeSecurity
-		a.Severity = mapGitHubSeverity(alert.Rule.GetSecuritySeverityLevel())
+		a.Severity = mapGitHubSeverity(codeScanningSecuritySeverity(alert))
 		a.Source = "GitHub Code Scanning"
-		a.Analyzer = alert.Rule.GetID()
-		a.Summary = alert.Rule.GetDescription()
+		a.Analyzer = ruleID
+		a.Summary = ruleDescription
 		a.Status = alert.GetState()
 		if alert.CreatedAt != nil {
 			t := alert.CreatedAt.Time
@@ -450,14 +598,14 @@ func createAlertAnalyses(ctx api.ScrapeContext, results *v1.ScrapeResults, exter
 		a.Message(alert.GetMostRecentInstance().GetMessage().GetText())
 		a.Analysis, _ = collections.ToJSONMap(alert)
 
-		repoFullName := strings.TrimPrefix(externalConfigID, "github/")
-		codeScanningURL := fmt.Sprintf("https://github.com/%s/security/code-scanning/%d", repoFullName, alert.GetNumber())
-		a.Properties = append(a.Properties, &types.Property{
-			Name:  "URL",
-			Text:  codeScanningURL,
-			Type:  "url",
-			Links: []types.Link{{URL: codeScanningURL, Type: "url"}},
-		})
+		if codeScanningURL := codeScanningAlertURL(externalConfigID, alert); codeScanningURL != "" {
+			a.Properties = append(a.Properties, &types.Property{
+				Name:  "URL",
+				Text:  codeScanningURL,
+				Type:  "url",
+				Links: []types.Link{{URL: codeScanningURL, Type: "url"}},
+			})
+		}
 		if tool := alert.GetTool(); tool != nil {
 			toolText := tool.GetName()
 			if ver := tool.GetVersion(); ver != "" {

--- a/scrapers/github/scraper_test.go
+++ b/scrapers/github/scraper_test.go
@@ -71,6 +71,122 @@ var _ = Describe("GitHubScraper", func() {
 		})
 	})
 
+	Context("OpenSSF code scanning dedupe", func() {
+		newCodeScanningAlert := func(number int, toolName, ruleID, ruleDescription string) *gogithub.Alert {
+			alert := &gogithub.Alert{
+				Number:          gogithub.Ptr(number),
+				State:           gogithub.Ptr("open"),
+				RuleID:          gogithub.Ptr(ruleID),
+				RuleDescription: gogithub.Ptr(ruleDescription),
+				Rule: &gogithub.Rule{
+					ID:                    gogithub.Ptr(ruleID),
+					Description:           gogithub.Ptr(ruleDescription),
+					Severity:              gogithub.Ptr("high"),
+					SecuritySeverityLevel: gogithub.Ptr("high"),
+				},
+				MostRecentInstance: &gogithub.MostRecentInstance{
+					Message: &gogithub.Message{Text: gogithub.Ptr("finding message")},
+				},
+			}
+			if toolName != "" {
+				alert.Tool = &gogithub.Tool{Name: gogithub.Ptr(toolName)}
+			}
+			return alert
+		}
+
+		codeScanningAnalyses := func(results v1.ScrapeResults) []*v1.AnalysisResult {
+			var analyses []*v1.AnalysisResult
+			for _, result := range results {
+				if result.AnalysisResult != nil && result.AnalysisResult.Source == "GitHub Code Scanning" {
+					analyses = append(analyses, result.AnalysisResult)
+				}
+			}
+			return analyses
+		}
+
+		It("detects Scorecard-origin alerts by tool name only", func() {
+			scorecardAlert := newCodeScanningAlert(32, "Scorecard", "VulnerabilitiesID", "Vulnerabilities")
+			Expect(isOpenSSFCodeScanningAlert(scorecardAlert)).To(BeTrue())
+
+			checkName, ok := openSSFCodeScanningCheckName(scorecardAlert)
+			Expect(ok).To(BeTrue())
+			Expect(checkName).To(Equal("Vulnerabilities"))
+
+			openssfScorecardAlert := newCodeScanningAlert(33, "OpenSSF Scorecard", "VulnerabilitiesID", "Vulnerabilities")
+			Expect(isOpenSSFCodeScanningAlert(openssfScorecardAlert)).To(BeTrue())
+
+			codeQLAlert := newCodeScanningAlert(34, "CodeQL", "VulnerabilitiesID", "Vulnerabilities")
+			Expect(isOpenSSFCodeScanningAlert(codeQLAlert)).To(BeFalse())
+		})
+
+		It("skips only Scorecard-origin code scanning alerts when OpenSSF API data exists", func() {
+			alerts := &allAlerts{codeScanning: []*gogithub.Alert{
+				newCodeScanningAlert(32, "Scorecard", "VulnerabilitiesID", "Vulnerabilities"),
+				newCodeScanningAlert(33, "CodeQL", "go/sql-injection", "SQL injection"),
+			}}
+
+			var results v1.ScrapeResults
+			ctx := api.NewScrapeContext(dutyCtx.New())
+			createAlertAnalyses(ctx, &results, "github/acme/repo", alerts, true)
+
+			analyses := codeScanningAnalyses(results)
+			Expect(analyses).To(HaveLen(1))
+			Expect(analyses[0].Analyzer).To(Equal("go/sql-injection"))
+		})
+
+		It("keeps Scorecard-origin code scanning alerts when OpenSSF API data is missing", func() {
+			alerts := &allAlerts{codeScanning: []*gogithub.Alert{
+				newCodeScanningAlert(32, "Scorecard", "VulnerabilitiesID", "Vulnerabilities"),
+			}}
+
+			var results v1.ScrapeResults
+			ctx := api.NewScrapeContext(dutyCtx.New())
+			createAlertAnalyses(ctx, &results, "github/acme/repo", alerts, false)
+
+			analyses := codeScanningAnalyses(results)
+			Expect(analyses).To(HaveLen(1))
+			Expect(analyses[0].Analyzer).To(Equal("VulnerabilitiesID"))
+		})
+
+		It("enriches OpenSSF analyses with matching GitHub code scanning URLs", func() {
+			alerts := &allAlerts{codeScanning: []*gogithub.Alert{
+				newCodeScanningAlert(32, "Scorecard", "VulnerabilitiesID", "Vulnerabilities"),
+			}}
+			urls := codeScanningURLsByOpenSSFCheckName("github/acme/repo", alerts)
+			Expect(urls).To(HaveKeyWithValue("Vulnerabilities", "https://github.com/acme/repo/security/code-scanning/32"))
+
+			scorecard := &ScorecardResponse{Checks: []CheckResult{{
+				Name:   "Vulnerabilities",
+				Score:  0,
+				Reason: "project has vulnerabilities",
+			}}}
+
+			var results v1.ScrapeResults
+			ctx := api.NewScrapeContext(dutyCtx.New())
+			createScorecardAnalyses(ctx, &results, "github/acme/repo", v1.GitHubRepository{}, scorecard, urls)
+
+			Expect(results).To(HaveLen(1))
+			var found bool
+			for _, property := range results[0].AnalysisResult.Properties {
+				if property.Name == "GitHub Code Scanning Alert" {
+					found = true
+					Expect(property.Text).To(Equal("https://github.com/acme/repo/security/code-scanning/32"))
+				}
+			}
+			Expect(found).To(BeTrue())
+		})
+
+		It("excludes skipped Scorecard-origin alerts from repository alert counts", func() {
+			alerts := &allAlerts{codeScanning: []*gogithub.Alert{
+				newCodeScanningAlert(32, "Scorecard", "VulnerabilitiesID", "Vulnerabilities"),
+				newCodeScanningAlert(33, "CodeQL", "go/sql-injection", "SQL injection"),
+			}}
+
+			counts := alerts.countsExcludingOpenSSFCodeScanning()
+			Expect(counts.high).To(Equal(1))
+		})
+	})
+
 	Context("with security and OpenSSF enabled", func() {
 		It("should scrape repository config and analysis results", func() {
 			if os.Getenv("GITHUB_TOKEN") == "" {
@@ -155,8 +271,12 @@ var _ = Describe("GitHubScraper", func() {
 				"dedup validation requires at least one OpenSSF check to be meaningful")
 			for _, a := range analyses {
 				if a.AnalysisResult != nil && a.AnalysisResult.Source == "GitHub Code Scanning" {
-					Expect(openssfCheckNames[a.AnalysisResult.Summary]).To(BeFalse(),
-						"code scanning alert %q should be deduped (covered by OpenSSF check)", a.AnalysisResult.Summary)
+					for _, property := range a.AnalysisResult.Properties {
+						if property.Name == "Tool" {
+							Expect(property.Text).ToNot(MatchRegexp("(?i)scorecard"),
+								"Scorecard-origin code scanning alert %q should be deduped", a.AnalysisResult.Summary)
+						}
+					}
 				}
 			}
 

--- a/scrapers/github/security.go
+++ b/scrapers/github/security.go
@@ -77,7 +77,7 @@ func scrapeSecurityAlerts(ctx api.ScrapeContext, client *GitHubClient, config v1
 	}
 
 	for _, alert := range alerts.codeScanning {
-		countAlertSeverity(&alerts.counts, alert.Rule.GetSeverity())
+		countAlertSeverity(&alerts.counts, codeScanningAlertSeverity(alert))
 	}
 
 	// Secret scanning alerts don't have a severity field in the GitHub API,
@@ -114,9 +114,30 @@ func countAlertSeverity(counts *alertCounts, severity string) {
 	}
 }
 
-func calculateAlertHealthStatus(alerts *allAlerts) health.HealthStatus {
+func (alerts *allAlerts) countsExcludingOpenSSFCodeScanning() alertCounts {
+	var counts alertCounts
+	if alerts == nil {
+		return counts
+	}
+
+	for _, alert := range alerts.dependabot {
+		countAlertSeverity(&counts, alert.SecurityAdvisory.GetSeverity())
+	}
+	for _, alert := range alerts.codeScanning {
+		if isOpenSSFCodeScanningAlert(alert) {
+			continue
+		}
+		countAlertSeverity(&counts, codeScanningAlertSeverity(alert))
+	}
+	for range alerts.secretScanning {
+		counts.high++
+	}
+
+	return counts
+}
+
+func calculateAlertHealthStatus(counts alertCounts) health.HealthStatus {
 	status := health.HealthStatus{Health: health.HealthHealthy, Ready: true}
-	counts := alerts.counts
 
 	if counts.critical > 0 {
 		status.Health = health.HealthUnhealthy


### PR DESCRIPTION
Improve OpenSSF Scorecard deduplication by identifying Scorecard-origin GitHub Code Scanning alerts by tool source instead of rule description.

When public OpenSSF Scorecard API data exists, skip Scorecard Code Scanning alerts in favor of the richer OpenSSF insight while keeping other Code Scanning findings.

Also include the GitHub Code Scanning alert URL as the source URL for Scorecard insights.