### PR TITLE
fix(codeql): Disable dependency caching

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,7 +51,7 @@ jobs:
         uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           languages: go
-          dependency-caching: true
+          dependency-caching: false
 
       # Build with slim tag to exclude heavy cloud provider dependencies (AWS/Azure/GCP SDKs)
       - name: Build


### PR DESCRIPTION
Don't use two different cache source.

Both actions restored the same Go module cache, leaving CodeQL with thousands of "File exists" errors and misleading missing go.sum failures. Let setup-go own the cache and disable CodeQL's duplicate caching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security analysis workflow configuration to improve scan consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->