### PR TITLE
fix: enforce scrape timeout for all runs

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -1,10 +1,8 @@
 package api
 
 import (
-	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/flanksource/commons/har"
 	"github.com/flanksource/commons/logger"
@@ -153,14 +151,6 @@ func (ctx ScrapeContext) WithScrapeConfig(scraper *v1.ScrapeConfig, plugins ...v
 		ctx.temp = c.(*TempCache)
 	}
 	return ctx
-}
-
-func (ctx ScrapeContext) WithTimeout(timeout time.Duration) (c ScrapeContext, cancel context.CancelFunc, cancelTimeout context.CancelFunc) {
-
-	ctx.Context, cancelTimeout = ctx.Context.WithTimeout(ctx.Properties().Duration("scraper.timeout", 4*time.Hour))
-	c2, cancel := context.WithCancel(ctx.Context)
-	ctx.Context = ctx.Context.Wrap(c2)
-	return ctx, cancel, cancelTimeout
 }
 
 func (ctx ScrapeContext) WithJobHistory(jobHistory *models.JobHistory) ScrapeContext {

--- a/api/v1/timeout_test.go
+++ b/api/v1/timeout_test.go
@@ -1,0 +1,47 @@
+package v1
+
+import (
+	"testing"
+	"time"
+)
+
+func TestScraperSpecTimeout(t *testing.T) {
+	defaultTimeout := 4 * time.Hour
+
+	t.Run("default", func(t *testing.T) {
+		got, err := (ScraperSpec{}).TimeoutDuration(defaultTimeout)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != defaultTimeout {
+			t.Fatalf("expected %s, got %s", defaultTimeout, got)
+		}
+	})
+
+	t.Run("explicit timeout shorter than default", func(t *testing.T) {
+		got, err := (ScraperSpec{Timeout: "30m"}).TimeoutDuration(defaultTimeout)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 30*time.Minute {
+			t.Fatalf("expected 30m, got %s", got)
+		}
+	})
+
+	t.Run("extended duration units", func(t *testing.T) {
+		got, err := (ScraperSpec{Timeout: "1d"}).TimeoutDuration(defaultTimeout)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 24*time.Hour {
+			t.Fatalf("expected 24h, got %s", got)
+		}
+	})
+
+	t.Run("invalid timeout", func(t *testing.T) {
+		_, err := (ScraperSpec{Timeout: "soon"}).TimeoutDuration(defaultTimeout)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}

--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/flanksource/clicky"
 	"github.com/flanksource/clicky/api"
+	"github.com/flanksource/commons/duration"
 	"github.com/flanksource/config-db/utils"
 
 	"github.com/google/uuid"
@@ -75,7 +77,11 @@ type ScraperSpec struct {
 	LogLevel string `json:"logLevel,omitempty" yaml:"logLevel,omitempty"`
 
 	// Schedule is a cron expression for when to run the scraper. Example: `@every 1m`, `0 */6 * * *` (every 6 hours)
-	Schedule       string           `json:"schedule,omitempty" yaml:"schedule,omitempty"`
+	Schedule string `json:"schedule,omitempty" yaml:"schedule,omitempty"`
+
+	// Timeout is the maximum duration for a scrape run. Uses duration strings, e.g. "30m", "1h", "1d".
+	Timeout string `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+
 	GCP            []GCP            `json:"gcp,omitempty" yaml:"gcp,omitempty"`
 	AWS            []AWS            `json:"aws,omitempty" yaml:"aws,omitempty"`
 	File           []File           `json:"file,omitempty" yaml:"file,omitempty"`
@@ -107,6 +113,19 @@ type ScraperSpec struct {
 
 	// Full flag when set will try to extract out changes from the scraped config.
 	Full bool `json:"full,omitempty"`
+}
+
+// TimeoutDuration returns the configured scrape timeout, falling back to defaultTimeout.
+func (c ScraperSpec) TimeoutDuration(defaultTimeout time.Duration) (time.Duration, error) {
+	if c.Timeout == "" {
+		return defaultTimeout, nil
+	}
+
+	timeout, err := duration.ParseDuration(c.Timeout)
+	if err != nil {
+		return 0, fmt.Errorf("invalid scraper timeout %q: %w", c.Timeout, err)
+	}
+	return time.Duration(timeout), nil
 }
 
 func (c ScraperSpec) ApplyPlugin(plugins []ScrapePluginSpec) ScraperSpec {

--- a/chart/crds/configs.flanksource.com_scrapeconfigs.yaml
+++ b/chart/crds/configs.flanksource.com_scrapeconfigs.yaml
@@ -3895,6 +3895,112 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        opensearch:
+                          properties:
+                            digest:
+                              type: boolean
+                            index:
+                              type: string
+                            insecureSkipVerify:
+                              type: boolean
+                            ntlm:
+                              type: boolean
+                            ntlmv2:
+                              type: boolean
+                            password:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    configMapKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - key
+                                      type: object
+                                    helmRef:
+                                      properties:
+                                        key:
+                                          description: Key is a JSONPath expression
+                                            used to fetch the key from the merged
+                                            JSON.
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - key
+                                      type: object
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - key
+                                      type: object
+                                    serviceAccount:
+                                      description: ServiceAccount specifies the service
+                                        account whose token should be fetched
+                                      type: string
+                                  type: object
+                              type: object
+                            urls:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                            username:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    configMapKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - key
+                                      type: object
+                                    helmRef:
+                                      properties:
+                                        key:
+                                          description: Key is a JSONPath expression
+                                            used to fetch the key from the merged
+                                            JSON.
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - key
+                                      type: object
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - key
+                                      type: object
+                                    serviceAccount:
+                                      description: ServiceAccount specifies the service
+                                        account whose token should be fetched
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
                         serviceAccount:
                           description: ServiceAccount when enabled will allow access
                             to KUBERNETES env vars
@@ -5930,10 +6036,9 @@ spec:
                           owner:
                             type: string
                           repo:
-                            description: Exact repository name or comma-separated
-                              collections.MatchItems patterns (`*`, `prefix*`, `*suffix`,
-                              `!name`). Pattern selectors discover matching non-archived
-                              repositories for owner.
+                            description: |-
+                              Repo can be an exact repository name or comma-separated collections.MatchItems patterns.
+                              Pattern selectors discover matching non-archived repositories for Owner.
                             type: string
                         required:
                         - owner
@@ -11933,6 +12038,112 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        opensearch:
+                          properties:
+                            digest:
+                              type: boolean
+                            index:
+                              type: string
+                            insecureSkipVerify:
+                              type: boolean
+                            ntlm:
+                              type: boolean
+                            ntlmv2:
+                              type: boolean
+                            password:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    configMapKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - key
+                                      type: object
+                                    helmRef:
+                                      properties:
+                                        key:
+                                          description: Key is a JSONPath expression
+                                            used to fetch the key from the merged
+                                            JSON.
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - key
+                                      type: object
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - key
+                                      type: object
+                                    serviceAccount:
+                                      description: ServiceAccount specifies the service
+                                        account whose token should be fetched
+                                      type: string
+                                  type: object
+                              type: object
+                            urls:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                            username:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    configMapKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - key
+                                      type: object
+                                    helmRef:
+                                      properties:
+                                        key:
+                                          description: Key is a JSONPath expression
+                                            used to fetch the key from the merged
+                                            JSON.
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - key
+                                      type: object
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - key
+                                      type: object
+                                    serviceAccount:
+                                      description: ServiceAccount specifies the service
+                                        account whose token should be fetched
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
                         serviceAccount:
                           description: ServiceAccount when enabled will allow access
                             to KUBERNETES env vars
@@ -16353,6 +16564,10 @@ spec:
                   - state
                   type: object
                 type: array
+              timeout:
+                description: Timeout is the maximum duration for a scrape run. Uses
+                  duration strings, e.g. "30m", "1h", "1d".
+                type: string
               trivy:
                 items:
                   properties:

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -165,10 +165,7 @@ var Run = &cobra.Command{
 				uiServer.UpdateScraper(scraperConfigs[i].Name, scrapeui.ScraperRunning, nil, nil, nil)
 			}
 
-			scrapeCtx, cancel, cancelTimeout := api.NewScrapeContext(dutyCtx).WithScrapeConfig(&scraperConfigs[i]).
-				WithTimeout(dutyCtx.Properties().Duration("scraper.timeout", 4*time.Hour))
-			defer cancelTimeout()
-			shutdown.AddHook(func() { defer cancel() })
+			scrapeCtx := api.NewScrapeContext(dutyCtx).WithScrapeConfig(&scraperConfigs[i])
 
 			if save && dutyapi.DefaultConfig.ConnectionString != "" {
 				prev := scrapers.GetLastScrapeSummary(dutyCtx, string(scraperConfigs[i].GetUID()))

--- a/config/schemas/config_exec.schema.json
+++ b/config/schemas/config_exec.schema.json
@@ -495,6 +495,9 @@
         },
         "azure": {
           "$ref": "#/$defs/AzureConnection"
+        },
+        "opensearch": {
+          "$ref": "#/$defs/OpensearchConnection"
         }
       },
       "additionalProperties": false,
@@ -745,6 +748,39 @@
         "$ref": "#/$defs/Mask"
       },
       "type": "array"
+    },
+    "OpensearchConnection": {
+      "properties": {
+        "username": {
+          "$ref": "#/$defs/EnvVar"
+        },
+        "password": {
+          "$ref": "#/$defs/EnvVar"
+        },
+        "ntlm": {
+          "type": "boolean"
+        },
+        "ntlmv2": {
+          "type": "boolean"
+        },
+        "digest": {
+          "type": "boolean"
+        },
+        "urls": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "index": {
+          "type": "string"
+        },
+        "insecureSkipVerify": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "RelationshipConfig": {
       "properties": {

--- a/config/schemas/config_github.schema.json
+++ b/config/schemas/config_github.schema.json
@@ -295,7 +295,7 @@
         },
         "repo": {
           "type": "string",
-          "description": "Exact repository name or comma-separated collections.MatchItems patterns (`*`, `prefix*`, `*suffix`, `!name`). Pattern selectors discover matching non-archived repositories for owner."
+          "description": "Repo can be an exact repository name or comma-separated collections.MatchItems patterns.\nPattern selectors discover matching non-archived repositories for Owner."
         }
       },
       "additionalProperties": false,

--- a/config/schemas/config_playwright.schema.json
+++ b/config/schemas/config_playwright.schema.json
@@ -377,6 +377,9 @@
         },
         "azure": {
           "$ref": "#/$defs/AzureConnection"
+        },
+        "opensearch": {
+          "$ref": "#/$defs/OpensearchConnection"
         }
       },
       "additionalProperties": false,
@@ -609,6 +612,39 @@
         "$ref": "#/$defs/Mask"
       },
       "type": "array"
+    },
+    "OpensearchConnection": {
+      "properties": {
+        "username": {
+          "$ref": "#/$defs/EnvVar"
+        },
+        "password": {
+          "$ref": "#/$defs/EnvVar"
+        },
+        "ntlm": {
+          "type": "boolean"
+        },
+        "ntlmv2": {
+          "type": "boolean"
+        },
+        "digest": {
+          "type": "boolean"
+        },
+        "urls": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "index": {
+          "type": "string"
+        },
+        "insecureSkipVerify": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "Playwright": {
       "properties": {

--- a/config/schemas/scrape_config.schema.json
+++ b/config/schemas/scrape_config.schema.json
@@ -1389,6 +1389,9 @@
         },
         "azure": {
           "$ref": "#/$defs/AzureConnection"
+        },
+        "opensearch": {
+          "$ref": "#/$defs/OpensearchConnection"
         }
       },
       "additionalProperties": false,
@@ -2097,7 +2100,7 @@
         },
         "repo": {
           "type": "string",
-          "description": "Exact repository name or comma-separated collections.MatchItems patterns (`*`, `prefix*`, `*suffix`, `!name`). Pattern selectors discover matching non-archived repositories for owner."
+          "description": "Repo can be an exact repository name or comma-separated collections.MatchItems patterns.\nPattern selectors discover matching non-archived repositories for Owner."
         }
       },
       "additionalProperties": false,
@@ -3162,6 +3165,39 @@
       ],
       "description": "OpenSearchConfig contains configuration for OpenSearch log scraping"
     },
+    "OpensearchConnection": {
+      "properties": {
+        "username": {
+          "$ref": "#/$defs/EnvVar"
+        },
+        "password": {
+          "$ref": "#/$defs/EnvVar"
+        },
+        "ntlm": {
+          "type": "boolean"
+        },
+        "ntlmv2": {
+          "type": "boolean"
+        },
+        "digest": {
+          "type": "boolean"
+        },
+        "urls": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "index": {
+          "type": "string"
+        },
+        "insecureSkipVerify": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "OwnerReference": {
       "properties": {
         "apiVersion": {
@@ -4064,6 +4100,10 @@
         "schedule": {
           "type": "string",
           "description": "Schedule is a cron expression for when to run the scraper. Example: `@every 1m`, `0 */6 * * *` (every 6 hours)"
+        },
+        "timeout": {
+          "type": "string",
+          "description": "Timeout is the maximum duration for a scrape run. Uses duration strings, e.g. \"30m\", \"1h\", \"1d\"."
         },
         "gcp": {
           "items": {

--- a/scrapers/run.go
+++ b/scrapers/run.go
@@ -24,6 +24,7 @@ type contextKey string
 
 const (
 	contextKeyScrapeStart contextKey = "scrape_start_time"
+	defaultScraperTimeout            = 4 * time.Hour
 )
 
 // Cache store to be used by watch jobs
@@ -206,6 +207,16 @@ func UpdateStaleConfigItems(ctx api.ScrapeContext, results v1.ScrapeResults) err
 
 // Run ...
 func Run(ctx api.ScrapeContext) (v1.ScrapeResults, error) {
+	timeout, err := ctx.ScrapeConfig().Spec.
+		TimeoutDuration(ctx.Properties().Duration("scraper.timeout", defaultScraperTimeout))
+	if err != nil {
+		return nil, err
+	}
+
+	timedContext, cancel := ctx.Context.WithTimeout(timeout)
+	defer cancel()
+	ctx.Context = timedContext
+
 	plugins, err := db.LoadAllPlugins(ctx.DutyContext())
 	if err != nil {
 		return nil, ctx.Oops().Wrapf(err, "failed to load plugins")

--- a/scrapers/run_now.go
+++ b/scrapers/run_now.go
@@ -20,10 +20,7 @@ import (
 	"github.com/flanksource/config-db/db"
 )
 
-const (
-	runNowTimeout         = 30 * time.Minute
-	runNowRequestMaxBytes = 8 * 1024
-)
+const runNowRequestMaxBytes = 8 * 1024
 
 type runNowResponse struct {
 	JobHistoryID string `json:"job_history_id,omitempty"`
@@ -73,11 +70,9 @@ func runNowSync(c echo.Context, baseCtx context.Context, configScraper v1.Scrape
 		err  error
 	}, 1)
 	go func() {
-		ctx, cancel := context.New().
+		ctx := context.New().
 			WithDB(baseCtx.DB(), baseCtx.Pool()).
-			WithSubject(baseCtx.Subject()).
-			WithTimeout(runNowTimeout)
-		defer cancel()
+			WithSubject(baseCtx.Subject())
 
 		scrapeCtx := api.NewScrapeContext(ctx).WithScrapeConfig(&configScraper)
 		j := newScraperJob(scrapeCtx, runOpts...)
@@ -115,11 +110,9 @@ func runNowSync(c echo.Context, baseCtx context.Context, configScraper v1.Scrape
 func runNowAsync(c echo.Context, baseCtx context.Context, scraper models.ConfigScraper, configScraper v1.ScrapeConfig, runOpts ...RunScraperOption) error {
 	startedAt := time.Now().UTC()
 	go func() {
-		ctx, cancel := context.New().
+		ctx := context.New().
 			WithDB(baseCtx.DB(), baseCtx.Pool()).
-			WithSubject(baseCtx.Subject()).
-			WithTimeout(runNowTimeout)
-		defer cancel()
+			WithSubject(baseCtx.Subject())
 
 		scrapeCtx := api.NewScrapeContext(ctx).WithScrapeConfig(&configScraper)
 		j := newScraperJob(scrapeCtx, runOpts...)


### PR DESCRIPTION
CloudTrail scrapes could run indefinitely when triggered by the scheduled job path.

The manual run path had its own hardcoded timeout, but scheduled runs did not consistently apply a scrape deadline. Add a top-level ScrapeConfig timeout and enforce it centrally when scrapers run, falling back to the scraper.timeout property and then 4h.

Manual, scheduled, and CLI runs now share the same timeout behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable scraper timeout, including support for duration values like `30m` and `1d`.
  * Added OpenSearch connection support in configuration schemas.

* **Bug Fixes**
  * Scraping now uses the configured timeout consistently, with a safe default when none is set.
  * Invalid timeout values now return a clear error instead of being accepted silently.

* **Documentation**
  * Updated schema descriptions to better explain repository matching options and OpenSearch settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->