### PR TITLE
chore: cosign docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,9 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+
       - name: Publish to DockerHub Registry
         uses: elgohr/Publish-Docker-Github-Action@cba9ef01f060d055caf693f34a0ed92d361f2ab1 # v5
         with:
@@ -92,6 +95,13 @@ jobs:
           snapshot: true
           dockerfile: build/Dockerfile
           tags: "latest,v${{ needs.create-release.outputs.version }}"
+
+      - name: Sign DockerHub image digest
+        env:
+          IMAGE: flanksource/config-db:v${{ needs.create-release.outputs.version }}
+        run: |
+          digest=$(docker buildx imagetools inspect "$IMAGE" --format '{{.Manifest.Digest}}')
+          cosign sign --yes "flanksource/config-db@${digest}"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v5
@@ -113,8 +123,20 @@ jobs:
           REPOSITORY: config-db
           IMAGE_TAG: "v${{ needs.create-release.outputs.version }}"
         run: |
-          docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG -f build/Dockerfile .
-          docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
+          image="$REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG"
+          docker build -t "$image" -f build/Dockerfile .
+          docker push "$image"
+
+      - name: Sign ECR Public image digest
+        env:
+          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          REGISTRY_ALIAS: k4y9r6y5
+          REPOSITORY: config-db
+          IMAGE_TAG: "v${{ needs.create-release.outputs.version }}"
+        run: |
+          image="$REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG"
+          digest=$(docker buildx imagetools inspect "$image" --format '{{.Manifest.Digest}}')
+          cosign sign --yes "$REGISTRY/$REGISTRY_ALIAS/$REPOSITORY@${digest}"
 
   helm:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,12 @@ jobs:
           dockerfile: build/Dockerfile
           tags: "latest,v${{ needs.create-release.outputs.version }}"
 
+      - name: Login to DockerHub Registry
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Sign DockerHub image digest
         env:
           IMAGE: flanksource/config-db:v${{ needs.create-release.outputs.version }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker images published as part of releases are now cryptographically signed using their published manifest digests.
  * The same signing step is applied to images pushed to ECR Public after publishing.
* **Chores**
  * Updated the release publishing workflow to install signing tooling and to compute and sign digests for each registry publish in a safer, more reliable way.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->