### PR TITLE
fix(build): cross-compile Docker images instead of emulating with QEMU

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -30,7 +30,12 @@ jobs:
           difference=$((final_space - initial_space))
           echo "Disk space difference (in KB): $difference"
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      # Build both release platforms so PRs catch cross-compilation breakage
+      # before it reaches the release workflow
       - name: Build Container
-        run: make docker
+        run: docker buildx build --platform linux/amd64,linux/arm64 -f build/Dockerfile .
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,17 +1,40 @@
-FROM rust:bookworm@sha256:29fe4376919e25b7587a1063d7b521d9db735fc137d3cf30ae41eb326d209471 AS rust-builder-base
-COPY external/diffgen/ /app/external/diffgen
-RUN cd /app/external/diffgen/ && cargo fetch
+## Builder stages run on the build platform and cross-compile to TARGETARCH,
+## so multi-arch builds don't pay for QEMU emulation of cargo/rustc/go.
+FROM --platform=$BUILDPLATFORM rust:bookworm@sha256:29fe4376919e25b7587a1063d7b521d9db735fc137d3cf30ae41eb326d209471 AS rust-builder-base
+WORKDIR /app/external/diffgen
+COPY external/diffgen/Cargo.toml external/diffgen/Cargo.lock ./
+## cargo fetch only needs the manifests; a stub lib.rs keeps this layer
+## cached across source-only changes
+RUN mkdir -p src && touch src/lib.rs && cargo fetch
 
 FROM rust-builder-base AS rust-builder
-WORKDIR /app
-COPY Makefile /app
-COPY external/diffgen /app/external/diffgen
-RUN make rust-diffgen
+ARG BUILDARCH
+ARG TARGETARCH
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+RUN case "$TARGETARCH" in \
+    amd64) echo x86_64-unknown-linux-gnu > /rust-target ;; \
+    arm64) echo aarch64-unknown-linux-gnu > /rust-target ;; \
+    *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
+    esac && \
+    rustup target add "$(cat /rust-target)" && \
+    if [ "$BUILDARCH" != "$TARGETARCH" ]; then \
+    apt-get update && \
+    case "$TARGETARCH" in \
+    amd64) apt-get install -y --no-install-recommends gcc-x86-64-linux-gnu libc6-dev-amd64-cross ;; \
+    arm64) apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross ;; \
+    esac && \
+    rm -rf /var/lib/apt/lists/*; \
+    fi
+COPY external/diffgen/src ./src
+## cgo links target/release/libdiffgen.a by fixed path, so place the
+## cross-compiled staticlib where a native build would put it
+RUN cargo build --release --target "$(cat /rust-target)" && \
+    mkdir -p target/release && \
+    cp "target/$(cat /rust-target)/release/libdiffgen.a" target/release/libdiffgen.a
 
-FROM golang:1.26-bookworm@sha256:4f4ab2c90005e7e63cb631f0b4427f05422f241622ee3ec4727cc5febbf83e34 AS builder-base
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm@sha256:4f4ab2c90005e7e63cb631f0b4427f05422f241622ee3ec4727cc5febbf83e34 AS builder-base
 WORKDIR /app
-
-ARG VERSION
 
 COPY go.mod /app/go.mod
 COPY go.sum /app/go.sum
@@ -19,11 +42,30 @@ RUN go mod download
 
 FROM builder-base AS builder
 
+ARG VERSION
+ARG BUILDARCH
+ARG TARGETARCH
+RUN if [ "$BUILDARCH" != "$TARGETARCH" ]; then \
+    apt-get update && \
+    case "$TARGETARCH" in \
+    amd64) apt-get install -y --no-install-recommends gcc-x86-64-linux-gnu libc6-dev-amd64-cross ;; \
+    arm64) apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross ;; \
+    *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
+    esac && \
+    rm -rf /var/lib/apt/lists/*; \
+    fi
+
 COPY ./ ./
 
-COPY --from=rust-builder /app/external/diffgen/target ./external/diffgen/target
+COPY --from=rust-builder /app/external/diffgen/target/release ./external/diffgen/target/release
 
-RUN make build-prod
+RUN if [ "$BUILDARCH" != "$TARGETARCH" ]; then \
+    case "$TARGETARCH" in \
+    amd64) export CC=x86_64-linux-gnu-gcc ;; \
+    arm64) export CC=aarch64-linux-gnu-gcc ;; \
+    esac; \
+    fi && \
+    CGO_ENABLED=1 GOOS=linux GOARCH="$TARGETARCH" make build-prod
 
 FROM flanksource/base-image:0.7.1@sha256:5e819e83199855d20ba5b988e8a6f369c6f4332fa6f07c184c99838d06a77cc8
 


### PR DESCRIPTION
## Problem

Since `a33bb6c` added `platforms: linux/amd64,linux/arm64`, the release docker publish job builds the arm64 image under QEMU emulation on a single amd64 `ubuntu-latest` runner. The Dockerfile is close to a worst case for emulation — a full Rust release build (`cargo build --release` for diffgen), a cgo-linked Go build (`-tags rustdiffgen`), and `go mod download` all run emulated, which is typically 5–20× slower than native. The amd64-only baseline for "Build and push image" was ~20 minutes (run 1476); the first multi-arch run ([30620320760](https://github.com/flanksource/config-db/actions/runs/30620320760)) burned ~70 minutes on attempt 1 and was still building deep into attempt 2.

## Fix

Cross-compile instead of emulating. All builder stages are pinned to `--platform=$BUILDPLATFORM` so they always run natively on the build host, and target `$TARGETARCH`:

- **Rust**: `rustup target add aarch64-unknown-linux-gnu` + `gcc-aarch64-linux-gnu` as the linker; the staticlib is copied to `target/release/libdiffgen.a`, the fixed path `rustdiffgen.go`'s cgo directive links against.
- **Go**: `CGO_ENABLED=1 GOARCH=$TARGETARCH CC=aarch64-linux-gnu-gcc make build-prod`.
- Native builds (`BUILDARCH == TARGETARCH`, e.g. local `make docker`) skip the cross toolchain entirely and behave as before.

Only the small final runtime stage still runs under emulation (`useradd` + `config-db go-offline`, which is network-bound).

Also included:

- `cargo fetch` now depends only on `Cargo.toml`/`Cargo.lock` (with a stub `lib.rs`), so the dependency layer survives diffgen source changes.
- The go builder copies only `target/release` from the rust stage instead of the entire multi-GB `target` directory.
- The PR **Build** workflow now builds both release platforms with buildx (timeout 20 → 30 min), so cross-compilation breakage is caught on PRs instead of on release. It reuses the same pinned `docker/setup-buildx-action` SHA as `flanksource/action-workflows`.

## Validation

- Cross-compiled `diffgen` to `aarch64-unknown-linux-gnu` with the exact toolchain packages from the Dockerfile; verified the produced staticlib/cdylib are `ELF 64-bit ARM aarch64`.
- Cross-compiled the full config-db binary with `CGO_ENABLED=1 GOARCH=arm64 CC=aarch64-linux-gnu-gcc make build-prod` linking the cross-built `libdiffgen.a` — build succeeded and the output is `ELF 64-bit LSB executable, ARM aarch64, dynamically linked, interpreter /lib/ld-linux-aarch64.so.1`.
- Verified the pinned `flanksource/base-image:0.7.1` digest is a multi-arch index containing amd64 and arm64.
- Exercised the Dockerfile's `case`/`if` shell logic for amd64-native, arm64-cross, and unsupported-arch paths.
- This PR's updated Build workflow additionally runs the full multi-arch image build end-to-end as CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NaE7LcgYZXbx5igVaN2Rg