### PR TITLE
feat(github): add organization relationships

### DIFF
--- a/api/v1/common.go
+++ b/api/v1/common.go
@@ -18,7 +18,7 @@ import (
 )
 
 // List of types which should not have scraper_id
-var ScraperLessTypes = []string{AWSRegion, AWSAvailabilityZone}
+var ScraperLessTypes = []string{AWSRegion, AWSAvailabilityZone, GitHubOrganization}
 
 // ConfigQuery defines a query that exports config items as JSON files for use in scripts.
 type ConfigQuery struct {

--- a/api/v1/github.go
+++ b/api/v1/github.go
@@ -6,6 +6,8 @@ import (
 	"github.com/flanksource/duty/types"
 )
 
+const GitHubOrganization = "GitHub::Organization"
+
 // GitHubActions scraper scrapes the workflow and its runs based on the given filter.
 // By default, it fetches the last 7 days of workflow runs (Configurable via property: scrapers.githubactions.maxAge)
 type GitHubActions struct {

--- a/scrapers/github/scraper.go
+++ b/scrapers/github/scraper.go
@@ -15,7 +15,10 @@ import (
 )
 
 const (
-	ConfigTypeRepository = "GitHub::Repository"
+	ConfigTypeRepository   = "GitHub::Repository"
+	ConfigTypeOrganization = v1.GitHubOrganization
+
+	RelationshipGitHubOrganizationRepository = "GitHubOrganizationRepository"
 )
 
 type GithubScraper struct{}
@@ -26,6 +29,7 @@ func (gh GithubScraper) CanScrape(spec v1.ScraperSpec) bool {
 
 func (gh GithubScraper) Scrape(ctx api.ScrapeContext) v1.ScrapeResults {
 	var results v1.ScrapeResults
+	organizations := make(map[string]struct{})
 
 	for _, config := range ctx.ScrapeConfig().Spec.GitHub {
 		repositories, rateLimited := resolveRepositoryConfigs(ctx, config, &results)
@@ -64,7 +68,11 @@ func (gh GithubScraper) Scrape(ctx api.ScrapeContext) v1.ScrapeResults {
 				continue
 			}
 
-			externalConfigID := fmt.Sprintf("github/%s", repoFullName)
+			if owner := repositoryOrganizationOwner(repo); owner != nil {
+				appendOrganizationResult(&results, organizations, owner)
+			}
+
+			externalConfigID := githubRepositoryExternalID(repoConfig.Owner, repoConfig.Repo)
 
 			var alerts *allAlerts
 			if config.Security {
@@ -227,9 +235,62 @@ func matchingRepositoryConfigs(owner, repoPattern string, repos []*github.Reposi
 	return matched
 }
 
+func appendOrganizationResult(results *v1.ScrapeResults, seen map[string]struct{}, owner *github.User) {
+	if owner == nil || owner.GetLogin() == "" {
+		return
+	}
+
+	externalConfigID := githubOrganizationExternalID(owner.GetLogin())
+	if _, ok := seen[externalConfigID]; ok {
+		return
+	}
+
+	seen[externalConfigID] = struct{}{}
+	*results = append(*results, buildOrganizationResult(owner))
+}
+
+func buildOrganizationResult(owner *github.User) v1.ScrapeResult {
+	login := owner.GetLogin()
+	externalConfigID := githubOrganizationExternalID(login)
+
+	var properties []*types.Property
+	if url := owner.GetHTMLURL(); url != "" {
+		properties = append(properties, &types.Property{
+			Name:  "URL",
+			Type:  "url",
+			Text:  url,
+			Links: []types.Link{{URL: url, Type: "url"}},
+		})
+	}
+
+	return v1.ScrapeResult{
+		Type:        ConfigTypeOrganization,
+		ID:          externalConfigID,
+		Name:        login,
+		ConfigClass: "Organization",
+		Config:      sanitizeActor(owner),
+		Tags: v1.JSONStringMap{
+			"owner": login,
+		},
+		CreatedAt:   owner.CreatedAt.GetTime(),
+		Properties:  properties,
+		ScraperLess: true,
+	}
+}
+
+func repositoryOrganizationOwner(repo *github.Repository) *github.User {
+	if repo == nil ||
+		repo.Owner == nil ||
+		repo.Owner.GetLogin() == "" ||
+		!strings.EqualFold(repo.Owner.GetType(), "Organization") {
+		return nil
+	}
+	return repo.Owner
+}
+
 func buildRepositoryResult(repo *github.Repository, repoConfig v1.GitHubRepository, alerts *allAlerts, scorecard *ScorecardResponse) v1.ScrapeResult {
 	repoFullName := fmt.Sprintf("%s/%s", repoConfig.Owner, repoConfig.Repo)
-	externalConfigID := fmt.Sprintf("github/%s", repoFullName)
+	externalConfigID := githubRepositoryExternalID(repoConfig.Owner, repoConfig.Repo)
 
 	var properties []*types.Property
 	properties = append(properties, &types.Property{
@@ -273,7 +334,38 @@ func buildRepositoryResult(repo *github.Repository, repoConfig v1.GitHubReposito
 		Properties: properties,
 	}
 
+	if owner := repositoryOrganizationOwner(repo); owner != nil {
+		result.RelationshipResults = append(result.RelationshipResults, githubOrganizationRepositoryRelationship(
+			owner.GetLogin(),
+			repoConfig.Owner,
+			repoConfig.Repo,
+		))
+	}
+
 	return result.WithHealthStatus(healthStatus)
+}
+
+func githubOrganizationRepositoryRelationship(owner, repoOwner, repo string) v1.RelationshipResult {
+	return v1.RelationshipResult{
+		ConfigExternalID: v1.ExternalID{
+			ConfigType: ConfigTypeOrganization,
+			ExternalID: githubOrganizationExternalID(owner),
+			ScraperID:  "all",
+		},
+		RelatedExternalID: v1.ExternalID{
+			ConfigType: ConfigTypeRepository,
+			ExternalID: githubRepositoryExternalID(repoOwner, repo),
+		},
+		Relationship: RelationshipGitHubOrganizationRepository,
+	}
+}
+
+func githubOrganizationExternalID(owner string) string {
+	return fmt.Sprintf("github/%s", strings.TrimSpace(owner))
+}
+
+func githubRepositoryExternalID(owner, repo string) string {
+	return fmt.Sprintf("github/%s/%s", strings.TrimSpace(owner), strings.TrimSpace(repo))
 }
 
 func alertProperties(counts alertCounts) []*types.Property {

--- a/scrapers/github/scraper_test.go
+++ b/scrapers/github/scraper_test.go
@@ -71,6 +71,74 @@ var _ = Describe("GitHubScraper", func() {
 		})
 	})
 
+	Context("organizations and relationships", func() {
+		It("creates a scraperless organization config for organization-owned repositories", func() {
+			owner := &gogithub.User{
+				Login:   gogithub.Ptr("flanksource"),
+				Type:    gogithub.Ptr("Organization"),
+				HTMLURL: gogithub.Ptr("https://github.com/flanksource"),
+			}
+
+			result := buildOrganizationResult(owner)
+
+			Expect(result.Type).To(Equal(ConfigTypeOrganization))
+			Expect(result.ID).To(Equal("github/flanksource"))
+			Expect(result.Name).To(Equal("flanksource"))
+			Expect(result.ConfigClass).To(Equal("Organization"))
+			Expect(result.ScraperLess).To(BeTrue())
+			Expect(v1.ScraperLessTypes).To(ContainElement(ConfigTypeOrganization))
+			Expect(result.Properties).To(HaveLen(1))
+			Expect(result.Properties[0].Text).To(Equal("https://github.com/flanksource"))
+		})
+
+		It("dedupes organization configs and relates repositories to the shared organization", func() {
+			owner := &gogithub.User{
+				Login: gogithub.Ptr("flanksource"),
+				Type:  gogithub.Ptr("Organization"),
+			}
+			repo := &gogithub.Repository{
+				Name:     gogithub.Ptr("config-db"),
+				FullName: gogithub.Ptr("flanksource/config-db"),
+				HTMLURL:  gogithub.Ptr("https://github.com/flanksource/config-db"),
+				Owner:    owner,
+			}
+
+			var results v1.ScrapeResults
+			seen := make(map[string]struct{})
+			appendOrganizationResult(&results, seen, owner)
+			appendOrganizationResult(&results, seen, owner)
+
+			Expect(results).To(HaveLen(1))
+
+			result := buildRepositoryResult(repo, v1.GitHubRepository{Owner: "flanksource", Repo: "config-db"}, nil, nil)
+
+			Expect(result.RelationshipResults).To(HaveLen(1))
+			relationship := result.RelationshipResults[0]
+			Expect(relationship.ConfigExternalID).To(Equal(v1.ExternalID{
+				ConfigType: ConfigTypeOrganization,
+				ExternalID: "github/flanksource",
+				ScraperID:  "all",
+			}))
+			Expect(relationship.RelatedExternalID).To(Equal(v1.ExternalID{
+				ConfigType: ConfigTypeRepository,
+				ExternalID: "github/flanksource/config-db",
+			}))
+			Expect(relationship.Relationship).To(Equal(RelationshipGitHubOrganizationRepository))
+		})
+
+		It("does not create an organization relationship for user-owned repositories", func() {
+			repo := &gogithub.Repository{
+				Name:    gogithub.Ptr("dotfiles"),
+				HTMLURL: gogithub.Ptr("https://github.com/aditya/dotfiles"),
+				Owner:   &gogithub.User{Login: gogithub.Ptr("aditya"), Type: gogithub.Ptr("User")},
+			}
+
+			result := buildRepositoryResult(repo, v1.GitHubRepository{Owner: "aditya", Repo: "dotfiles"}, nil, nil)
+
+			Expect(result.RelationshipResults).To(BeEmpty())
+		})
+	})
+
 	Context("OpenSSF code scanning dedupe", func() {
 		newCodeScanningAlert := func(number int, toolName, ruleID, ruleDescription string) *gogithub.Alert {
 			alert := &gogithub.Alert{
@@ -212,19 +280,27 @@ var _ = Describe("GitHubScraper", func() {
 
 			results := scraper.Scrape(ctx)
 
-			var configs []v1.ScrapeResult
+			var configs, repoConfigs, orgConfigs []v1.ScrapeResult
 			var analyses []v1.ScrapeResult
 			for _, r := range results {
 				if r.Config != nil {
 					configs = append(configs, r)
+					switch r.Type {
+					case ConfigTypeRepository:
+						repoConfigs = append(repoConfigs, r)
+					case ConfigTypeOrganization:
+						orgConfigs = append(orgConfigs, r)
+					}
 				} else if r.AnalysisResult != nil {
 					analyses = append(analyses, r)
 				}
 			}
 
-			Expect(configs).To(HaveLen(1), "expected exactly 1 GitHub::Repository config item")
+			Expect(repoConfigs).To(HaveLen(1), "expected exactly 1 GitHub::Repository config item")
+			Expect(orgConfigs).To(HaveLen(1), "expected exactly 1 GitHub::Organization config item")
+			Expect(orgConfigs[0].ScraperLess).To(BeTrue())
 
-			repo := configs[0]
+			repo := repoConfigs[0]
 			Expect(repo.Type).To(Equal("GitHub::Repository"))
 			Expect(repo.ID).To(Equal("github/flanksource/canary-checker"))
 			Expect(repo.Name).To(Equal("flanksource/canary-checker"))
@@ -307,17 +383,26 @@ var _ = Describe("GitHubScraper", func() {
 			ctx := api.NewScrapeContext(dutyCtx.New()).WithScrapeConfig(&scrapeConfig)
 			results := GithubScraper{}.Scrape(ctx)
 
-			var configs, analyses []v1.ScrapeResult
+			var configs, repoConfigs, orgConfigs, analyses []v1.ScrapeResult
 			for _, r := range results {
 				if r.Config != nil {
 					configs = append(configs, r)
+					switch r.Type {
+					case ConfigTypeRepository:
+						repoConfigs = append(repoConfigs, r)
+					case ConfigTypeOrganization:
+						orgConfigs = append(orgConfigs, r)
+					}
 				} else if r.AnalysisResult != nil {
 					analyses = append(analyses, r)
 				}
 			}
 
-			Expect(configs).To(HaveLen(1))
-			Expect(configs[0].Type).To(Equal("GitHub::Repository"))
+			Expect(configs).To(HaveLen(2))
+			Expect(repoConfigs).To(HaveLen(1))
+			Expect(repoConfigs[0].Type).To(Equal("GitHub::Repository"))
+			Expect(orgConfigs).To(HaveLen(1))
+			Expect(orgConfigs[0].ScraperLess).To(BeTrue())
 
 			var hasVulnerabilities bool
 			for _, a := range analyses {


### PR DESCRIPTION
GitHub repository scrapes now emit a shared `GitHub::Organization` config item for organization-owned repositories.

Organizations are scraperless so multiple GitHub scrapers can scrape different repos from the same org without fighting over ownership. Repository configs remain scraper-owned, and each scraper owns its own org-to-repo relationship edges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub scraping now detects repository-owning organizations.
  * Adds organization configuration records without duplicating organizations.
  * Links organizations to their repositories through relationship results.
  * User-owned repositories are not assigned organization relationships.

* **Bug Fixes**
  * Improved handling of organization information in GitHub scrape results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->