### PR TITLE
ci: Pin release workflow and IAM dep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-    uses: flanksource/action-workflows/.github/workflows/create-release.yml@main
+    uses: flanksource/action-workflows/.github/workflows/create-release.yml@6e3308211f3e1694e187ea2057c24978e5a01c2f
     secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
+      token: ${{ secrets.FLANKBOT }}
   binary:
     runs-on: ubuntu-latest
     needs: create-release

--- a/go.mod
+++ b/go.mod
@@ -409,7 +409,7 @@ require (
 
 require (
 	cloud.google.com/go v0.123.0 // indirect
-	cloud.google.com/go/iam v1.7.0 // indirect
+	cloud.google.com/go/iam v1.7.0
 	cloud.google.com/go/storage v1.62.3 // indirect
 	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect


### PR DESCRIPTION
## What
- Pin the release workflow to a known action revision.
- Use the dedicated release token.
- Declare the IAM package as a direct dependency.

## Why
- Keep release automation reproducible and expose the IAM dependency directly to consumers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow reliability by pinning the release process to a specific version.
  * Updated release authentication configuration.
  * Promoted the Google Cloud IAM dependency to a direct project requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->