### PR TITLE
fix: pass GitHub token to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     uses: flanksource/action-workflows/.github/workflows/create-release.yml@main
     secrets:
-      token: ${{ github.token }}
+      token: ${{ secrets.GITHUB_TOKEN }}
   binary:
     runs-on: ubuntu-latest
     needs: create-release


### PR DESCRIPTION
The release workflow failed during checkout because `github.token` resolves to null at the reusable-workflow call site.

Pass the automatically provided `GITHUB_TOKEN` secret so checkout and semantic-release receive the required token.