### PR TITLE
fix: Do not pin flanksource/action-workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-    uses: flanksource/action-workflows/.github/workflows/create-release.yml@a7df3dcb783c34338e46318364e99c0ada62bcd9
+    uses: flanksource/action-workflows/.github/workflows/create-release.yml@main
     secrets:
       token: ${{ secrets.FLANKBOT }}
   binary:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to use the latest release automation configuration.
  * Existing release outputs and dependent steps continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->