### PR TITLE
feat(gcp): add support for organizations 

### DIFF
--- a/api/v1/gcp.go
+++ b/api/v1/gcp.go
@@ -46,7 +46,6 @@ var (
 	AllIncludes = []string{IncludeIAMPolicy, IncludeAuditLogs, IncludeGroupMembers}
 )
 
-// +kubebuilder:validation:XValidation:rule="(has(self.organization) && size(self.organization) > 0) || (has(self.project) && size(self.project) > 0) || (has(self.projects) && self.projects.exists(p, size(p) > 0))",message="one of organization, project, or projects must be set"
 type GCP struct {
 	BaseScraper              `json:",inline"`
 	connection.GCPConnection `json:",inline"`

--- a/api/v1/gcp.go
+++ b/api/v1/gcp.go
@@ -52,8 +52,8 @@ type GCP struct {
 
 	// Organization to scrape, given as an organization number ("1234567890") or a
 	// qualified name ("organizations/1234567890"). Its resource hierarchy and
-	// Security Center findings are scraped once, and every project beneath it is
-	// scraped unless projects narrows the set.
+	// Security Center findings are scraped at the organization root unless projects
+	// narrows the scrape to selected project roots.
 	// Projects that belong to no organization can still be scraped by listing
 	// them in projects without an organization.
 	Organization string `json:"organization,omitempty"`
@@ -149,8 +149,8 @@ func (gcp GCP) Scope() string {
 	return strings.Join(gcp.ConfiguredProjects(), ", ")
 }
 
-// IsOrgScoped reports whether an organization was configured. Its hierarchy and
-// Security Center findings are then scraped once, on top of the per-project work.
+// IsOrgScoped reports whether an organization was configured. Its hierarchy is
+// then available in addition to the work performed at the resolved scrape roots.
 func (gcp GCP) IsOrgScoped() bool {
 	return gcp.Organization != ""
 }

--- a/api/v1/gcp.go
+++ b/api/v1/gcp.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 
@@ -48,16 +49,46 @@ var (
 type GCP struct {
 	BaseScraper              `json:",inline"`
 	connection.GCPConnection `json:",inline"`
-	Project                  string `json:"project"`
 
-	// Include is a list of GCP asset types to scrape, and/or feature flags that
-	// enable non-asset scrapers.
+	// Organization to scrape, given as an organization number ("1234567890") or a
+	// qualified name ("organizations/1234567890"). Its resource hierarchy and
+	// Security Center findings are scraped once, and every project beneath it is
+	// scraped unless projects narrows the set.
+	// Projects that belong to no organization can still be scraped by listing
+	// them in projects without an organization.
+	Organization string `json:"organization,omitempty"`
+
+	// Projects narrows the scrape to these projects, given as project ids
+	// ("gcp-proj-1") or qualified names ("projects/gcp-proj-1"). Empty means every
+	// project in the organization. Combined with an organization, only projects
+	// that actually belong to it are scraped.
+	Projects []string `json:"projects,omitempty"`
+
+	// Project is an alias for a single-entry projects list.
+	Project string `json:"project,omitempty"`
+
+	// Include holds GCP asset types and/or feature flags, and is a strict
+	// allowlist: leave it empty and everything except AuditLogs runs, but set it
+	// and only what is listed runs. Anything omitted is silently off, so narrowing
+	// one dimension turns the other off entirely:
+	//
+	//   include: [storage.googleapis.com/Bucket]   # buckets only, NO IAM/RBAC
+	//   include: [IAMPolicy]                       # IAM/RBAC only, NO assets
+	//
+	// List both to filter assets while keeping the rest:
+	//
+	//   include: [storage.googleapis.com/Bucket, IAMPolicy, IAMGroupMembers]
+	//
 	// Asset types reference: https://cloud.google.com/asset-inventory/docs/supported-asset-types
-	// Example asset type: storage.googleapis.com/Bucket
-	// Feature flags: IAMPolicy (RBAC access from IAM policy bindings) and
-	// IAMGroupMembers (expand Google group membership via the Cloud Identity
-	// groups.readonly scope) both run by default; disable group expansion with
-	// exclude: [IAMGroupMembers]. AuditLogs (BigQuery audit-log access) is opt-in.
+	//
+	// Feature flags:
+	//   IAMPolicy       - RBAC access from IAM policy bindings, and the resource
+	//                     hierarchy (organization and folder config items), which
+	//                     is read as part of the same pass.
+	//   IAMGroupMembers - expand Google group membership via the Cloud Identity
+	//                     groups.readonly scope. Disable with exclude: [IAMGroupMembers].
+	//   AuditLogs       - BigQuery audit-log access. Opt-in: it runs only when
+	//                     listed here explicitly.
 	Include []string `json:"include,omitempty"`
 
 	// Exclude is a list of GCP asset types to exclude from scraping.
@@ -71,6 +102,11 @@ type GCPAuditLogs struct {
 	// BigQuery dataset to query audit logs from
 	// Example: "default._AllLogs"
 	Dataset string `json:"dataset,omitempty"`
+
+	// Project holding the BigQuery dataset. Defaults to the scraped project.
+	// An organization-scoped scrape must set this to the project its aggregated
+	// log sink writes to, since the organization itself holds no dataset.
+	Project string `json:"project,omitempty"`
 
 	// Time range to query audit logs (defaults to last 7 days if not specified)
 	// Examples: "24h", "7d", "30d"
@@ -90,6 +126,61 @@ type GCPAuditLogs struct {
 
 	// Filter methods matching these patterns
 	Methods types.MatchExpressions `json:"methods,omitempty"`
+}
+
+const (
+	ProjectPrefix      = "projects/"
+	OrganizationPrefix = "organizations/"
+)
+
+// Validate reports whether the config names anything to scrape.
+func (gcp GCP) Validate() error {
+	if gcp.Organization == "" && len(gcp.ConfiguredProjects()) == 0 {
+		return fmt.Errorf("one of organization or projects must be set")
+	}
+	return nil
+}
+
+// Scope describes what the scrape covers, for logs and error messages.
+func (gcp GCP) Scope() string {
+	if gcp.IsOrgScoped() {
+		return OrganizationPrefix + gcp.OrganizationID()
+	}
+	return strings.Join(gcp.ConfiguredProjects(), ", ")
+}
+
+// IsOrgScoped reports whether an organization was configured. Its hierarchy and
+// Security Center findings are then scraped once, on top of the per-project work.
+func (gcp GCP) IsOrgScoped() bool {
+	return gcp.Organization != ""
+}
+
+// OrganizationID returns the bare organization number, without the
+// organizations/ prefix. Empty when no organization is configured.
+func (gcp GCP) OrganizationID() string {
+	return strings.TrimPrefix(gcp.Organization, OrganizationPrefix)
+}
+
+// ConfiguredProjects returns the explicitly named projects as bare project ids,
+// merging the singular project alias. Empty means the scrape is not narrowed to
+// a subset, i.e. every project in the organization.
+func (gcp GCP) ConfiguredProjects() []string {
+	var projects []string
+	seen := make(map[string]struct{})
+
+	for _, project := range append(slices.Clone(gcp.Projects), gcp.Project) {
+		id := strings.TrimPrefix(project, ProjectPrefix)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		projects = append(projects, id)
+	}
+
+	return projects
 }
 
 func (gcp GCP) Includes(resource string) bool {

--- a/api/v1/gcp.go
+++ b/api/v1/gcp.go
@@ -46,6 +46,7 @@ var (
 	AllIncludes = []string{IncludeIAMPolicy, IncludeAuditLogs, IncludeGroupMembers}
 )
 
+// +kubebuilder:validation:XValidation:rule="(has(self.organization) && size(self.organization) > 0) || (has(self.project) && size(self.project) > 0) || (has(self.projects) && self.projects.exists(p, size(p) > 0))",message="one of organization, project, or projects must be set"
 type GCP struct {
 	BaseScraper              `json:",inline"`
 	connection.GCPConnection `json:",inline"`

--- a/api/v1/gcp_test.go
+++ b/api/v1/gcp_test.go
@@ -36,4 +36,57 @@ var _ = Describe("GCP", func() {
 			GCP{Include: []string{"storage.googleapis.com/Bucket", "compute.googleapis.com/Instance"}},
 			[]string{"storage.googleapis.com/Bucket", "compute.googleapis.com/Instance"}),
 	)
+
+	DescribeTable("ConfiguredProjects",
+		func(config GCP, expected []string) {
+			Expect(config.ConfiguredProjects()).To(Equal(expected))
+		},
+		Entry("nothing configured", GCP{}, nil),
+		Entry("singular project alias", GCP{Project: "gcp-proj-1"}, []string{"gcp-proj-1"}),
+		Entry("qualified names are trimmed",
+			GCP{Projects: []string{"projects/gcp-proj-1", "gcp-proj-2"}},
+			[]string{"gcp-proj-1", "gcp-proj-2"}),
+		Entry("alias merges with the list",
+			GCP{Project: "gcp-proj-1", Projects: []string{"gcp-proj-2"}},
+			[]string{"gcp-proj-2", "gcp-proj-1"}),
+		Entry("alias already in the list is not duplicated",
+			GCP{Project: "gcp-proj-1", Projects: []string{"projects/gcp-proj-1"}},
+			[]string{"gcp-proj-1"}),
+		Entry("blank entries are dropped",
+			GCP{Projects: []string{"", "gcp-proj-1"}},
+			[]string{"gcp-proj-1"}),
+	)
+
+	DescribeTable("Validate",
+		func(config GCP, expectErr bool) {
+			if expectErr {
+				Expect(config.Validate()).To(HaveOccurred())
+				return
+			}
+			Expect(config.Validate()).ToNot(HaveOccurred())
+		},
+		Entry("organization only", GCP{Organization: "1234567890"}, false),
+		Entry("projects only", GCP{Projects: []string{"gcp-proj-1"}}, false),
+		Entry("singular project only", GCP{Project: "gcp-proj-1"}, false),
+		Entry("organization and projects", GCP{Organization: "1234567890", Projects: []string{"gcp-proj-1"}}, false),
+		Entry("neither", GCP{}, true),
+	)
+
+	DescribeTable("IsOrgScoped",
+		func(config GCP, expected bool) {
+			Expect(config.IsOrgScoped()).To(Equal(expected))
+		},
+		Entry("projects only", GCP{Project: "gcp-proj-1"}, false),
+		Entry("organization set", GCP{Organization: "1234567890"}, true),
+		Entry("organization and projects", GCP{Organization: "1234567890", Projects: []string{"p"}}, true),
+	)
+
+	DescribeTable("OrganizationID",
+		func(config GCP, expected string) {
+			Expect(config.OrganizationID()).To(Equal(expected))
+		},
+		Entry("bare organization number", GCP{Organization: "1234567890"}, "1234567890"),
+		Entry("organization already qualified", GCP{Organization: "organizations/1234567890"}, "1234567890"),
+		Entry("no organization", GCP{Project: "gcp-proj-1"}, ""),
+	)
 })

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -913,6 +913,11 @@ func (in *GCP) DeepCopyInto(out *GCP) {
 	*out = *in
 	in.BaseScraper.DeepCopyInto(&out.BaseScraper)
 	in.GCPConnection.DeepCopyInto(&out.GCPConnection)
+	if in.Projects != nil {
+		in, out := &in.Projects, &out.Projects
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Include != nil {
 		in, out := &in.Include, &out.Include
 		*out = make([]string, len(*in))

--- a/chart/crds/configs.flanksource.com_scrapeconfigs.yaml
+++ b/chart/crds/configs.flanksource.com_scrapeconfigs.yaml
@@ -5894,11 +5894,6 @@ spec:
                         the type for the resource.
                       type: string
                   type: object
-                  x-kubernetes-validations:
-                  - message: one of organization, project, or projects must be set
-                    rule: (has(self.organization) && size(self.organization) > 0)
-                      || (has(self.project) && size(self.project) > 0) || (has(self.projects)
-                      && self.projects.exists(p, size(p) > 0))
                 type: array
               github:
                 items:

--- a/chart/crds/configs.flanksource.com_scrapeconfigs.yaml
+++ b/chart/crds/configs.flanksource.com_scrapeconfigs.yaml
@@ -5894,6 +5894,11 @@ spec:
                         the type for the resource.
                       type: string
                   type: object
+                  x-kubernetes-validations:
+                  - message: one of organization, project, or projects must be set
+                    rule: (has(self.organization) && size(self.organization) > 0)
+                      || (has(self.project) && size(self.project) > 0) || (has(self.projects)
+                      && self.projects.exists(p, size(p) > 0))
                 type: array
               github:
                 items:

--- a/chart/crds/configs.flanksource.com_scrapeconfigs.yaml
+++ b/chart/crds/configs.flanksource.com_scrapeconfigs.yaml
@@ -5244,6 +5244,12 @@ spec:
                             description: MatchExpression uses MatchItems
                             type: string
                           type: array
+                        project:
+                          description: |-
+                            Project holding the BigQuery dataset. Defaults to the scraped project.
+                            An organization-scoped scrape must set this to the project its aggregated
+                            log sink writes to, since the organization itself holds no dataset.
+                          type: string
                         serviceNames:
                           description: Filter service names matching these patterns
                           items:
@@ -5353,14 +5359,28 @@ spec:
                       type: string
                     include:
                       description: |-
-                        Include is a list of GCP asset types to scrape, and/or feature flags that
-                        enable non-asset scrapers.
+                        Include holds GCP asset types and/or feature flags, and is a strict
+                        allowlist: leave it empty and everything except AuditLogs runs, but set it
+                        and only what is listed runs. Anything omitted is silently off, so narrowing
+                        one dimension turns the other off entirely:
+
+                          include: [storage.googleapis.com/Bucket]   # buckets only, NO IAM/RBAC
+                          include: [IAMPolicy]                       # IAM/RBAC only, NO assets
+
+                        List both to filter assets while keeping the rest:
+
+                          include: [storage.googleapis.com/Bucket, IAMPolicy, IAMGroupMembers]
+
                         Asset types reference: https://cloud.google.com/asset-inventory/docs/supported-asset-types
-                        Example asset type: storage.googleapis.com/Bucket
-                        Feature flags: IAMPolicy (RBAC access from IAM policy bindings) and
-                        IAMGroupMembers (expand Google group membership via the Cloud Identity
-                        groups.readonly scope) both run by default; disable group expansion with
-                        exclude: [IAMGroupMembers]. AuditLogs (BigQuery audit-log access) is opt-in.
+
+                        Feature flags:
+                          IAMPolicy       - RBAC access from IAM policy bindings, and the resource
+                                            hierarchy (organization and folder config items), which
+                                            is read as part of the same pass.
+                          IAMGroupMembers - expand Google group membership via the Cloud Identity
+                                            groups.readonly scope. Disable with exclude: [IAMGroupMembers].
+                          AuditLogs       - BigQuery audit-log access. Opt-in: it runs only when
+                                            listed here explicitly.
                       items:
                         type: string
                       type: array
@@ -5378,8 +5398,26 @@ spec:
                       description: A static value or JSONPath expression to use as
                         the Name for the resource.
                       type: string
+                    organization:
+                      description: |-
+                        Organization to scrape, given as an organization number ("1234567890") or a
+                        qualified name ("organizations/1234567890"). Its resource hierarchy and
+                        Security Center findings are scraped at the organization root unless projects
+                        narrows the scrape to selected project roots.
+                        Projects that belong to no organization can still be scraped by listing
+                        them in projects without an organization.
+                      type: string
                     project:
                       type: string
+                    projects:
+                      description: |-
+                        Projects narrows the scrape to these projects, given as project ids
+                        ("gcp-proj-1") or qualified names ("projects/gcp-proj-1"). Empty means every
+                        project in the organization. Combined with an organization, only projects
+                        that actually belong to it are scraped.
+                      items:
+                        type: string
+                      type: array
                     properties:
                       description: |-
                         Properties are custom templatable properties for the scraped config items
@@ -5855,8 +5893,6 @@ spec:
                       description: A static value or JSONPath expression to use as
                         the type for the resource.
                       type: string
-                  required:
-                  - project
                   type: object
                 type: array
               github:

--- a/config/schemas/config_gcp.schema.json
+++ b/config/schemas/config_gcp.schema.json
@@ -267,14 +267,26 @@
           "type": "boolean"
         },
         "project": {
-          "type": "string"
+          "type": "string",
+          "description": "Project is an alias for a single-entry projects list."
+        },
+        "organization": {
+          "type": "string",
+          "description": "Organization to scrape, given as an organization number (\"1234567890\") or a\nqualified name (\"organizations/1234567890\"). Its resource hierarchy and\nSecurity Center findings are scraped once, and every project beneath it is\nscraped unless projects narrows the set.\nProjects that belong to no organization can still be scraped by listing\nthem in projects without an organization."
+        },
+        "projects": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Projects narrows the scrape to these projects, given as project ids\n(\"gcp-proj-1\") or qualified names (\"projects/gcp-proj-1\"). Empty means every\nproject in the organization. Combined with an organization, only projects\nthat actually belong to it are scraped."
         },
         "include": {
           "items": {
             "type": "string"
           },
           "type": "array",
-          "description": "Include is a list of GCP asset types to scrape, and/or feature flags that\nenable non-asset scrapers.\nAsset types reference: https://cloud.google.com/asset-inventory/docs/supported-asset-types\nExample asset type: storage.googleapis.com/Bucket\nFeature flags: IAMPolicy (RBAC access from IAM policy bindings) and\nIAMGroupMembers (expand Google group membership via the Cloud Identity\ngroups.readonly scope) both run by default; disable group expansion with\nexclude: [IAMGroupMembers]. AuditLogs (BigQuery audit-log access) is opt-in."
+          "description": "Include holds GCP asset types and/or feature flags, and is a strict\nallowlist: leave it empty and everything except AuditLogs runs, but set it\nand only what is listed runs. Anything omitted is silently off, so narrowing\none dimension turns the other off entirely:\n\n  include: [storage.googleapis.com/Bucket]   # buckets only, NO IAM/RBAC\n  include: [IAMPolicy]                       # IAM/RBAC only, NO assets\n\nList both to filter assets while keeping the rest:\n\n  include: [storage.googleapis.com/Bucket, IAMPolicy, IAMGroupMembers]\n\nAsset types reference: https://cloud.google.com/asset-inventory/docs/supported-asset-types\n\nFeature flags:\n  IAMPolicy       - RBAC access from IAM policy bindings, and the resource\n                    hierarchy (organization and folder config items), which\n                    is read as part of the same pass.\n  IAMGroupMembers - expand Google group membership via the Cloud Identity\n                    groups.readonly scope. Disable with exclude: [IAMGroupMembers].\n  AuditLogs       - BigQuery audit-log access. Opt-in: it runs only when\n                    listed here explicitly."
         },
         "exclude": {
           "items": {
@@ -289,16 +301,17 @@
         }
       },
       "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "project"
-      ]
+      "type": "object"
     },
     "GCPAuditLogs": {
       "properties": {
         "dataset": {
           "type": "string",
           "description": "BigQuery dataset to query audit logs from\nExample: \"default._AllLogs\""
+        },
+        "project": {
+          "type": "string",
+          "description": "Project holding the BigQuery dataset. Defaults to the scraped project.\nAn organization-scoped scrape must set this to the project its aggregated\nlog sink writes to, since the organization itself holds no dataset."
         },
         "since": {
           "type": "string",

--- a/config/schemas/config_gcp.schema.json
+++ b/config/schemas/config_gcp.schema.json
@@ -272,7 +272,7 @@
         },
         "organization": {
           "type": "string",
-          "description": "Organization to scrape, given as an organization number (\"1234567890\") or a\nqualified name (\"organizations/1234567890\"). Its resource hierarchy and\nSecurity Center findings are scraped once, and every project beneath it is\nscraped unless projects narrows the set.\nProjects that belong to no organization can still be scraped by listing\nthem in projects without an organization."
+          "description": "Organization to scrape, given as an organization number (\"1234567890\") or a\nqualified name (\"organizations/1234567890\"). Its resource hierarchy and\nSecurity Center findings are scraped at the organization root unless projects\nnarrows the scrape to selected project roots.\nProjects that belong to no organization can still be scraped by listing\nthem in projects without an organization."
         },
         "projects": {
           "items": {

--- a/config/schemas/scrape_config.schema.json
+++ b/config/schemas/scrape_config.schema.json
@@ -1672,7 +1672,7 @@
         },
         "organization": {
           "type": "string",
-          "description": "Organization to scrape, given as an organization number (\"1234567890\") or a\nqualified name (\"organizations/1234567890\"). Its resource hierarchy and\nSecurity Center findings are scraped once, and every project beneath it is\nscraped unless projects narrows the set.\nProjects that belong to no organization can still be scraped by listing\nthem in projects without an organization."
+          "description": "Organization to scrape, given as an organization number (\"1234567890\") or a\nqualified name (\"organizations/1234567890\"). Its resource hierarchy and\nSecurity Center findings are scraped at the organization root unless projects\nnarrows the scrape to selected project roots.\nProjects that belong to no organization can still be scraped by listing\nthem in projects without an organization."
         },
         "projects": {
           "items": {

--- a/config/schemas/scrape_config.schema.json
+++ b/config/schemas/scrape_config.schema.json
@@ -1667,14 +1667,26 @@
           "type": "boolean"
         },
         "project": {
-          "type": "string"
+          "type": "string",
+          "description": "Project is an alias for a single-entry projects list."
+        },
+        "organization": {
+          "type": "string",
+          "description": "Organization to scrape, given as an organization number (\"1234567890\") or a\nqualified name (\"organizations/1234567890\"). Its resource hierarchy and\nSecurity Center findings are scraped once, and every project beneath it is\nscraped unless projects narrows the set.\nProjects that belong to no organization can still be scraped by listing\nthem in projects without an organization."
+        },
+        "projects": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Projects narrows the scrape to these projects, given as project ids\n(\"gcp-proj-1\") or qualified names (\"projects/gcp-proj-1\"). Empty means every\nproject in the organization. Combined with an organization, only projects\nthat actually belong to it are scraped."
         },
         "include": {
           "items": {
             "type": "string"
           },
           "type": "array",
-          "description": "Include is a list of GCP asset types to scrape, and/or feature flags that\nenable non-asset scrapers.\nAsset types reference: https://cloud.google.com/asset-inventory/docs/supported-asset-types\nExample asset type: storage.googleapis.com/Bucket\nFeature flags: IAMPolicy (RBAC access from IAM policy bindings) and\nIAMGroupMembers (expand Google group membership via the Cloud Identity\ngroups.readonly scope) both run by default; disable group expansion with\nexclude: [IAMGroupMembers]. AuditLogs (BigQuery audit-log access) is opt-in."
+          "description": "Include holds GCP asset types and/or feature flags, and is a strict\nallowlist: leave it empty and everything except AuditLogs runs, but set it\nand only what is listed runs. Anything omitted is silently off, so narrowing\none dimension turns the other off entirely:\n\n  include: [storage.googleapis.com/Bucket]   # buckets only, NO IAM/RBAC\n  include: [IAMPolicy]                       # IAM/RBAC only, NO assets\n\nList both to filter assets while keeping the rest:\n\n  include: [storage.googleapis.com/Bucket, IAMPolicy, IAMGroupMembers]\n\nAsset types reference: https://cloud.google.com/asset-inventory/docs/supported-asset-types\n\nFeature flags:\n  IAMPolicy       - RBAC access from IAM policy bindings, and the resource\n                    hierarchy (organization and folder config items), which\n                    is read as part of the same pass.\n  IAMGroupMembers - expand Google group membership via the Cloud Identity\n                    groups.readonly scope. Disable with exclude: [IAMGroupMembers].\n  AuditLogs       - BigQuery audit-log access. Opt-in: it runs only when\n                    listed here explicitly."
         },
         "exclude": {
           "items": {
@@ -1689,16 +1701,17 @@
         }
       },
       "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "project"
-      ]
+      "type": "object"
     },
     "GCPAuditLogs": {
       "properties": {
         "dataset": {
           "type": "string",
           "description": "BigQuery dataset to query audit logs from\nExample: \"default._AllLogs\""
+        },
+        "project": {
+          "type": "string",
+          "description": "Project holding the BigQuery dataset. Defaults to the scraped project.\nAn organization-scoped scrape must set this to the project its aggregated\nlog sink writes to, since the organization itself holds no dataset."
         },
         "since": {
           "type": "string",

--- a/fixtures/gcp.yaml
+++ b/fixtures/gcp.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: mc
 spec:
   gcp:
+    # An organization on its own scrapes every project beneath it. Add projects to
+    # narrow it to those that belong to the organization. Listing projects without
+    # an organization still works, but identities are then tenanted by project.
+    #- organization: "1234567890"
+    #  projects:
+    #    - workload-prod-eu-02
     - project: workload-prod-eu-02
       exclude:
         - SecurityCenter
@@ -19,6 +25,9 @@ spec:
         #- AuditLogs         # access history from the BigQuery audit-log dataset
       #auditLogs:
         #dataset: default._AllLogs
+        # Project holding the dataset. Required when scraping an organization or
+        # more than one project, since the dataset lives in exactly one project.
+        #project: logging-prod
         #since: 30d
         #excludeMethods:
           #- io.k8s.*

--- a/fixtures/gcp.yaml
+++ b/fixtures/gcp.yaml
@@ -16,11 +16,13 @@ spec:
         - SecurityCenter
         #- IAMGroupMembers  # disable Google-group expansion (needs Cloud Identity groups.readonly)
       #connection: connection://mc/gcloud-flanksource
+      # IAMPolicy and IAMGroupMembers run by default only when include is empty.
+      # Once include filters asset types, list the IAM flags explicitly to keep IAM data:
       #include:
         #- storage.googleapis.com/Bucket
         #- container.googleapis.com/Cluster
-        # IAMPolicy (RBAC: users/groups/service-accounts -> roles) and
-        # IAMGroupMembers (expand Google group membership) run by default.
+        #- IAMPolicy         # RBAC: users/groups/service-accounts -> roles
+        #- IAMGroupMembers   # expand Google group membership
         # AuditLogs is opt-in and only runs when listed here:
         #- AuditLogs         # access history from the BigQuery audit-log dataset
       #auditLogs:

--- a/scrapers/gcp/ancestry.go
+++ b/scrapers/gcp/ancestry.go
@@ -1,0 +1,159 @@
+// Resolves asset ancestry into config relationships: the project that owns each
+// asset, and the resource hierarchy links between organizations, folders and
+// projects discovered by an organization-scoped scrape.
+package gcp
+
+import (
+	"strings"
+
+	"cloud.google.com/go/asset/apiv1/assetpb"
+
+	v1 "github.com/flanksource/config-db/api/v1"
+)
+
+const (
+	projectAssetType      = "cloudresourcemanager.googleapis.com/Project"
+	folderAssetType       = "cloudresourcemanager.googleapis.com/Folder"
+	organizationAssetType = "cloudresourcemanager.googleapis.com/Organization"
+
+	organizationPrefix      = "organizations/"
+	organizationConfigClass = "ResourceManager::Organization"
+)
+
+// isResourceManagerNode reports whether an asset is a node of the resource
+// hierarchy, whose parent comes from its ancestry rather than from a relationship
+// resolver.
+func isResourceManagerNode(assetType string) bool {
+	switch assetType {
+	case projectAssetType, folderAssetType, organizationAssetType:
+		return true
+	}
+	return false
+}
+
+// resourceManagerParent returns the immediate hierarchy parent of an asset from
+// its ancestry, nil for an organization (which has no parent). Ancestry starts
+// with the asset itself, so the parent is the second entry.
+func resourceManagerParent(ancestors []string) (*v1.ConfigExternalKey, error) {
+	if len(ancestors) < 2 {
+		return nil, nil
+	}
+
+	metadata, err := resourceManagerMetadataForName(ancestors[1])
+	if err != nil {
+		return nil, err
+	}
+
+	return &v1.ConfigExternalKey{
+		Type:       "GCP::" + metadata.ConfigClass,
+		ExternalID: resourceManagerPrefix + metadata.Name,
+	}, nil
+}
+
+// assetAncestry is the ancestry of a scraped asset, retained so the owning
+// project can be attached once the whole listing has been seen.
+type assetAncestry struct {
+	ancestors       []string
+	isHierarchyNode bool
+}
+
+// projectResolver maps a project number to its project id. Cloud Asset
+// Inventory reports ancestry as project numbers ("projects/123456789") while
+// config items are keyed by project id ("gcp-proj-1"); the Project assets in the
+// same listing carry both, so the mapping is built as assets stream past.
+type projectResolver struct {
+	fallback string
+	ids      map[string]string
+}
+
+// newProjectResolver returns a resolver that falls back to the given project id
+// for assets with no resolvable ancestor project. Org-scoped scrapes pass an
+// empty fallback.
+func newProjectResolver(fallback string) *projectResolver {
+	return &projectResolver{fallback: fallback, ids: map[string]string{}}
+}
+
+// record learns the number→id mapping from a project asset, ignoring every
+// other asset type.
+func (r *projectResolver) record(asset *assetpb.Asset) {
+	if asset.AssetType != projectAssetType || asset.Resource == nil || asset.Resource.Data == nil {
+		return
+	}
+
+	fields := asset.Resource.Data.Fields
+	projectID := fields["projectId"].GetStringValue()
+	if projectID == "" {
+		return
+	}
+
+	number := fields["projectNumber"].GetStringValue()
+	if number == "" {
+		// The v3 Cloud Resource Manager representation carries the number in
+		// the resource name instead: projects/123456789.
+		number = strings.TrimPrefix(trimResourceManagerPrefix(asset.Name), "projects/")
+		if name := fields["name"].GetStringValue(); strings.HasPrefix(name, "projects/") {
+			number = strings.TrimPrefix(name, "projects/")
+		}
+	}
+	if number == "" {
+		return
+	}
+
+	r.ids[number] = projectID
+}
+
+// resolve returns the project id owning an asset with the given ancestry.
+func (r *projectResolver) resolve(ancestors []string) string {
+	number := projectNumberFromAncestors(ancestors)
+	if number == "" {
+		return r.fallback
+	}
+	if id, ok := r.ids[number]; ok {
+		return id
+	}
+	if r.fallback != "" {
+		return r.fallback
+	}
+	// Better to attribute the asset to the bare number than to drop the
+	// association entirely when the project asset was filtered out of the scrape.
+	return number
+}
+
+// organizationFromAncestors returns the organization number an asset lives under,
+// empty for an asset with no organization. Cloud Asset Inventory reports the full
+// ancestry on every asset, so this needs no Cloud Resource Manager permission.
+func organizationFromAncestors(ancestors []string) string {
+	for _, ancestor := range ancestors {
+		if number, ok := strings.CutPrefix(ancestor, organizationPrefix); ok {
+			return number
+		}
+	}
+	return ""
+}
+
+// organizationFromAssets returns the first organization found in the ancestry of
+// any listed asset.
+func organizationFromAssets(assets []*assetpb.Asset) string {
+	for _, asset := range assets {
+		if organization := organizationFromAncestors(asset.Ancestors); organization != "" {
+			return organization
+		}
+	}
+	return ""
+}
+
+// projectNumberFromAncestors returns the number of the closest ancestor project,
+// empty for assets that live above the project level (folders, organizations).
+// Ancestry starts at the closest ancestor: ["projects/123", "folders/5", "organizations/1"].
+func projectNumberFromAncestors(ancestors []string) string {
+	for _, ancestor := range ancestors {
+		if number, ok := strings.CutPrefix(ancestor, "projects/"); ok {
+			return number
+		}
+	}
+	return ""
+}
+
+func trimResourceManagerPrefix(name string) string {
+	return strings.TrimPrefix(name, resourceManagerPrefix)
+}

--- a/scrapers/gcp/ancestry_test.go
+++ b/scrapers/gcp/ancestry_test.go
@@ -1,0 +1,161 @@
+package gcp
+
+import (
+	"cloud.google.com/go/asset/apiv1/assetpb"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func projectAsset(name string, fields map[string]any) *assetpb.Asset {
+	data, err := structpb.NewStruct(fields)
+	Expect(err).ToNot(HaveOccurred())
+	return &assetpb.Asset{
+		Name:      name,
+		AssetType: projectAssetType,
+		Resource:  &assetpb.Resource{Data: data},
+	}
+}
+
+var _ = Describe("projectNumberFromAncestors", func() {
+	DescribeTable("extracts the owning project number",
+		func(ancestors []string, expected string) {
+			Expect(projectNumberFromAncestors(ancestors)).To(Equal(expected))
+		},
+		Entry("full ancestry", []string{"projects/123456789", "folders/5432", "organizations/1234"}, "123456789"),
+		Entry("project directly under org", []string{"projects/123456789", "organizations/1234"}, "123456789"),
+		Entry("the project asset itself", []string{"projects/123456789"}, "123456789"),
+		Entry("folder has no owning project", []string{"folders/5432", "organizations/1234"}, ""),
+		Entry("org has no owning project", []string{"organizations/1234"}, ""),
+		Entry("no ancestors", nil, ""),
+	)
+})
+
+var _ = Describe("projectResolver", func() {
+	It("maps an asset to the project id of its ancestor project", func() {
+		resolver := newProjectResolver("")
+		resolver.record(projectAsset(
+			"//cloudresourcemanager.googleapis.com/projects/123456789",
+			map[string]any{"projectId": "gcp-proj-1", "name": "projects/123456789"},
+		))
+
+		Expect(resolver.resolve([]string{"projects/123456789", "organizations/1234"})).To(Equal("gcp-proj-1"))
+	})
+
+	It("reads the project number from projectNumber when present", func() {
+		resolver := newProjectResolver("")
+		resolver.record(projectAsset(
+			"//cloudresourcemanager.googleapis.com/projects/whatever",
+			map[string]any{"projectId": "gcp-proj-2", "projectNumber": "987654321"},
+		))
+
+		Expect(resolver.resolve([]string{"projects/987654321"})).To(Equal("gcp-proj-2"))
+	})
+
+	It("falls back to the configured project when the number is unknown", func() {
+		resolver := newProjectResolver("gcp-proj-fallback")
+		Expect(resolver.resolve([]string{"projects/000000000"})).To(Equal("gcp-proj-fallback"))
+	})
+
+	It("falls back to the bare project number when org-scoped and the project asset is missing", func() {
+		resolver := newProjectResolver("")
+		Expect(resolver.resolve([]string{"projects/123456789"})).To(Equal("123456789"))
+	})
+
+	It("returns the fallback when the asset has no ancestor project", func() {
+		resolver := newProjectResolver("gcp-proj-fallback")
+		Expect(resolver.resolve([]string{"organizations/1234"})).To(Equal("gcp-proj-fallback"))
+	})
+
+	It("ignores non-project assets", func() {
+		resolver := newProjectResolver("")
+		resolver.record(&assetpb.Asset{
+			Name:      "//compute.googleapis.com/projects/gcp-proj-1/zones/us-east1-b/instances/vm",
+			AssetType: "compute.googleapis.com/Instance",
+		})
+
+		Expect(resolver.resolve([]string{"projects/123456789"})).To(Equal("123456789"))
+	})
+})
+
+var _ = Describe("resourceManagerParent", func() {
+	It("links a folder to its parent folder", func() {
+		parent, err := resourceManagerParent([]string{"folders/5432", "folders/999", "organizations/1234"})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(parent).ToNot(BeNil())
+		Expect(parent.Type).To(Equal("GCP::ResourceManager::Folder"))
+		Expect(parent.ExternalID).To(Equal("//cloudresourcemanager.googleapis.com/folders/999"))
+	})
+
+	It("links a folder directly under the organization", func() {
+		parent, err := resourceManagerParent([]string{"folders/5432", "organizations/1234"})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(parent).ToNot(BeNil())
+		Expect(parent.Type).To(Equal("GCP::ResourceManager::Organization"))
+		Expect(parent.ExternalID).To(Equal("//cloudresourcemanager.googleapis.com/organizations/1234"))
+	})
+
+	It("links a project to its parent folder", func() {
+		parent, err := resourceManagerParent([]string{"projects/123456789", "folders/5432", "organizations/1234"})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(parent).ToNot(BeNil())
+		Expect(parent.Type).To(Equal("GCP::ResourceManager::Folder"))
+		Expect(parent.ExternalID).To(Equal("//cloudresourcemanager.googleapis.com/folders/5432"))
+	})
+
+	It("returns no parent for the organization itself", func() {
+		parent, err := resourceManagerParent([]string{"organizations/1234"})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(parent).To(BeNil())
+	})
+
+	It("returns no parent when ancestry is missing", func() {
+		parent, err := resourceManagerParent(nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(parent).To(BeNil())
+	})
+})
+
+var _ = Describe("organizationFromAncestors", func() {
+	DescribeTable("finds the organization in an ancestry chain",
+		func(ancestors []string, expected string) {
+			Expect(organizationFromAncestors(ancestors)).To(Equal(expected))
+		},
+		Entry("full chain", []string{"projects/123", "folders/5432", "organizations/1234"}, "1234"),
+		Entry("project directly under org", []string{"projects/123", "organizations/1234"}, "1234"),
+		Entry("no organization", []string{"projects/123"}, ""),
+		Entry("no ancestors", nil, ""),
+	)
+})
+
+var _ = Describe("organizationFromAssets", func() {
+	It("finds the organization from any listed asset", func() {
+		assets := []*assetpb.Asset{
+			{Name: "//storage.googleapis.com/b", Ancestors: []string{"projects/123"}},
+			{Name: "//compute.googleapis.com/vm", Ancestors: []string{"projects/123", "organizations/1234"}},
+		}
+
+		Expect(organizationFromAssets(assets)).To(Equal("1234"))
+	})
+
+	It("returns empty when no asset has an organization ancestor", func() {
+		assets := []*assetpb.Asset{
+			{Name: "//storage.googleapis.com/b", Ancestors: []string{"projects/123"}},
+		}
+
+		Expect(organizationFromAssets(assets)).To(BeEmpty())
+	})
+})
+
+var _ = Describe("isResourceManagerNode", func() {
+	DescribeTable("recognises the resource hierarchy asset types",
+		func(assetType string, expected bool) {
+			Expect(isResourceManagerNode(assetType)).To(Equal(expected))
+		},
+		Entry("project", "cloudresourcemanager.googleapis.com/Project", true),
+		Entry("folder", "cloudresourcemanager.googleapis.com/Folder", true),
+		Entry("organization", "cloudresourcemanager.googleapis.com/Organization", true),
+		Entry("compute instance", "compute.googleapis.com/Instance", false),
+		Entry("apigee organization", "apigee.googleapis.com/Organization", false),
+	)
+})

--- a/scrapers/gcp/audit_logs.go
+++ b/scrapers/gcp/audit_logs.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -22,6 +23,7 @@ type BigQueryRow struct {
 	Email          string    `bigquery:"email"`
 	Permission     string    `bigquery:"permission"`
 	PermissionType string    `bigquery:"permission_type"`
+	ProjectID      string    `bigquery:"project_id"`
 	Timestamp      time.Time `bigquery:"timestamp"`
 }
 
@@ -101,19 +103,25 @@ func buildAuditLogQuery(auditLogs v1.GCPAuditLogs) (string, []bigquery.QueryPara
 WITH auth as (
   select  
     timestamp,
-    proto_payload.audit_log,
     proto_payload.audit_log.service_name as service_name,
-    proto_payload.audit_log.authentication_info.principal_email as email,  
-    proto_payload.audit_log.authorization_info[0].permission_type AS permission_type,
-    proto_payload.audit_log.authorization_info[0].permission AS permission
-  FROM `+"`%s`"+`
+    proto_payload.audit_log.authentication_info.principal_email as email,
+    authorization.permission_type AS permission_type,
+    authorization.permission AS permission,
+    COALESCE(
+      NULLIF(JSON_VALUE(TO_JSON(resource.labels), '$.project_id'), ''),
+      REGEXP_EXTRACT(authorization.resource, r'(?:^|/)projects/([^/]+)'),
+      REGEXP_EXTRACT(log_name, r'(?:^|/)projects/([^/]+)'),
+      ''
+    ) AS project_id
+  FROM `+"`%s`"+`,
+  UNNEST(proto_payload.audit_log.authorization_info) AS authorization
   Where %s
 ) 
 
-SELECT email, permission, permission_type, max(timestamp) as timestamp
+SELECT email, permission, permission_type, project_id, max(timestamp) as timestamp
 from auth 
 %s
-group by email, permission, permission_type
+group by email, permission, permission_type, project_id
 `, auditLogs.Dataset, cteWhereClause, outerWhereClause)
 
 	finalArgs := append(cteArgs, outerArgs...)
@@ -124,9 +132,33 @@ group by email, permission, permission_type
 	return finalQuery, args, nil
 }
 
-// FetchAuditLogs fetches external roles and config accesses from BigQuery audit logs
-func (gcp Scraper) FetchAuditLogs(ctx *GCPContext, config v1.GCP, project string) (v1.ScrapeResults, error) {
-	bqClient, err := bigquery.NewClient(ctx, project, ctx.ClientOpts...)
+// auditLogAffectedProject resolves the project affected by a log row. Project
+// roots restrict an aggregated sink to the selected scrape scope; an
+// organization root means every affected project is allowed. Rows without an
+// affected project are skipped rather than attributed to the dataset project.
+func auditLogAffectedProject(row BigQueryRow, parents []string) (string, bool) {
+	var scopedProjects []string
+	for _, parent := range parents {
+		if project := projectFromParent(parent); project != "" {
+			scopedProjects = append(scopedProjects, project)
+		}
+	}
+
+	project := strings.TrimPrefix(row.ProjectID, v1.ProjectPrefix)
+	if project == "" {
+		return "", false
+	}
+	if len(scopedProjects) > 0 && !slices.Contains(scopedProjects, project) {
+		return "", false
+	}
+	return project, true
+}
+
+// FetchAuditLogs fetches external roles and config accesses from BigQuery audit
+// logs. datasetProject is only the BigQuery transport/billing project; each row
+// is attached to the project affected by the underlying audit event.
+func (gcp Scraper) FetchAuditLogs(ctx *GCPContext, config v1.GCP, datasetProject string, parents []string) (v1.ScrapeResults, error) {
+	bqClient, err := bigquery.NewClient(ctx, datasetProject, ctx.ClientOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create BigQuery client: %w", err)
 	}
@@ -162,15 +194,21 @@ func (gcp Scraper) FetchAuditLogs(ctx *GCPContext, config v1.GCP, project string
 			return nil, fmt.Errorf("failed to read BigQuery row: %w", err)
 		}
 
-		// All the audit logs are attached to the project config.
-		var resourceID v1.ExternalID
-		resourceID.ExternalID = fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s", project)
-		resourceID.ConfigType = "GCP::Compute::Project"
+		affectedProject, ok := auditLogAffectedProject(row, parents)
+		if !ok {
+			ctx.Warnf("gcp audit logs: skipping access with unresolved or out-of-scope project %q", row.ProjectID)
+			continue
+		}
+
+		resourceID := v1.ExternalID{
+			ExternalID: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s", affectedProject),
+			ConfigType: v1.GCPProject,
+		}
 
 		uniquePermissions.Insert(row.Permission)
 
 		configAccesses = append(configAccesses, v1.ExternalConfigAccess{
-			ID:               generateConsistentID(fmt.Sprintf("%s::%s::%s::%s", project, row.Email, row.Permission, row.PermissionType)).String(),
+			ID:               generateConsistentID(fmt.Sprintf("%s::%s::%s::%s", affectedProject, row.Email, row.Permission, row.PermissionType)).String(),
 			ExternalUserID:   lo.ToPtr(generateConsistentID(row.Email)),
 			ExternalRoleID:   lo.ToPtr(generateConsistentID(row.Permission)),
 			OwnerScraperID:   ctx.ScrapeConfig().GetPersistedID(),

--- a/scrapers/gcp/audit_logs.go
+++ b/scrapers/gcp/audit_logs.go
@@ -125,8 +125,8 @@ group by email, permission, permission_type
 }
 
 // FetchAuditLogs fetches external roles and config accesses from BigQuery audit logs
-func (gcp Scraper) FetchAuditLogs(ctx *GCPContext, config v1.GCP) (v1.ScrapeResults, error) {
-	bqClient, err := bigquery.NewClient(ctx, config.Project, ctx.ClientOpts...)
+func (gcp Scraper) FetchAuditLogs(ctx *GCPContext, config v1.GCP, project string) (v1.ScrapeResults, error) {
+	bqClient, err := bigquery.NewClient(ctx, project, ctx.ClientOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create BigQuery client: %w", err)
 	}
@@ -164,13 +164,13 @@ func (gcp Scraper) FetchAuditLogs(ctx *GCPContext, config v1.GCP) (v1.ScrapeResu
 
 		// All the audit logs are attached to the project config.
 		var resourceID v1.ExternalID
-		resourceID.ExternalID = fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s", config.Project)
+		resourceID.ExternalID = fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s", project)
 		resourceID.ConfigType = "GCP::Compute::Project"
 
 		uniquePermissions.Insert(row.Permission)
 
 		configAccesses = append(configAccesses, v1.ExternalConfigAccess{
-			ID:               generateConsistentID(fmt.Sprintf("%s::%s::%s::%s", config.Project, row.Email, row.Permission, row.PermissionType)).String(),
+			ID:               generateConsistentID(fmt.Sprintf("%s::%s::%s::%s", project, row.Email, row.Permission, row.PermissionType)).String(),
 			ExternalUserID:   lo.ToPtr(generateConsistentID(row.Email)),
 			ExternalRoleID:   lo.ToPtr(generateConsistentID(row.Permission)),
 			OwnerScraperID:   ctx.ScrapeConfig().GetPersistedID(),

--- a/scrapers/gcp/audit_logs_test.go
+++ b/scrapers/gcp/audit_logs_test.go
@@ -53,19 +53,25 @@ func TestBuildAuditLogQuery_SpecificSQL(t *testing.T) {
 WITH auth as (
   select  
     timestamp,
-    proto_payload.audit_log,
     proto_payload.audit_log.service_name as service_name,
-    proto_payload.audit_log.authentication_info.principal_email as email,  
-    proto_payload.audit_log.authorization_info[0].permission_type AS permission_type,
-    proto_payload.audit_log.authorization_info[0].permission AS permission
-  FROM ` + "`default._AllLogs`" + `
+    proto_payload.audit_log.authentication_info.principal_email as email,
+    authorization.permission_type AS permission_type,
+    authorization.permission AS permission,
+    COALESCE(
+      NULLIF(JSON_VALUE(TO_JSON(resource.labels), '$.project_id'), ''),
+      REGEXP_EXTRACT(authorization.resource, r'(?:^|/)projects/([^/]+)'),
+      REGEXP_EXTRACT(log_name, r'(?:^|/)projects/([^/]+)'),
+      ''
+    ) AS project_id
+  FROM ` + "`default._AllLogs`" + `,
+  UNNEST(proto_payload.audit_log.authorization_info) AS authorization
   Where timestamp >= '2025-06-12' AND ARRAY_LENGTH(proto_payload.audit_log.authorization_info) > 0 AND (proto_payload.audit_log.request_metadata.caller_supplied_user_agent NOT LIKE ? AND proto_payload.audit_log.request_metadata.caller_supplied_user_agent NOT LIKE ?) AND (proto_payload.audit_log.authentication_info.principal_email NOT LIKE ? AND proto_payload.audit_log.authentication_info.principal_email NOT LIKE ? AND proto_payload.audit_log.authentication_info.principal_email NOT LIKE ?)
 ) 
 
-SELECT email, permission, permission_type, max(timestamp) as timestamp
+SELECT email, permission, permission_type, project_id, max(timestamp) as timestamp
 from auth 
 WHERE (permission NOT LIKE ? AND permission NOT LIKE ? AND permission NOT LIKE ? AND permission NOT LIKE ? AND permission NOT LIKE ? AND permission NOT LIKE ? AND permission NOT LIKE ? AND permission NOT LIKE ?) AND (service_name <> ?)
-group by email, permission, permission_type
+group by email, permission, permission_type, project_id
 `
 	g.Expect(query).To(gomega.Equal(expectedQuery), "query mismatch")
 
@@ -90,4 +96,27 @@ group by email, permission, permission_type
 	for i, expectedParam := range expectedParams {
 		g.Expect(params[i].Value).To(gomega.Equal(expectedParam), "parameter mismatch at index %d", i)
 	}
+}
+
+func TestAuditLogAffectedProject(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	project, ok := auditLogAffectedProject(
+		BigQueryRow{ProjectID: "workload-prod"},
+		[]string{"projects/workload-prod", "projects/workload-dev"},
+	)
+	g.Expect(ok).To(gomega.BeTrue())
+	g.Expect(project).To(gomega.Equal("workload-prod"))
+
+	_, ok = auditLogAffectedProject(
+		BigQueryRow{ProjectID: "outside-project"},
+		[]string{"projects/workload-prod"},
+	)
+	g.Expect(ok).To(gomega.BeFalse(), "an aggregated sink must not escape a narrowed scope")
+
+	_, ok = auditLogAffectedProject(BigQueryRow{}, []string{"projects/workload-prod"})
+	g.Expect(ok).To(gomega.BeFalse(), "a missing affected project must not fall back to the selected project")
+
+	_, ok = auditLogAffectedProject(BigQueryRow{}, []string{"organizations/1234"})
+	g.Expect(ok).To(gomega.BeFalse(), "an organization scrape must not fall back to the sink project")
 }

--- a/scrapers/gcp/audit_logs_test.go
+++ b/scrapers/gcp/audit_logs_test.go
@@ -119,4 +119,11 @@ func TestAuditLogAffectedProject(t *testing.T) {
 
 	_, ok = auditLogAffectedProject(BigQueryRow{}, []string{"organizations/1234"})
 	g.Expect(ok).To(gomega.BeFalse(), "an organization scrape must not fall back to the sink project")
+
+	project, ok = auditLogAffectedProject(
+		BigQueryRow{ProjectID: "organization-project"},
+		[]string{"organizations/1234"},
+	)
+	g.Expect(ok).To(gomega.BeTrue(), "an organization scope accepts every resolved project")
+	g.Expect(project).To(gomega.Equal("organization-project"))
 }

--- a/scrapers/gcp/cloudsql_backup.go
+++ b/scrapers/gcp/cloudsql_backup.go
@@ -1,6 +1,7 @@
 package gcp
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -14,31 +15,8 @@ import (
 )
 
 // scrapeCloudSQLBackupsForAllInstances finds Cloud SQL instances in the results and scrapes their backups
-func (gcp Scraper) scrapeCloudSQLBackupsForAllInstances(ctx *GCPContext, config v1.GCP, results v1.ScrapeResults) (v1.ScrapeResults, error) {
-	var instances []instanceInfo
-	for _, result := range results {
-		if result.Type == v1.CloudSQLInstance {
-			instanceName := result.Name
-			instanceSelfLink := ""
-
-			// Try to get the self link from the config.
-			// This will be used as the external ID to link back to the SQL instance config item.
-			if result.Config != nil {
-				if configStruct, ok := result.Config.(*structpb.Struct); ok {
-					if selfLinkField, exists := configStruct.Fields["selfLink"]; exists {
-						instanceSelfLink = selfLinkField.GetStringValue()
-					}
-				}
-			}
-
-			if instanceSelfLink == "" {
-				instanceSelfLink = result.ID
-			}
-
-			instances = append(instances, instanceInfo{name: instanceName, selfLink: instanceSelfLink})
-		}
-	}
-
+func (gcp Scraper) scrapeCloudSQLBackupsForAllInstances(ctx *GCPContext, config v1.GCP, parent string, results v1.ScrapeResults) (v1.ScrapeResults, error) {
+	instances := collectSQLInstances(results, projectFromParent(parent))
 	if len(instances) == 0 {
 		return nil, nil
 	}
@@ -59,8 +37,8 @@ func (gcp Scraper) scrapeCloudSQLBackupsForAllInstances(ctx *GCPContext, config 
 		}
 	}
 
-	if operationChanges, err := gcp.scrapeOperations(ctx, config, sqlService, instances); err != nil {
-		scrapeResults.Errorf(err, "failed to scrape operations for project %s", config.Project)
+	if operationChanges, err := gcp.scrapeOperations(ctx, sqlService, instances); err != nil {
+		scrapeResults.Errorf(err, "failed to scrape Cloud SQL operations for %s", config.Scope())
 	} else {
 		allChanges = append(allChanges, operationChanges...)
 	}
@@ -77,6 +55,64 @@ func (gcp Scraper) scrapeCloudSQLBackupsForAllInstances(ctx *GCPContext, config 
 type instanceInfo struct {
 	name     string
 	selfLink string
+	// project owns the instance. An organization-scoped scrape spans many
+	// projects, and Cloud SQL operations are listed one project at a time.
+	project string
+}
+
+// collectSQLInstances picks the Cloud SQL instances out of already-scraped
+// results, attributing each to its owning project and falling back to the
+// configured project when an asset carries no project tag.
+func collectSQLInstances(results v1.ScrapeResults, fallbackProject string) []instanceInfo {
+	var instances []instanceInfo
+	for _, result := range results {
+		if result.Type != v1.CloudSQLInstance {
+			continue
+		}
+
+		instanceSelfLink := ""
+
+		// Try to get the self link from the config.
+		// This will be used as the external ID to link back to the SQL instance config item.
+		if result.Config != nil {
+			if configStruct, ok := result.Config.(*structpb.Struct); ok {
+				if selfLinkField, exists := configStruct.Fields["selfLink"]; exists {
+					instanceSelfLink = selfLinkField.GetStringValue()
+				}
+			}
+		}
+
+		if instanceSelfLink == "" {
+			instanceSelfLink = result.ID
+		}
+
+		project := result.Tags["project"]
+		if project == "" {
+			project = fallbackProject
+		}
+
+		instances = append(instances, instanceInfo{
+			name:     result.Name,
+			selfLink: instanceSelfLink,
+			project:  project,
+		})
+	}
+
+	return instances
+}
+
+// instancesByProject groups instances by owning project so operations are listed
+// once per project. Instances with no resolvable project are dropped rather than
+// triggering a call against an empty project id.
+func instancesByProject(instances []instanceInfo) map[string][]instanceInfo {
+	grouped := make(map[string][]instanceInfo)
+	for _, instance := range instances {
+		if instance.project == "" {
+			continue
+		}
+		grouped[instance.project] = append(grouped[instance.project], instance)
+	}
+	return grouped
 }
 
 // scrapeBackupRuns scrapes Cloud SQL backup runs for a specific instance
@@ -127,9 +163,26 @@ func (gcp Scraper) scrapeBackupRuns(ctx *GCPContext, results v1.ScrapeResults, i
 	return changes, nil
 }
 
-// scrapeOperations scrapes Cloud SQL import/export operations for all instances
-func (gcp Scraper) scrapeOperations(ctx *GCPContext, config v1.GCP, service *sqladmin.Service, instances []instanceInfo) ([]v1.ChangeResult, error) {
-	ctx.Logger.V(3).Infof("scraping operations for project %s", config.Project)
+// scrapeOperations scrapes Cloud SQL import/export operations for all instances,
+// one call per project that owns an instance.
+func (gcp Scraper) scrapeOperations(ctx *GCPContext, service *sqladmin.Service, instances []instanceInfo) ([]v1.ChangeResult, error) {
+	var changes []v1.ChangeResult
+	var errs []error
+
+	for project, projectInstances := range instancesByProject(instances) {
+		projectChanges, err := gcp.scrapeProjectOperations(ctx, service, project, projectInstances)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		changes = append(changes, projectChanges...)
+	}
+
+	return changes, errors.Join(errs...)
+}
+
+func (gcp Scraper) scrapeProjectOperations(ctx *GCPContext, service *sqladmin.Service, project string, instances []instanceInfo) ([]v1.ChangeResult, error) {
+	ctx.Logger.V(3).Infof("scraping operations for project %s", project)
 
 	instanceMap := make(map[string]string) // instanceName -> selfLink
 	for _, instance := range instances {
@@ -138,7 +191,7 @@ func (gcp Scraper) scrapeOperations(ctx *GCPContext, config v1.GCP, service *sql
 
 	var changes []v1.ChangeResult
 
-	operationsCall := service.Operations.List(config.Project)
+	operationsCall := service.Operations.List(project)
 	err := operationsCall.Pages(ctx, func(operationsResp *sqladmin.OperationsListResponse) error {
 		for _, operation := range operationsResp.Items {
 			if operation.OperationType != "IMPORT" && operation.OperationType != "EXPORT" {
@@ -181,7 +234,7 @@ func (gcp Scraper) scrapeOperations(ctx *GCPContext, config v1.GCP, service *sql
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list operations: %w", err)
+		return nil, fmt.Errorf("failed to list operations for project %s: %w", project, err)
 	}
 
 	return changes, nil

--- a/scrapers/gcp/cloudsql_backup.go
+++ b/scrapers/gcp/cloudsql_backup.go
@@ -104,10 +104,13 @@ func collectSQLInstances(results v1.ScrapeResults, fallbackProject string) []ins
 // instancesByProject groups instances by owning project so operations are listed
 // once per project. Instances with no resolvable project are dropped rather than
 // triggering a call against an empty project id.
-func instancesByProject(instances []instanceInfo) map[string][]instanceInfo {
+func instancesByProject(instances []instanceInfo, warn func(format string, args ...any)) map[string][]instanceInfo {
 	grouped := make(map[string][]instanceInfo)
 	for _, instance := range instances {
 		if instance.project == "" {
+			if warn != nil {
+				warn("gcp cloud sql: skipping operations for instance %s (%s): owning project could not be resolved", instance.name, instance.selfLink)
+			}
 			continue
 		}
 		grouped[instance.project] = append(grouped[instance.project], instance)
@@ -169,7 +172,7 @@ func (gcp Scraper) scrapeOperations(ctx *GCPContext, service *sqladmin.Service, 
 	var changes []v1.ChangeResult
 	var errs []error
 
-	for project, projectInstances := range instancesByProject(instances) {
+	for project, projectInstances := range instancesByProject(instances, ctx.Warnf) {
 		projectChanges, err := gcp.scrapeProjectOperations(ctx, service, project, projectInstances)
 		if err != nil {
 			errs = append(errs, err)

--- a/scrapers/gcp/cloudsql_backup.go
+++ b/scrapers/gcp/cloudsql_backup.go
@@ -37,10 +37,10 @@ func (gcp Scraper) scrapeCloudSQLBackupsForAllInstances(ctx *GCPContext, config 
 		}
 	}
 
-	if operationChanges, err := gcp.scrapeOperations(ctx, sqlService, instances); err != nil {
+	operationChanges, err := gcp.scrapeOperations(ctx, sqlService, instances)
+	allChanges = append(allChanges, operationChanges...)
+	if err != nil {
 		scrapeResults.Errorf(err, "failed to scrape Cloud SQL operations for %s", config.Scope())
-	} else {
-		allChanges = append(allChanges, operationChanges...)
 	}
 
 	if len(allChanges) > 0 {

--- a/scrapers/gcp/cloudsql_backup_test.go
+++ b/scrapers/gcp/cloudsql_backup_test.go
@@ -1,11 +1,17 @@
 package gcp
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/flanksource/config-db/api"
+	v1 "github.com/flanksource/config-db/api/v1"
+	dutyContext "github.com/flanksource/duty/context"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/api/option"
 	"google.golang.org/protobuf/types/known/structpb"
-
-	v1 "github.com/flanksource/config-db/api/v1"
 )
 
 func sqlInstanceResult(name, selfLink, project string) v1.ScrapeResult {
@@ -54,6 +60,55 @@ var _ = Describe("collectSQLInstances", func() {
 
 		Expect(instances).To(HaveLen(1))
 		Expect(instances[0].selfLink).To(Equal("instance-id"))
+	})
+})
+
+var _ = Describe("Cloud SQL operation partial results", func() {
+	It("keeps successful project changes when another project fails", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case strings.Contains(r.URL.Path, "/projects/gcp-proj-1/operations"):
+				_, _ = w.Write([]byte(`{"items":[{"name":"operation-a","operationType":"EXPORT","status":"DONE","targetId":"db-a","startTime":"2025-06-19T12:00:00Z"}]}`))
+			case strings.Contains(r.URL.Path, "/projects/gcp-proj-2/operations"):
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"error":{"code":403,"message":"permission denied"}}`))
+			default:
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"error":{"code":404,"message":"not found"}}`))
+			}
+		}))
+		defer server.Close()
+
+		ctx := &GCPContext{
+			ScrapeContext: api.NewScrapeContext(dutyContext.New()),
+			ClientOpts: []option.ClientOption{
+				option.WithEndpoint(server.URL + "/"),
+				option.WithoutAuthentication(),
+			},
+		}
+		assets := v1.ScrapeResults{
+			sqlInstanceResult("db-a", "https://sqladmin/instances/db-a", "gcp-proj-1"),
+			sqlInstanceResult("db-b", "https://sqladmin/instances/db-b", "gcp-proj-2"),
+		}
+
+		results, err := (Scraper{}).scrapeCloudSQLBackupsForAllInstances(ctx, v1.GCP{
+			Projects: []string{"gcp-proj-1", "gcp-proj-2"},
+		}, "organizations/1234", assets)
+
+		Expect(err).ToNot(HaveOccurred())
+		var changes []v1.ChangeResult
+		var errors int
+		for _, result := range results {
+			changes = append(changes, result.Changes...)
+			if result.Error != nil {
+				errors++
+				Expect(result.Error.Error()).To(ContainSubstring("gcp-proj-2"))
+			}
+		}
+		Expect(errors).To(Equal(1))
+		Expect(changes).To(HaveLen(1))
+		Expect(changes[0].ExternalChangeID).To(Equal("operation-a"))
 	})
 })
 

--- a/scrapers/gcp/cloudsql_backup_test.go
+++ b/scrapers/gcp/cloudsql_backup_test.go
@@ -1,0 +1,82 @@
+package gcp
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	v1 "github.com/flanksource/config-db/api/v1"
+)
+
+func sqlInstanceResult(name, selfLink, project string) v1.ScrapeResult {
+	data, err := structpb.NewStruct(map[string]any{"selfLink": selfLink})
+	Expect(err).ToNot(HaveOccurred())
+
+	result := v1.ScrapeResult{
+		Type:   v1.CloudSQLInstance,
+		ID:     selfLink,
+		Name:   name,
+		Config: data,
+	}
+	if project != "" {
+		result.Tags = map[string]string{"project": project}
+	}
+	return result
+}
+
+var _ = Describe("collectSQLInstances", func() {
+	It("attributes each instance to the project that owns it", func() {
+		instances := collectSQLInstances(v1.ScrapeResults{
+			sqlInstanceResult("db-a", "https://sqladmin/instances/db-a", "gcp-proj-1"),
+			sqlInstanceResult("db-b", "https://sqladmin/instances/db-b", "gcp-proj-2"),
+			{Type: v1.GCSBucket, Name: "not-a-database"},
+		}, "")
+
+		Expect(instances).To(ConsistOf(
+			instanceInfo{name: "db-a", selfLink: "https://sqladmin/instances/db-a", project: "gcp-proj-1"},
+			instanceInfo{name: "db-b", selfLink: "https://sqladmin/instances/db-b", project: "gcp-proj-2"},
+		))
+	})
+
+	It("falls back to the configured project when the tag is missing", func() {
+		instances := collectSQLInstances(v1.ScrapeResults{
+			sqlInstanceResult("db-a", "https://sqladmin/instances/db-a", ""),
+		}, "gcp-proj-fallback")
+
+		Expect(instances).To(HaveLen(1))
+		Expect(instances[0].project).To(Equal("gcp-proj-fallback"))
+	})
+
+	It("uses the result id when the config carries no self link", func() {
+		instances := collectSQLInstances(v1.ScrapeResults{
+			{Type: v1.CloudSQLInstance, ID: "instance-id", Name: "db-a"},
+		}, "gcp-proj-1")
+
+		Expect(instances).To(HaveLen(1))
+		Expect(instances[0].selfLink).To(Equal("instance-id"))
+	})
+})
+
+var _ = Describe("instancesByProject", func() {
+	It("groups instances so each project is listed once", func() {
+		grouped := instancesByProject([]instanceInfo{
+			{name: "db-a", project: "gcp-proj-1"},
+			{name: "db-b", project: "gcp-proj-2"},
+			{name: "db-c", project: "gcp-proj-1"},
+		})
+
+		Expect(grouped).To(HaveLen(2))
+		Expect(grouped["gcp-proj-1"]).To(HaveLen(2))
+		Expect(grouped["gcp-proj-2"]).To(HaveLen(1))
+	})
+
+	It("drops instances with no resolvable project rather than querying an empty one", func() {
+		grouped := instancesByProject([]instanceInfo{
+			{name: "db-a", project: ""},
+			{name: "db-b", project: "gcp-proj-1"},
+		})
+
+		Expect(grouped).To(HaveLen(1))
+		Expect(grouped).To(HaveKey("gcp-proj-1"))
+	})
+})

--- a/scrapers/gcp/cloudsql_backup_test.go
+++ b/scrapers/gcp/cloudsql_backup_test.go
@@ -98,15 +98,15 @@ var _ = Describe("Cloud SQL operation partial results", func() {
 
 		Expect(err).ToNot(HaveOccurred())
 		var changes []v1.ChangeResult
-		var errors int
+		var errorCount int
 		for _, result := range results {
 			changes = append(changes, result.Changes...)
 			if result.Error != nil {
-				errors++
+				errorCount++
 				Expect(result.Error.Error()).To(ContainSubstring("gcp-proj-2"))
 			}
 		}
-		Expect(errors).To(Equal(1))
+		Expect(errorCount).To(Equal(1))
 		Expect(changes).To(HaveLen(1))
 		Expect(changes[0].ExternalChangeID).To(Equal("operation-a"))
 	})
@@ -118,20 +118,27 @@ var _ = Describe("instancesByProject", func() {
 			{name: "db-a", project: "gcp-proj-1"},
 			{name: "db-b", project: "gcp-proj-2"},
 			{name: "db-c", project: "gcp-proj-1"},
-		})
+		}, nil)
 
 		Expect(grouped).To(HaveLen(2))
 		Expect(grouped["gcp-proj-1"]).To(HaveLen(2))
 		Expect(grouped["gcp-proj-2"]).To(HaveLen(1))
 	})
 
-	It("drops instances with no resolvable project rather than querying an empty one", func() {
+	It("warns when dropping an instance with no resolvable project", func() {
+		var warningFormat string
+		var warningArgs []any
 		grouped := instancesByProject([]instanceInfo{
-			{name: "db-a", project: ""},
+			{name: "db-a", selfLink: "https://sqladmin/instances/db-a", project: ""},
 			{name: "db-b", project: "gcp-proj-1"},
+		}, func(format string, args ...any) {
+			warningFormat = format
+			warningArgs = args
 		})
 
 		Expect(grouped).To(HaveLen(1))
 		Expect(grouped).To(HaveKey("gcp-proj-1"))
+		Expect(warningFormat).To(ContainSubstring("owning project could not be resolved"))
+		Expect(warningArgs).To(ConsistOf("db-a", "https://sqladmin/instances/db-a"))
 	})
 })

--- a/scrapers/gcp/gcp.go
+++ b/scrapers/gcp/gcp.go
@@ -129,6 +129,15 @@ func parseResourceData(asset *assetpb.Asset) ResourceData {
 	selfLink := data.Fields["selfLink"].GetStringValue()
 	selfLink2 := strings.TrimPrefix(selfLink, "https://www.googleapis.com/compute/v1/") // Certain references are without this prefix
 
+	aliases := []string{selfLink, selfLink2}
+
+	// A service account is also an IAM principal, where it is identified by
+	// email rather than by resource name. The alias is what ties the config item
+	// to the principal holding the grants.
+	if asset.AssetType == serviceAccountAssetType {
+		aliases = append(aliases, data.Fields["email"].GetStringValue())
+	}
+
 	return ResourceData{
 		ID:        id,
 		Name:      getName(asset),
@@ -137,7 +146,7 @@ func parseResourceData(asset *assetpb.Asset) ResourceData {
 		URL:       selfLink,
 		Zone:      strings.ToLower(zone),
 		Region:    strings.ToLower(region),
-		Aliases:   []string{selfLink, selfLink2},
+		Aliases:   lo.Compact(aliases),
 		Raw:       data,
 	}
 }
@@ -169,6 +178,8 @@ func getLink(rd ResourceData) *types.Property {
 		},
 	}
 }
+
+const serviceAccountAssetType = "iam.googleapis.com/ServiceAccount"
 
 var defaultIgnoreList = []string{
 	"compute.googleapis.com/InstanceSettings",
@@ -245,11 +256,13 @@ func processResults(results v1.ScrapeResults) v1.ScrapeResults {
 	return results
 }
 
-func (gcp Scraper) FetchAllAssets(ctx *GCPContext, config v1.GCP) (v1.ScrapeResults, error) {
+// FetchAllAssets lists every asset beneath parent, which is either a single
+// project or a whole organization.
+func (gcp Scraper) FetchAllAssets(ctx *GCPContext, config v1.GCP, parent string) (v1.ScrapeResults, error) {
 	var results v1.ScrapeResults
 
 	req := &assetpb.ListAssetsRequest{
-		Parent:      fmt.Sprintf("projects/%s", config.Project),
+		Parent:      parent,
 		ContentType: assetpb.ContentType_RESOURCE,
 		AssetTypes:  []string{".*.googleapis.com.*"},
 		PageSize:    1000,
@@ -269,8 +282,13 @@ func (gcp Scraper) FetchAllAssets(ctx *GCPContext, config v1.GCP) (v1.ScrapeResu
 		}
 	}()
 
-	baseTags := []v1.Tag{{Name: "project", Value: config.Project}}
 	ignoreList := append(defaultIgnoreList, config.Exclude...)
+
+	// Ancestry is resolved after the listing completes: a project's own asset can
+	// arrive after the assets it owns, so the number→id mapping is only complete
+	// once every asset has streamed past.
+	resolver := newProjectResolver(projectFromParent(parent))
+	var ancestries []assetAncestry
 
 	it := assetClient.ListAssets(ctx, req)
 	for {
@@ -282,6 +300,8 @@ func (gcp Scraper) FetchAllAssets(ctx *GCPContext, config v1.GCP) (v1.ScrapeResu
 			return nil, fmt.Errorf("error listing assets: %w", err)
 		}
 
+		resolver.record(asset)
+
 		if lo.Contains(ignoreList, asset.AssetType) {
 			continue
 		}
@@ -291,7 +311,7 @@ func (gcp Scraper) FetchAllAssets(ctx *GCPContext, config v1.GCP) (v1.ScrapeResu
 		configClass := parseGCPConfigClass(asset.AssetType)
 		configType := fmt.Sprintf("GCP::%s", configClass)
 
-		tags := baseTags
+		var tags []v1.Tag
 
 		region := rd.Region
 		if region != "" {
@@ -303,11 +323,6 @@ func (gcp Scraper) FetchAllAssets(ctx *GCPContext, config v1.GCP) (v1.ScrapeResu
 		}
 
 		relationships := RelationshipResolver(configType, rd)
-		// Add project as parent (if multiple parents are present, we use first available)
-		relationships.Parents = append(relationships.Parents, v1.ConfigExternalKey{
-			Type:       v1.GCPProject,
-			ExternalID: config.Project,
-		})
 
 		res := v1.ScrapeResult{
 			BaseScraper:         config.BaseScraper,
@@ -332,6 +347,40 @@ func (gcp Scraper) FetchAllAssets(ctx *GCPContext, config v1.GCP) (v1.ScrapeResu
 		}
 
 		results = append(results, res)
+		ancestries = append(ancestries, assetAncestry{
+			ancestors:       asset.Ancestors,
+			isHierarchyNode: isResourceManagerNode(asset.AssetType),
+		})
+	}
+
+	for i := range results {
+		ancestry := ancestries[i]
+
+		if project := resolver.resolve(ancestry.ancestors); project != "" {
+			if results[i].Tags == nil {
+				results[i].Tags = map[string]string{}
+			}
+			results[i].Tags["project"] = project
+
+			if !ancestry.isHierarchyNode {
+				// Add project as parent (if multiple parents are present, we use first available)
+				results[i].Parents = append(results[i].Parents, v1.ConfigExternalKey{
+					Type:       v1.GCPProject,
+					ExternalID: project,
+				})
+			}
+		}
+
+		// Organizations, folders and projects hang off the hierarchy rather than
+		// off a project, so their parent comes straight from their ancestry.
+		if ancestry.isHierarchyNode {
+			parent, err := resourceManagerParent(ancestry.ancestors)
+			if err != nil {
+				ctx.Warnf("gcp assets: %v", err)
+			} else if parent != nil {
+				results[i].Parents = append(results[i].Parents, *parent)
+			}
+		}
 	}
 
 	return results, nil
@@ -341,69 +390,125 @@ func (Scraper) CanScrape(configs v1.ScraperSpec) bool {
 	return len(configs.GCP) > 0
 }
 
+// scrapeParent runs the passes that are scoped to one asset-inventory root.
+func (gcp Scraper) scrapeParent(ctx *GCPContext, config v1.GCP, parent string) v1.ScrapeResults {
+	var results v1.ScrapeResults
+
+	if len(config.GetAssetTypes()) > 0 || len(config.Include) == 0 {
+		assetResults, err := gcp.FetchAllAssets(ctx, config, parent)
+		if err != nil {
+			results.Errorf(err, "failed to fetch GCP assets for %s", parent)
+			return results
+		}
+		results = append(results, assetResults...)
+
+		if backupResults, err := gcp.scrapeCloudSQLBackupsForAllInstances(ctx, config, parent, assetResults); err != nil {
+			results.Errorf(err, "failed to scrape Cloud SQL backups for %s", parent)
+		} else {
+			results = append(results, backupResults...)
+		}
+	}
+
+	if config.Includes(v1.IncludeIAMPolicy) {
+		iamPolicy, err := gcp.FetchIAMPolicies(ctx, config, parent)
+		if err != nil {
+			results.Errorf(err, "failed to fetch GCP IAM policies for %s", parent)
+			return results
+		}
+		results = append(results, iamPolicy.Results...)
+
+		// Group-membership expansion runs by default alongside IAM policy so
+		// group grants unwrap to their members. It needs the Cloud Identity
+		// groups.readonly scope; disable with exclude: [IAMGroupMembers] when
+		// the scrape service account lacks it.
+		if config.Includes(v1.IncludeGroupMembers) && !config.Excludes(v1.IncludeGroupMembers) {
+			memberResults, err := gcp.FetchGroupMemberships(ctx, config, iamPolicy.Scope, iamPolicy.GroupEmails)
+			if err != nil {
+				results.Errorf(err, "failed to fetch GCP group memberships for %s", parent)
+			} else {
+				results = append(results, memberResults...)
+			}
+		}
+	}
+
+	return results
+}
+
+// securityCenterParents returns the roots to read findings from: the
+// organization once when there is one, otherwise every scraped project.
+func securityCenterParents(config v1.GCP, parents []string) []string {
+	if config.IsOrgScoped() {
+		return []string{v1.OrganizationPrefix + config.OrganizationID()}
+	}
+	return parents
+}
+
+// auditLogProject returns the project holding the audit-log dataset: the one
+// configured explicitly, or the sole scraped project when it is unambiguous.
+func auditLogProject(config v1.GCP) string {
+	if config.AuditLogs.Project != "" {
+		return strings.TrimPrefix(config.AuditLogs.Project, v1.ProjectPrefix)
+	}
+	if projects := config.ConfiguredProjects(); len(projects) == 1 {
+		return projects[0]
+	}
+	return ""
+}
+
 func (gcp Scraper) Scrape(ctx api.ScrapeContext) v1.ScrapeResults {
 	allResults := v1.ScrapeResults{}
 
 	for _, gcpConfig := range ctx.ScrapeConfig().Spec.GCP {
+		if err := gcpConfig.Validate(); err != nil {
+			allResults.Errorf(err, "invalid GCP scraper config")
+			continue
+		}
+
+		if !gcpConfig.IsOrgScoped() {
+			ctx.Warnf("gcp: no organization configured for %s, identities are tenanted by project", gcpConfig.Scope())
+		}
+
 		gcpCtx, err := NewGCPContext(ctx, gcpConfig)
 		if err != nil {
 			allResults.Errorf(err, "failed to create GCP context")
 			continue
 		}
 
-		if len(gcpConfig.GetAssetTypes()) > 0 || len(gcpConfig.Include) == 0 {
-			assetResults, err := gcp.FetchAllAssets(gcpCtx, gcpConfig)
-			if err != nil {
-				allResults.Errorf(err, "failed to fetch GCP assets")
-				continue
-			} else {
-				allResults = append(allResults, assetResults...)
-			}
-
-			if backupResults, err := gcp.scrapeCloudSQLBackupsForAllInstances(gcpCtx, gcpConfig, assetResults); err != nil {
-				allResults.Errorf(err, "failed to scrape Cloud SQL backups")
-			} else {
-				allResults = append(allResults, backupResults...)
-			}
+		parents, err := resolveParents(gcpCtx, gcpConfig)
+		if err != nil {
+			allResults.Errorf(err, "failed to resolve GCP scrape scope")
+			continue
+		}
+		if len(parents) == 0 {
+			ctx.Warnf("gcp: nothing to scrape for %s", gcpConfig.Scope())
+			continue
 		}
 
-		if gcpConfig.Includes(v1.IncludeIAMPolicy) {
-			iamPolicyResults, groupEmails, err := gcp.FetchIAMPolicies(gcpCtx, gcpConfig)
-			if err != nil {
-				allResults.Errorf(err, "failed to fetch GCP IAM policies for project %s", gcpConfig.Project)
-			} else {
-				allResults = append(allResults, iamPolicyResults...)
+		for _, parent := range parents {
+			allResults = append(allResults, gcp.scrapeParent(gcpCtx, gcpConfig, parent)...)
+		}
 
-				// Group-membership expansion runs by default alongside IAM
-				// policy so group grants unwrap to their members. It needs the
-				// Cloud Identity groups.readonly scope; disable per project with
-				// exclude: [IAMGroupMembers] when the scrape SA lacks it.
-				if gcpConfig.Includes(v1.IncludeGroupMembers) && !gcpConfig.Excludes(v1.IncludeGroupMembers) {
-					memberResults, err := gcp.FetchGroupMemberships(gcpCtx, gcpConfig, groupEmails)
-					if err != nil {
-						allResults.Errorf(err, "failed to fetch GCP group memberships for project %s", gcpConfig.Project)
-					} else {
-						allResults = append(allResults, memberResults...)
-					}
+		// Security Center findings cover the whole organization in one listing;
+		// without an organization they are read per project.
+		if !gcpConfig.Excludes(v1.ExcludeSecurityCenter) {
+			for _, parent := range securityCenterParents(gcpConfig, parents) {
+				if analysisResults, err := gcp.ListFindings(gcpCtx, parent); err != nil {
+					allResults.Errorf(err, "failed to scrape GCP Security Center findings for %s", parent)
+				} else {
+					allResults = append(allResults, analysisResults...)
 				}
 			}
 		}
 
-		// Audit logs must be enabled explicitly.
+		// Audit logs must be enabled explicitly. The dataset lives in a single
+		// project, so it is read once rather than per scraped project.
 		if gcpConfig.Includes(v1.IncludeAuditLogs) && len(gcpConfig.Include) > 0 {
-			accessLogResults, err := gcp.FetchAuditLogs(gcpCtx, gcpConfig)
-			if err != nil {
-				allResults.Errorf(err, "failed to fetch GCP access logs for project %s", gcpConfig.Project)
+			if project := auditLogProject(gcpConfig); project == "" {
+				ctx.Warnf("gcp: skipping audit logs for %s, set auditLogs.project to the project holding the dataset", gcpConfig.Scope())
+			} else if accessLogResults, err := gcp.FetchAuditLogs(gcpCtx, gcpConfig, project); err != nil {
+				allResults.Errorf(err, "failed to fetch GCP access logs for project %s", project)
 			} else {
 				allResults = append(allResults, accessLogResults...)
-			}
-		}
-
-		if !gcpConfig.Excludes(v1.ExcludeSecurityCenter) {
-			if analysisResults, err := gcp.ListFindings(gcpCtx, gcpConfig); err != nil {
-				allResults.Errorf(err, "failed to scrape GCP Security Center findings")
-			} else {
-				allResults = append(allResults, analysisResults...)
 			}
 		}
 	}

--- a/scrapers/gcp/gcp.go
+++ b/scrapers/gcp/gcp.go
@@ -248,6 +248,7 @@ func addExtraAliases(results v1.ScrapeResults) v1.ScrapeResults {
 }
 
 func processResults(results v1.ScrapeResults) v1.ScrapeResults {
+	results = coalesceIAMRoleConfigs(results)
 	results = mergeDNSRecordSetsIntoManagedZone(results)
 	results = stripUnwantedFields(results)
 	results = cleanLinks(results)
@@ -434,12 +435,10 @@ func (gcp Scraper) scrapeParent(ctx *GCPContext, config v1.GCP, parent string) v
 	return results
 }
 
-// securityCenterParents returns the roots to read findings from: the
-// organization once when there is one, otherwise every scraped project.
-func securityCenterParents(config v1.GCP, parents []string) []string {
-	if config.IsOrgScoped() {
-		return []string{v1.OrganizationPrefix + config.OrganizationID()}
-	}
+// securityCenterParents returns the already-resolved scrape roots. An
+// unrestricted organization has one organization root, while a narrowed
+// organization has only its selected project roots.
+func securityCenterParents(parents []string) []string {
 	return parents
 }
 
@@ -488,10 +487,10 @@ func (gcp Scraper) Scrape(ctx api.ScrapeContext) v1.ScrapeResults {
 			allResults = append(allResults, gcp.scrapeParent(gcpCtx, gcpConfig, parent)...)
 		}
 
-		// Security Center findings cover the whole organization in one listing;
-		// without an organization they are read per project.
+		// Security Center follows the resolved scope: one organization listing for
+		// an unrestricted organization, or one listing per selected project.
 		if !gcpConfig.Excludes(v1.ExcludeSecurityCenter) {
-			for _, parent := range securityCenterParents(gcpConfig, parents) {
+			for _, parent := range securityCenterParents(parents) {
 				if analysisResults, err := gcp.ListFindings(gcpCtx, parent); err != nil {
 					allResults.Errorf(err, "failed to scrape GCP Security Center findings for %s", parent)
 				} else {
@@ -505,7 +504,7 @@ func (gcp Scraper) Scrape(ctx api.ScrapeContext) v1.ScrapeResults {
 		if gcpConfig.Includes(v1.IncludeAuditLogs) && len(gcpConfig.Include) > 0 {
 			if project := auditLogProject(gcpConfig); project == "" {
 				ctx.Warnf("gcp: skipping audit logs for %s, set auditLogs.project to the project holding the dataset", gcpConfig.Scope())
-			} else if accessLogResults, err := gcp.FetchAuditLogs(gcpCtx, gcpConfig, project); err != nil {
+			} else if accessLogResults, err := gcp.FetchAuditLogs(gcpCtx, gcpConfig, project, parents); err != nil {
 				allResults.Errorf(err, "failed to fetch GCP access logs for project %s", project)
 			} else {
 				allResults = append(allResults, accessLogResults...)

--- a/scrapers/gcp/gcp.go
+++ b/scrapers/gcp/gcp.go
@@ -435,13 +435,6 @@ func (gcp Scraper) scrapeParent(ctx *GCPContext, config v1.GCP, parent string) v
 	return results
 }
 
-// securityCenterParents returns the already-resolved scrape roots. An
-// unrestricted organization has one organization root, while a narrowed
-// organization has only its selected project roots.
-func securityCenterParents(parents []string) []string {
-	return parents
-}
-
 // auditLogProject returns the project holding the audit-log dataset: the one
 // configured explicitly, or the sole scraped project when it is unambiguous.
 func auditLogProject(config v1.GCP) string {
@@ -487,10 +480,10 @@ func (gcp Scraper) Scrape(ctx api.ScrapeContext) v1.ScrapeResults {
 			allResults = append(allResults, gcp.scrapeParent(gcpCtx, gcpConfig, parent)...)
 		}
 
-		// Security Center follows the resolved scope: one organization listing for
-		// an unrestricted organization, or one listing per selected project.
+		// Security Center follows the resolved roots directly: one organization
+		// listing for an unrestricted organization, or one per selected project.
 		if !gcpConfig.Excludes(v1.ExcludeSecurityCenter) {
-			for _, parent := range securityCenterParents(parents) {
+			for _, parent := range parents {
 				if analysisResults, err := gcp.ListFindings(gcpCtx, parent); err != nil {
 					allResults.Errorf(err, "failed to scrape GCP Security Center findings for %s", parent)
 				} else {

--- a/scrapers/gcp/gcp_test.go
+++ b/scrapers/gcp/gcp_test.go
@@ -25,6 +25,53 @@ func TestGCP(t *testing.T) {
 	RunSpecs(t, "GCP Suite")
 }
 
+var _ = Describe("parseResourceData aliases", func() {
+	assetWith := func(assetType string, fields map[string]any) *assetpb.Asset {
+		data, err := structpb.NewStruct(fields)
+		Expect(err).ToNot(HaveOccurred())
+		return &assetpb.Asset{AssetType: assetType, Resource: &assetpb.Resource{Data: data}}
+	}
+
+	It("aliases a service account by email so it matches its IAM principal", func() {
+		rd := parseResourceData(assetWith(serviceAccountAssetType, map[string]any{
+			"name":  "projects/gcp-proj-1/serviceAccounts/sa-etl@gcp-proj-1.iam.gserviceaccount.com",
+			"email": "sa-etl@gcp-proj-1.iam.gserviceaccount.com",
+		}))
+
+		Expect(rd.Aliases).To(ContainElement("sa-etl@gcp-proj-1.iam.gserviceaccount.com"))
+	})
+
+	It("does not alias other asset types by email", func() {
+		rd := parseResourceData(assetWith("storage.googleapis.com/Bucket", map[string]any{
+			"name":  "my-bucket",
+			"email": "owner@example.com",
+		}))
+
+		Expect(rd.Aliases).ToNot(ContainElement("owner@example.com"))
+	})
+
+	It("emits no empty aliases for an asset without a self link", func() {
+		rd := parseResourceData(assetWith(serviceAccountAssetType, map[string]any{
+			"name":  "projects/gcp-proj-1/serviceAccounts/sa-etl@gcp-proj-1.iam.gserviceaccount.com",
+			"email": "sa-etl@gcp-proj-1.iam.gserviceaccount.com",
+		}))
+
+		Expect(rd.Aliases).ToNot(ContainElement(""))
+	})
+
+	It("keeps the self link aliases for assets that have one", func() {
+		rd := parseResourceData(assetWith("compute.googleapis.com/Instance", map[string]any{
+			"name":     "vm-1",
+			"selfLink": "https://www.googleapis.com/compute/v1/projects/p/zones/us-east1-b/instances/vm-1",
+		}))
+
+		Expect(rd.Aliases).To(ContainElements(
+			"https://www.googleapis.com/compute/v1/projects/p/zones/us-east1-b/instances/vm-1",
+			"projects/p/zones/us-east1-b/instances/vm-1",
+		))
+	})
+})
+
 var _ = Describe("parseResourceData", func() {
 	It("extracts zone and region from testdata fixtures", func() {
 		files, err := os.ReadDir("testdata")

--- a/scrapers/gcp/iam.go
+++ b/scrapers/gcp/iam.go
@@ -333,11 +333,16 @@ func coalesceIAMRoleConfigs(results v1.ScrapeResults) v1.ScrapeResults {
 		}
 		if target, ok := existing.Config.(map[string]any); ok {
 			if source, ok := result.Config.(map[string]any); ok {
+				merged := make(map[string]any, len(target)+len(source))
+				for name, value := range target {
+					merged[name] = value
+				}
 				for name, value := range source {
-					if _, found := target[name]; !found {
-						target[name] = value
+					if _, found := merged[name]; !found {
+						merged[name] = value
 					}
 				}
+				existing.Config = merged
 			}
 		}
 	}

--- a/scrapers/gcp/iam.go
+++ b/scrapers/gcp/iam.go
@@ -10,7 +10,6 @@ import (
 	"github.com/flanksource/duty/models"
 	"github.com/lib/pq"
 	"github.com/samber/lo"
-	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v3"
 	"google.golang.org/api/iterator"
 )
 
@@ -52,6 +51,58 @@ func parseGCPMember(member string) (gcpPrincipal, bool) {
 	return gcpPrincipal{}, false
 }
 
+// iamScope identifies the account an IAM scrape is rooted at.
+type iamScope struct {
+	// Tenant is stamped on every discovered identity as its account_id. It is
+	// the organization whenever one is reachable, so the same principal resolves
+	// to one account across every project it appears in.
+	Tenant string
+	// Project is the configured project id, empty for organization-scoped scrapes.
+	Project string
+	// Root owns roles that belong to neither a single project nor a single
+	// organization, i.e. GCP's predefined roles.
+	Root v1.ConfigExternalKey
+}
+
+// scopeFor resolves the scope of one asset-inventory root. organization may be
+// empty, in which case a project falls back to tenanting by itself.
+func scopeFor(parent, organization string) iamScope {
+	project := projectFromParent(parent)
+	scope := iamScope{
+		Tenant:  project,
+		Project: project,
+		Root:    v1.ConfigExternalKey{Type: v1.GCPProject, ExternalID: project},
+	}
+
+	if organization != "" {
+		scope.Tenant = organization
+	}
+
+	if project == "" {
+		scope.Root = v1.ConfigExternalKey{
+			Type:       "GCP::" + organizationConfigClass,
+			ExternalID: resourceManagerPrefix + organizationPrefix + organization,
+		}
+	}
+
+	return scope
+}
+
+// resolveOrganization finds the organization identities should be tenanted by,
+// preferring the configured one, then the resource hierarchy, then the ancestry
+// Cloud Asset Inventory reports on every asset. The last needs no Cloud Resource
+// Manager permission, so a narrowly-scoped scrape service account still tenants
+// by organization.
+func resolveOrganization(config v1.GCP, hierarchy resourceHierarchy, assets []*assetpb.Asset) string {
+	if organization := config.OrganizationID(); organization != "" {
+		return organization
+	}
+	if hierarchy.OrganizationID != "" {
+		return hierarchy.OrganizationID
+	}
+	return organizationFromAssets(assets)
+}
+
 // iamAccessResult is the deduplicated view of a project's IAM policy bindings.
 type iamAccessResult struct {
 	// RoleConfigs are GCP::IAMRole config items (one per distinct bound role)
@@ -70,7 +121,7 @@ type iamAccessResult struct {
 // buildIAMAccess collapses IAM policy bindings across all assets into role
 // config items, external identities, and per-(resource, principal, role) grant edges.
 // Pure and unit-tested; persistence resolves everything by alias.
-func buildIAMAccess(assets []*assetpb.Asset, project string) iamAccessResult {
+func buildIAMAccess(assets []*assetpb.Asset, scope iamScope) iamAccessResult {
 	var res iamAccessResult
 
 	roleIdx := make(map[string]int)
@@ -96,11 +147,11 @@ func buildIAMAccess(assets []*assetpb.Asset, project string) iamAccessResult {
 			if !ok {
 				idx = len(res.RoleConfigs)
 				roleIdx[role] = idx
-				res.RoleConfigs = append(res.RoleConfigs, newRoleConfig(role, project))
+				res.RoleConfigs = append(res.RoleConfigs, newRoleConfig(role, scope))
 				res.Roles = append(res.Roles, models.ExternalRole{
 					Aliases:  pq.StringArray{role},
 					Name:     roleShortName(role),
-					Tenant:   project,
+					Tenant:   scope.Tenant,
 					RoleType: roleType(role),
 				})
 			}
@@ -140,7 +191,7 @@ func buildIAMAccess(assets []*assetpb.Asset, project string) iamAccessResult {
 						res.Groups = append(res.Groups, models.ExternalGroup{
 							Aliases:   pq.StringArray{p.Alias},
 							Name:      p.Name,
-							Tenant:    project,
+							Tenant:    scope.Tenant,
 							GroupType: p.Type,
 						})
 						if p.Type == "Group" {
@@ -154,7 +205,7 @@ func buildIAMAccess(assets []*assetpb.Asset, project string) iamAccessResult {
 						user := models.ExternalUser{
 							Aliases:  pq.StringArray{p.Alias},
 							Name:     p.Name,
-							Tenant:   project,
+							Tenant:   scope.Tenant,
 							UserType: p.Type,
 						}
 						if strings.Contains(p.Alias, "@") {
@@ -180,25 +231,69 @@ func contains(set map[string]struct{}, key string) bool {
 // newRoleConfig builds the GCP::IAMRole config item for a bound role. Config is
 // a non-nil map so the item is a real config (not metadata-only); enrichRoleConfigs
 // augments it with the role's title / permissions from the IAM Admin API.
-func newRoleConfig(role, project string) v1.ScrapeResult {
+//
+// A custom role names the project or organization that defines it, and is
+// parented there. Predefined roles belong to no single resource and hang off the
+// scrape root.
+func newRoleConfig(role string, scope iamScope) v1.ScrapeResult {
 	kind := "custom"
 	if strings.HasPrefix(role, "roles/") {
 		kind = "predefined"
 	}
 
-	return v1.ScrapeResult{
+	config := map[string]any{
+		"name": role,
+		"type": kind,
+	}
+	parent := scope.Root
+
+	switch owner, id := roleOwner(role); owner {
+	case "project":
+		config["project"] = id
+		parent = v1.ConfigExternalKey{Type: v1.GCPProject, ExternalID: id}
+	case "organization":
+		config["organization"] = id
+		parent = v1.ConfigExternalKey{
+			Type:       "GCP::" + organizationConfigClass,
+			ExternalID: resourceManagerPrefix + organizationPrefix + id,
+		}
+	default:
+		if scope.Project != "" {
+			config["project"] = scope.Project
+		}
+	}
+
+	result := v1.ScrapeResult{
 		ID:          role,
 		Name:        roleShortName(role),
 		ConfigClass: "IAMRole",
 		Type:        v1.IAMRole,
 		Aliases:     []string{role},
-		Config: map[string]any{
-			"name":    role,
-			"type":    kind,
-			"project": project,
-		},
-		Parents: []v1.ConfigExternalKey{{Type: v1.GCPProject, ExternalID: project}},
+		Config:      config,
 	}
+	if parent.ExternalID != "" {
+		result.Parents = []v1.ConfigExternalKey{parent}
+	}
+
+	return result
+}
+
+// roleOwner returns the kind of resource that defines a custom role and its id,
+// e.g. ("project", "gcp-proj-1") for projects/gcp-proj-1/roles/customViewer.
+// Predefined roles have no owner.
+func roleOwner(role string) (string, string) {
+	prefix, _, found := strings.Cut(role, "/roles/")
+	if !found {
+		return "", ""
+	}
+
+	if id, ok := strings.CutPrefix(prefix, "projects/"); ok {
+		return "project", id
+	}
+	if id, ok := strings.CutPrefix(prefix, organizationPrefix); ok {
+		return "organization", id
+	}
+	return "", ""
 }
 
 // roleShortName returns the last path segment of a role id
@@ -218,41 +313,55 @@ func roleType(role string) string {
 }
 
 type iamPolicyFetchers struct {
-	listAssets     func(*GCPContext, v1.GCP) ([]*assetpb.Asset, error)
-	fetchHierarchy func(*GCPContext, v1.GCP) (*cloudresourcemanager.Project, []resourceManagerNode, error)
+	listAssets     func(*GCPContext, v1.GCP, string) ([]*assetpb.Asset, error)
+	fetchHierarchy func(*GCPContext, v1.GCP, string) (resourceHierarchy, error)
 	enrichRoles    func(*GCPContext, []v1.ScrapeResult)
 }
 
-// FetchIAMPolicies reads Cloud Asset Inventory IAM policies for the project and
-// emits role config items, external identities, and grant edges. The returned
-// group emails are the real Google groups discovered in bindings, for optional
-// membership expansion by the caller.
-func (scraper Scraper) FetchIAMPolicies(ctx *GCPContext, config v1.GCP) (v1.ScrapeResults, []string, error) {
-	return scraper.fetchIAMPolicies(ctx, config, iamPolicyFetchers{
+// iamPolicyResult is a completed IAM-policy scrape.
+type iamPolicyResult struct {
+	Results v1.ScrapeResults
+	// Scope is the resolved account the discovered identities belong to, reused
+	// by group-membership expansion so it stamps the same tenant.
+	Scope iamScope
+	// GroupEmails are the real Google groups discovered in bindings, eligible for
+	// membership expansion by the caller.
+	GroupEmails []string
+}
+
+// FetchIAMPolicies reads Cloud Asset Inventory IAM policies beneath parent and
+// emits role config items, external identities, and grant edges.
+func (scraper Scraper) FetchIAMPolicies(ctx *GCPContext, config v1.GCP, parent string) (iamPolicyResult, error) {
+	return scraper.fetchIAMPolicies(ctx, config, parent, iamPolicyFetchers{
 		listAssets:     listIAMPolicyAssets,
 		fetchHierarchy: fetchResourceManagerHierarchy,
 		enrichRoles:    enrichRoleConfigs,
 	})
 }
 
-func (Scraper) fetchIAMPolicies(ctx *GCPContext, config v1.GCP, fetchers iamPolicyFetchers) (v1.ScrapeResults, []string, error) {
-	assets, err := fetchers.listAssets(ctx, config)
+func (Scraper) fetchIAMPolicies(ctx *GCPContext, config v1.GCP, parent string, fetchers iamPolicyFetchers) (iamPolicyResult, error) {
+	assets, err := fetchers.listAssets(ctx, config, parent)
 	if err != nil {
-		return nil, nil, err
+		return iamPolicyResult{}, err
 	}
 
+	// A hierarchy that cannot be read costs the organization and folder config
+	// items, so it is reported as a scraper error rather than only logged. The
+	// organization id itself is still recovered from the parent chain or the
+	// asset ancestry, so identities stay tenanted correctly.
 	var hierarchyResults v1.ScrapeResults
-	project, nodes, err := fetchers.fetchHierarchy(ctx, config)
+	hierarchy, err := fetchers.fetchHierarchy(ctx, config, parent)
 	if err != nil {
-		ctx.Warnf("gcp iam policies: resource hierarchy unavailable: %v", err)
-	} else if hierarchy, policies, err := buildResourceManagerHierarchy(project, nodes, config.BaseScraper); err != nil {
-		ctx.Warnf("gcp iam policies: invalid resource hierarchy: %v", err)
+		hierarchyResults.Errorf(err, "failed to read the GCP resource hierarchy above %s, its organization and folder config items will be missing", parent)
+	} else if results, policies, err := buildResourceManagerHierarchy(hierarchy.Project, hierarchy.Nodes, config.BaseScraper); err != nil {
+		hierarchyResults.Errorf(err, "invalid GCP resource hierarchy above %s, its organization and folder config items will be missing", parent)
 	} else {
-		hierarchyResults = hierarchy
+		hierarchyResults = results
 		assets = append(assets, policies...)
 	}
 
-	access := buildIAMAccess(assets, config.Project)
+	scope := scopeFor(parent, resolveOrganization(config, hierarchy, assets))
+	access := buildIAMAccess(assets, scope)
 	fetchers.enrichRoles(ctx, access.RoleConfigs)
 
 	results := hierarchyResults
@@ -269,12 +378,12 @@ func (Scraper) fetchIAMPolicies(ctx *GCPContext, config v1.GCP, fetchers iamPoli
 		ConfigAccess:   access.Access,
 	})
 
-	return results, access.GroupEmails, nil
+	return iamPolicyResult{Results: results, Scope: scope, GroupEmails: access.GroupEmails}, nil
 }
 
-func listIAMPolicyAssets(ctx *GCPContext, config v1.GCP) ([]*assetpb.Asset, error) {
+func listIAMPolicyAssets(ctx *GCPContext, config v1.GCP, parent string) ([]*assetpb.Asset, error) {
 	req := &assetpb.ListAssetsRequest{
-		Parent:      fmt.Sprintf("projects/%s", config.Project),
+		Parent:      parent,
 		ContentType: assetpb.ContentType_IAM_POLICY,
 		PageSize:    1000,
 	}

--- a/scrapers/gcp/iam.go
+++ b/scrapers/gcp/iam.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	asset "cloud.google.com/go/asset/apiv1"
@@ -51,41 +52,34 @@ func parseGCPMember(member string) (gcpPrincipal, bool) {
 	return gcpPrincipal{}, false
 }
 
-// iamScope identifies the account an IAM scrape is rooted at.
+// iamScope identifies the tenant an IAM scrape belongs to and the stable config
+// parent used for global predefined roles.
 type iamScope struct {
 	// Tenant is stamped on every discovered identity as its account_id. It is
 	// the organization whenever one is reachable, so the same principal resolves
 	// to one account across every project it appears in.
 	Tenant string
-	// Project is the configured project id, empty for organization-scoped scrapes.
-	Project string
-	// Root owns roles that belong to neither a single project nor a single
-	// organization, i.e. GCP's predefined roles.
-	Root v1.ConfigExternalKey
+	Root   v1.ConfigExternalKey
 }
 
-// scopeFor resolves the scope of one asset-inventory root. organization may be
-// empty, in which case a project falls back to tenanting by itself.
+// scopeFor resolves one asset-inventory root. When an organization is known it
+// is also the stable role root for every narrowed project pass; otherwise the
+// project is used for backward compatibility.
 func scopeFor(parent, organization string) iamScope {
-	project := projectFromParent(parent)
-	scope := iamScope{
-		Tenant:  project,
-		Project: project,
-		Root:    v1.ConfigExternalKey{Type: v1.GCPProject, ExternalID: project},
-	}
-
 	if organization != "" {
-		scope.Tenant = organization
-	}
-
-	if project == "" {
-		scope.Root = v1.ConfigExternalKey{
-			Type:       "GCP::" + organizationConfigClass,
-			ExternalID: resourceManagerPrefix + organizationPrefix + organization,
+		return iamScope{
+			Tenant: organization,
+			Root: v1.ConfigExternalKey{
+				Type:       "GCP::" + organizationConfigClass,
+				ExternalID: resourceManagerPrefix + organizationPrefix + organization,
+			},
 		}
 	}
-
-	return scope
+	project := projectFromParent(parent)
+	return iamScope{
+		Tenant: project,
+		Root:   v1.ConfigExternalKey{Type: v1.GCPProject, ExternalID: project},
+	}
 }
 
 // resolveOrganization finds the organization identities should be tenanted by,
@@ -115,7 +109,8 @@ type iamAccessResult struct {
 	Access []v1.ExternalConfigAccess
 	// GroupEmails are the real Google-group emails eligible for membership
 	// expansion (excludes domain / all-users pseudo-principals).
-	GroupEmails []string
+	GroupEmails                []string
+	SkippedConditionalBindings int
 }
 
 // buildIAMAccess collapses IAM policy bindings across all assets into role
@@ -138,6 +133,10 @@ func buildIAMAccess(assets []*assetpb.Asset, scope iamScope) iamAccessResult {
 		resourceType := fmt.Sprintf("GCP::%s", parseGCPConfigClass(a.AssetType))
 
 		for _, binding := range a.IamPolicy.Bindings {
+			if binding == nil {
+				continue
+			}
+
 			role := binding.Role
 			if role == "" {
 				continue
@@ -154,6 +153,15 @@ func buildIAMAccess(assets []*assetpb.Asset, scope iamScope) iamAccessResult {
 					Tenant:   scope.Tenant,
 					RoleType: roleType(role),
 				})
+			}
+
+			// ConfigAccess has no condition model, and IAM conditions can depend on
+			// request-time attributes that cannot be evaluated during a scrape. Do
+			// not turn a conditional grant into an unconditional one. The role
+			// definition remains discoverable, but all grant-derived edges are omitted.
+			if binding.Condition != nil {
+				res.SkippedConditionalBindings++
+				continue
 			}
 
 			if rrKey := role + "\x00" + resourceType + "\x00" + a.Name; !contains(seenRoleResource, rrKey) {
@@ -232,9 +240,9 @@ func contains(set map[string]struct{}, key string) bool {
 // a non-nil map so the item is a real config (not metadata-only); enrichRoleConfigs
 // augments it with the role's title / permissions from the IAM Admin API.
 //
-// A custom role names the project or organization that defines it, and is
-// parented there. Predefined roles belong to no single resource and hang off the
-// scrape root.
+// A custom role names the project or organization that defines it and is
+// parented there. Predefined roles are global, so every project pass uses the
+// same organization root when one is known.
 func newRoleConfig(role string, scope iamScope) v1.ScrapeResult {
 	kind := "custom"
 	if strings.HasPrefix(role, "roles/") {
@@ -257,10 +265,6 @@ func newRoleConfig(role string, scope iamScope) v1.ScrapeResult {
 			Type:       "GCP::" + organizationConfigClass,
 			ExternalID: resourceManagerPrefix + organizationPrefix + id,
 		}
-	default:
-		if scope.Project != "" {
-			config["project"] = scope.Project
-		}
 	}
 
 	result := v1.ScrapeResult{
@@ -276,6 +280,83 @@ func newRoleConfig(role string, scope iamScope) v1.ScrapeResult {
 	}
 
 	return result
+}
+
+// coalesceIAMRoleConfigs merges roles emitted by separate project roots. A
+// narrowed organization scrape can encounter the same predefined role in every
+// project; persisting those copies independently makes the final config depend
+// on project iteration order and can lose role-to-resource relationships.
+func coalesceIAMRoleConfigs(results v1.ScrapeResults) v1.ScrapeResults {
+	coalesced := make(v1.ScrapeResults, 0, len(results))
+	roleIndex := make(map[string]int)
+
+	for _, result := range results {
+		if result.Type != v1.IAMRole || result.ID == "" {
+			coalesced = append(coalesced, result)
+			continue
+		}
+
+		key := result.Type + "\x00" + v1.NormalizeExternalID(result.ID)
+		idx, found := roleIndex[key]
+		if !found {
+			roleIndex[key] = len(coalesced)
+			coalesced = append(coalesced, result)
+			continue
+		}
+
+		existing := &coalesced[idx]
+		for _, alias := range result.Aliases {
+			if !slices.Contains(existing.Aliases, alias) {
+				existing.Aliases = append(existing.Aliases, alias)
+			}
+		}
+		for _, parent := range result.Parents {
+			if !slices.Contains(existing.Parents, parent) {
+				existing.Parents = append(existing.Parents, parent)
+			}
+		}
+		for _, child := range result.Children {
+			if !slices.Contains(existing.Children, child) {
+				existing.Children = append(existing.Children, child)
+			}
+		}
+		for _, relationship := range result.RelationshipResults {
+			if !slices.ContainsFunc(existing.RelationshipResults, func(current v1.RelationshipResult) bool {
+				return relationshipResultKey(current) == relationshipResultKey(relationship)
+			}) {
+				existing.RelationshipResults = append(existing.RelationshipResults, relationship)
+			}
+		}
+
+		if existing.Description == "" {
+			existing.Description = result.Description
+		}
+		if target, ok := existing.Config.(map[string]any); ok {
+			if source, ok := result.Config.(map[string]any); ok {
+				for name, value := range source {
+					if _, found := target[name]; !found {
+						target[name] = value
+					}
+				}
+			}
+		}
+	}
+
+	return coalesced
+}
+
+func relationshipResultKey(relationship v1.RelationshipResult) string {
+	return strings.Join([]string{
+		relationship.ConfigID,
+		relationship.ConfigExternalID.ConfigType,
+		relationship.ConfigExternalID.ExternalID,
+		relationship.ConfigExternalID.ScraperID,
+		relationship.RelatedConfigID,
+		relationship.RelatedExternalID.ConfigType,
+		relationship.RelatedExternalID.ExternalID,
+		relationship.RelatedExternalID.ScraperID,
+		relationship.Relationship,
+	}, "\x00")
 }
 
 // roleOwner returns the kind of resource that defines a custom role and its id,
@@ -370,13 +451,20 @@ func (Scraper) fetchIAMPolicies(ctx *GCPContext, config v1.GCP, parent string, f
 		results = append(results, access.RoleConfigs[i])
 	}
 
-	results = append(results, v1.ScrapeResult{
+	accessResult := v1.ScrapeResult{
 		BaseScraper:    config.BaseScraper,
 		ExternalRoles:  access.Roles,
 		ExternalUsers:  access.Users,
 		ExternalGroups: access.Groups,
 		ConfigAccess:   access.Access,
-	})
+	}
+	if access.SkippedConditionalBindings > 0 {
+		accessResult.Warnings = append(accessResult.Warnings, v1.Warning{
+			Error: "conditional GCP IAM bindings cannot be modeled and were omitted from effective access",
+			Count: access.SkippedConditionalBindings,
+		})
+	}
+	results = append(results, accessResult)
 
 	return iamPolicyResult{Results: results, Scope: scope, GroupEmails: access.GroupEmails}, nil
 }

--- a/scrapers/gcp/iam_group_members.go
+++ b/scrapers/gcp/iam_group_members.go
@@ -23,7 +23,7 @@ type leafMember struct {
 // The config_access_unwrapped view joins external_user_groups a single level,
 // so nested groups are flattened: every transitive leaf member is linked
 // directly to the bound group it was reached from.
-func (Scraper) FetchGroupMemberships(ctx *GCPContext, config v1.GCP, groupEmails []string) (v1.ScrapeResults, error) {
+func (Scraper) FetchGroupMemberships(ctx *GCPContext, config v1.GCP, scope iamScope, groupEmails []string) (v1.ScrapeResults, error) {
 	if len(groupEmails) == 0 {
 		return nil, nil
 	}
@@ -34,7 +34,7 @@ func (Scraper) FetchGroupMemberships(ctx *GCPContext, config v1.GCP, groupEmails
 	}
 
 	exp := &groupExpander{ctx: ctx, svc: svc, memberships: map[string][]*cloudidentity.Membership{}}
-	acc := newMembershipAccumulator(config.Project)
+	acc := newMembershipAccumulator(scope.Tenant)
 
 	var results v1.ScrapeResults
 	for _, groupEmail := range groupEmails {
@@ -113,7 +113,7 @@ func traverseGroup(
 // membershipAccumulator deduplicates the users, groups, and user→group edges
 // discovered across all expanded bound groups.
 type membershipAccumulator struct {
-	project    string
+	tenant     string
 	userGroups []v1.ExternalUserGroup
 	users      []models.ExternalUser
 	groups     []models.ExternalGroup
@@ -122,9 +122,9 @@ type membershipAccumulator struct {
 	seenGroup  map[string]struct{}
 }
 
-func newMembershipAccumulator(project string) *membershipAccumulator {
+func newMembershipAccumulator(tenant string) *membershipAccumulator {
 	return &membershipAccumulator{
-		project:   project,
+		tenant:    tenant,
 		seenEdge:  make(map[string]struct{}),
 		seenUser:  make(map[string]struct{}),
 		seenGroup: make(map[string]struct{}),
@@ -146,7 +146,7 @@ func (a *membershipAccumulator) add(groupEmail string, leaves []leafMember, nest
 			a.users = append(a.users, models.ExternalUser{
 				Aliases:  pq.StringArray{leaf.email},
 				Name:     leaf.email,
-				Tenant:   a.project,
+				Tenant:   a.tenant,
 				UserType: leaf.userType,
 				Email:    lo.ToPtr(leaf.email),
 			})
@@ -159,7 +159,7 @@ func (a *membershipAccumulator) add(groupEmail string, leaves []leafMember, nest
 			a.groups = append(a.groups, models.ExternalGroup{
 				Aliases:   pq.StringArray{nestedEmail},
 				Name:      nestedEmail,
-				Tenant:    a.project,
+				Tenant:    a.tenant,
 				GroupType: "Group",
 			})
 		}

--- a/scrapers/gcp/iam_hierarchy.go
+++ b/scrapers/gcp/iam_hierarchy.go
@@ -45,13 +45,19 @@ type resourceHierarchy struct {
 // A node that cannot be read degrades the hierarchy config items but still yields
 // OrganizationID, so identities stay tenanted by organization.
 func fetchResourceManagerHierarchy(ctx *GCPContext, _ v1.GCP, parent string) (resourceHierarchy, error) {
+	projectID := projectFromParent(parent)
+	organization, isOrganization := strings.CutPrefix(parent, organizationPrefix)
+	if projectID == "" && (!isOrganization || organization == "") {
+		return resourceHierarchy{}, fmt.Errorf("unsupported GCP resource hierarchy root %q", parent)
+	}
+
 	service, err := cloudresourcemanager.NewService(ctx, ctx.ClientOpts...)
 	if err != nil {
 		return resourceHierarchy{}, fmt.Errorf("create Cloud Resource Manager client: %w", err)
 	}
 
-	if projectFromParent(parent) == "" {
-		hierarchy := resourceHierarchy{OrganizationID: strings.TrimPrefix(parent, organizationPrefix)}
+	if projectID == "" {
+		hierarchy := resourceHierarchy{OrganizationID: organization}
 		node, err := fetchResourceManagerNode(ctx, service, parent)
 		if err != nil {
 			return hierarchy, err
@@ -250,6 +256,16 @@ func resourceManagerMetadataForName(name string) (resourceManagerMetadata, error
 	}
 }
 
+// resourceManagerIAMPolicy preserves version-3 IAM conditions while adapting
+// Resource Manager policies to the common IAM policy representation.
+// buildIAMAccess deliberately excludes bindings with a non-nil Condition from
+// effective access because conditions cannot be modeled or evaluated safely; it
+// emits one bounded warning with the number omitted.
+//
+// Upgrade notice: older versions emitted these conditional bindings as
+// unconditional access edges. A full scrape reconciles those obsolete edges when
+// at least one current access row resolves; installations with only conditional
+// bindings may need to remove the legacy rows manually.
 func resourceManagerIAMPolicy(policy *cloudresourcemanager.Policy) *iampb.Policy {
 	bindings := make([]*iampb.Binding, 0, len(policy.Bindings))
 	for _, binding := range policy.Bindings {

--- a/scrapers/gcp/iam_hierarchy.go
+++ b/scrapers/gcp/iam_hierarchy.go
@@ -26,43 +26,72 @@ type resourceManagerMetadata struct {
 	AssetType   string
 }
 
-func fetchResourceManagerHierarchy(ctx *GCPContext, config v1.GCP) (*cloudresourcemanager.Project, []resourceManagerNode, error) {
+// resourceHierarchy is the ancestor chain above a scraped root.
+type resourceHierarchy struct {
+	// Project is the hierarchy root, nil when the root is an organization.
+	Project *cloudresourcemanager.Project
+	Nodes   []resourceManagerNode
+	// OrganizationID is the organization the root belongs to. The parent chain
+	// names it before any node is read, so it survives a scrape service account
+	// that may not read the organization resource itself.
+	OrganizationID string
+}
+
+// fetchResourceManagerHierarchy walks upwards from parent. An organization root
+// has nothing above it, so it is returned as the sole node with a nil project;
+// the folders and projects beneath it arrive as assets instead.
+//
+// A node that cannot be read degrades the hierarchy config items but still yields
+// OrganizationID, so identities stay tenanted by organization.
+func fetchResourceManagerHierarchy(ctx *GCPContext, _ v1.GCP, parent string) (resourceHierarchy, error) {
 	service, err := cloudresourcemanager.NewService(ctx, ctx.ClientOpts...)
 	if err != nil {
-		return nil, nil, fmt.Errorf("create Cloud Resource Manager client: %w", err)
+		return resourceHierarchy{}, fmt.Errorf("create Cloud Resource Manager client: %w", err)
 	}
 
-	projectName := config.Project
-	if !strings.HasPrefix(projectName, "projects/") {
-		projectName = "projects/" + projectName
+	if projectFromParent(parent) == "" {
+		hierarchy := resourceHierarchy{OrganizationID: strings.TrimPrefix(parent, organizationPrefix)}
+		node, err := fetchResourceManagerNode(ctx, service, parent)
+		if err != nil {
+			return hierarchy, err
+		}
+		hierarchy.Nodes = []resourceManagerNode{node}
+		return hierarchy, nil
 	}
-	project, err := service.Projects.Get(projectName).Context(ctx).Do()
+
+	project, err := service.Projects.Get(parent).Context(ctx).Do()
 	if err != nil {
-		return nil, nil, fmt.Errorf("get GCP project hierarchy root %s: %w", projectName, err)
+		return resourceHierarchy{}, fmt.Errorf("get GCP project hierarchy root %s: %w", parent, err)
 	}
 
-	var nodes []resourceManagerNode
+	hierarchy := resourceHierarchy{Project: project}
 	visited := make(map[string]struct{})
 	for parent := project.Parent; parent != ""; {
 		if _, ok := visited[parent]; ok {
-			return nil, nil, fmt.Errorf("cyclic GCP resource hierarchy at %s", parent)
+			return hierarchy, fmt.Errorf("cyclic GCP resource hierarchy at %s", parent)
 		}
 		visited[parent] = struct{}{}
 
+		// Recorded before the read so an organization the caller may not read is
+		// still known.
+		if organization, ok := strings.CutPrefix(parent, organizationPrefix); ok {
+			hierarchy.OrganizationID = organization
+		}
+
 		node, err := fetchResourceManagerNode(ctx, service, parent)
 		if err != nil {
-			return nil, nil, err
+			return hierarchy, err
 		}
-		nodes = append(nodes, node)
+		hierarchy.Nodes = append(hierarchy.Nodes, node)
 
 		metadata, err := node.metadata()
 		if err != nil {
-			return nil, nil, err
+			return hierarchy, err
 		}
 		parent = metadata.Parent
 	}
 
-	return project, nodes, nil
+	return hierarchy, nil
 }
 
 func fetchResourceManagerNode(ctx *GCPContext, service *cloudresourcemanager.Service, name string) (resourceManagerNode, error) {
@@ -96,24 +125,38 @@ func fetchResourceManagerNode(ctx *GCPContext, service *cloudresourcemanager.Ser
 	}
 }
 
+// buildResourceManagerHierarchy turns the ancestor chain into config items and
+// IAM-policy assets. A nil project means the scrape is rooted at an organization,
+// where nodes holds just that organization and the descendants arrive as assets.
 func buildResourceManagerHierarchy(project *cloudresourcemanager.Project, nodes []resourceManagerNode, base v1.BaseScraper) (v1.ScrapeResults, []*assetpb.Asset, error) {
-	if project == nil || project.Name == "" {
-		return nil, nil, fmt.Errorf("GCP project hierarchy root has no resource name")
-	}
-	projectMetadata, err := resourceManagerMetadataForName(project.Name)
-	if err != nil {
-		return nil, nil, err
+	var projectKey *v1.ConfigExternalKey
+	var expectedName string
+
+	if project != nil {
+		if project.Name == "" {
+			return nil, nil, fmt.Errorf("GCP project hierarchy root has no resource name")
+		}
+		projectMetadata, err := resourceManagerMetadataForName(project.Name)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// The project itself is emitted by the asset inventory loop (see the
+		// cloudresourcemanager.googleapis.com/Project mapping in types.go); link the
+		// deepest ancestor to it rather than emitting a second, conflicting result.
+		projectKey = &v1.ConfigExternalKey{
+			Type:       "GCP::" + projectMetadata.ConfigClass,
+			ExternalID: resourceManagerPrefix + projectMetadata.Name,
+		}
+		expectedName = project.Parent
+	} else if len(nodes) > 0 {
+		metadata, err := nodes[0].metadata()
+		if err != nil {
+			return nil, nil, err
+		}
+		expectedName = metadata.Name
 	}
 
-	// The project itself is emitted by the asset inventory loop (see the
-	// cloudresourcemanager.googleapis.com/Project mapping in types.go); link the
-	// deepest ancestor to it rather than emitting a second, conflicting result.
-	projectKey := v1.ConfigExternalKey{
-		Type:       "GCP::" + projectMetadata.ConfigClass,
-		ExternalID: resourceManagerPrefix + project.Name,
-	}
-
-	expectedName := project.Parent
 	var results v1.ScrapeResults
 	var policies []*assetpb.Asset
 	for i, node := range nodes {
@@ -138,8 +181,8 @@ func buildResourceManagerHierarchy(project *cloudresourcemanager.Project, nodes 
 		if result.Name == "" {
 			result.Name = metadata.Name
 		}
-		if i == 0 {
-			result.Children = []v1.ConfigExternalKey{projectKey}
+		if i == 0 && projectKey != nil {
+			result.Children = []v1.ConfigExternalKey{*projectKey}
 		}
 		if metadata.Parent != "" {
 			parentMetadata, err := resourceManagerMetadataForName(metadata.Parent)

--- a/scrapers/gcp/iam_hierarchy.go
+++ b/scrapers/gcp/iam_hierarchy.go
@@ -8,6 +8,7 @@ import (
 	"cloud.google.com/go/iam/apiv1/iampb"
 	v1 "github.com/flanksource/config-db/api/v1"
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v3"
+	expr "google.golang.org/genproto/googleapis/type/expr"
 )
 
 const resourceManagerPrefix = "//cloudresourcemanager.googleapis.com/"
@@ -255,10 +256,19 @@ func resourceManagerIAMPolicy(policy *cloudresourcemanager.Policy) *iampb.Policy
 		if binding == nil {
 			continue
 		}
-		bindings = append(bindings, &iampb.Binding{
+		converted := &iampb.Binding{
 			Role:    binding.Role,
 			Members: binding.Members,
-		})
+		}
+		if binding.Condition != nil {
+			converted.Condition = &expr.Expr{
+				Expression:  binding.Condition.Expression,
+				Title:       binding.Condition.Title,
+				Description: binding.Condition.Description,
+				Location:    binding.Condition.Location,
+			}
+		}
+		bindings = append(bindings, converted)
 	}
 	return &iampb.Policy{
 		Version:  int32(policy.Version),

--- a/scrapers/gcp/iam_scope_test.go
+++ b/scrapers/gcp/iam_scope_test.go
@@ -1,6 +1,8 @@
 package gcp
 
 import (
+	"fmt"
+
 	"cloud.google.com/go/asset/apiv1/assetpb"
 	"cloud.google.com/go/iam/apiv1/iampb"
 	. "github.com/onsi/ginkgo/v2"
@@ -10,30 +12,18 @@ import (
 )
 
 var _ = Describe("scopeFor", func() {
-	It("tenants by organization when one is known", func() {
+	It("tenants and roots roles by organization when one is known", func() {
 		scope := scopeFor("projects/gcp-proj-1", "1234")
 		Expect(scope.Tenant).To(Equal("1234"))
-		Expect(scope.Project).To(Equal("gcp-proj-1"))
-	})
-
-	It("falls back to the project when no organization is known", func() {
-		scope := scopeFor("projects/gcp-proj-1", "")
-		Expect(scope.Tenant).To(Equal("gcp-proj-1"))
-		Expect(scope.Project).To(Equal("gcp-proj-1"))
-	})
-
-	It("roots an organization parent at the organization", func() {
-		scope := scopeFor("organizations/1234", "1234")
-		Expect(scope.Tenant).To(Equal("1234"))
-		Expect(scope.Project).To(BeEmpty())
 		Expect(scope.Root).To(Equal(v1.ConfigExternalKey{
 			Type:       "GCP::ResourceManager::Organization",
 			ExternalID: "//cloudresourcemanager.googleapis.com/organizations/1234",
 		}))
 	})
 
-	It("roots a project parent at the project", func() {
-		scope := scopeFor("projects/gcp-proj-1", "1234")
+	It("falls back to the project when no organization is known", func() {
+		scope := scopeFor("projects/gcp-proj-1", "")
+		Expect(scope.Tenant).To(Equal("gcp-proj-1"))
 		Expect(scope.Root).To(Equal(v1.ConfigExternalKey{
 			Type:       v1.GCPProject,
 			ExternalID: "gcp-proj-1",
@@ -79,13 +69,7 @@ var _ = Describe("fetchResourceManagerHierarchy salvage", func() {
 })
 
 var _ = Describe("newRoleConfig", func() {
-	orgScope := iamScope{
-		Tenant: "1234",
-		Root: v1.ConfigExternalKey{
-			Type:       "GCP::ResourceManager::Organization",
-			ExternalID: "//cloudresourcemanager.googleapis.com/organizations/1234",
-		},
-	}
+	orgScope := scopeFor("projects/gcp-proj-1", "1234")
 
 	It("parents a project custom role to its own project", func() {
 		role := newRoleConfig("projects/gcp-proj-7/roles/customViewer", orgScope)
@@ -105,12 +89,14 @@ var _ = Describe("newRoleConfig", func() {
 		Expect(role.Config).To(HaveKeyWithValue("organization", "9999"))
 	})
 
-	It("parents a predefined role to the scrape root", func() {
+	It("parents a predefined role consistently to the organization", func() {
 		role := newRoleConfig("roles/storage.admin", orgScope)
 		Expect(role.Parents).To(ConsistOf(orgScope.Root))
+		Expect(role.Config).ToNot(HaveKey("project"))
+		Expect(role.Config).ToNot(HaveKey("organization"))
 	})
 
-	It("never emits an empty parent external id when org-scoped", func() {
+	It("never emits an empty parent external id", func() {
 		for _, id := range []string{"roles/viewer", "organizations/1234/roles/x", "projects/p/roles/y"} {
 			role := newRoleConfig(id, orgScope)
 			for _, parent := range role.Parents {
@@ -120,13 +106,42 @@ var _ = Describe("newRoleConfig", func() {
 	})
 })
 
+var _ = Describe("coalesceIAMRoleConfigs", func() {
+	It("merges a predefined role emitted by multiple project roots", func() {
+		scope := scopeFor("projects/gcp-proj-1", "1234")
+		roleA := newRoleConfig("roles/viewer", scope)
+		roleA.RelationshipResults = append(roleA.RelationshipResults, v1.RelationshipResult{
+			ConfigExternalID:  v1.ExternalID{ConfigType: v1.IAMRole, ExternalID: "roles/viewer"},
+			RelatedExternalID: v1.ExternalID{ConfigType: v1.GCSBucket, ExternalID: "bucket-a"},
+			Relationship:      "IAMBinding",
+		})
+		roleB := newRoleConfig("roles/viewer", scope)
+		roleB.RelationshipResults = append(roleB.RelationshipResults, v1.RelationshipResult{
+			ConfigExternalID:  v1.ExternalID{ConfigType: v1.IAMRole, ExternalID: "roles/viewer"},
+			RelatedExternalID: v1.ExternalID{ConfigType: v1.GCSBucket, ExternalID: "bucket-b"},
+			Relationship:      "IAMBinding",
+		})
+
+		results := coalesceIAMRoleConfigs(v1.ScrapeResults{roleA, roleB})
+
+		Expect(results).To(HaveLen(1))
+		Expect(results[0].Parents).To(ConsistOf(scope.Root))
+		Expect(results[0].RelationshipResults).To(HaveLen(2))
+	})
+
+	It("leaves unrelated and error results untouched", func() {
+		errResult := v1.ScrapeResult{Error: fmt.Errorf("failed")}
+		bucket := v1.ScrapeResult{ID: "bucket", Type: v1.GCSBucket}
+
+		Expect(coalesceIAMRoleConfigs(v1.ScrapeResults{errResult, bucket})).To(Equal(
+			v1.ScrapeResults{errResult, bucket},
+		))
+	})
+})
+
 var _ = Describe("buildIAMAccess tenant", func() {
 	It("stamps the organization tenant on every external identity", func() {
-		scope := iamScope{
-			Tenant:  "1234",
-			Project: "gcp-proj-1",
-			Root:    v1.ConfigExternalKey{Type: v1.GCPProject, ExternalID: "gcp-proj-1"},
-		}
+		scope := scopeFor("projects/gcp-proj-1", "1234")
 
 		res := buildIAMAccess([]*assetpb.Asset{
 			iamPolicyAsset("//storage.googleapis.com/projects/_/buckets/b", "storage.googleapis.com/Bucket",

--- a/scrapers/gcp/iam_scope_test.go
+++ b/scrapers/gcp/iam_scope_test.go
@@ -1,0 +1,154 @@
+package gcp
+
+import (
+	"cloud.google.com/go/asset/apiv1/assetpb"
+	"cloud.google.com/go/iam/apiv1/iampb"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "github.com/flanksource/config-db/api/v1"
+)
+
+var _ = Describe("scopeFor", func() {
+	It("tenants by organization when one is known", func() {
+		scope := scopeFor("projects/gcp-proj-1", "1234")
+		Expect(scope.Tenant).To(Equal("1234"))
+		Expect(scope.Project).To(Equal("gcp-proj-1"))
+	})
+
+	It("falls back to the project when no organization is known", func() {
+		scope := scopeFor("projects/gcp-proj-1", "")
+		Expect(scope.Tenant).To(Equal("gcp-proj-1"))
+		Expect(scope.Project).To(Equal("gcp-proj-1"))
+	})
+
+	It("roots an organization parent at the organization", func() {
+		scope := scopeFor("organizations/1234", "1234")
+		Expect(scope.Tenant).To(Equal("1234"))
+		Expect(scope.Project).To(BeEmpty())
+		Expect(scope.Root).To(Equal(v1.ConfigExternalKey{
+			Type:       "GCP::ResourceManager::Organization",
+			ExternalID: "//cloudresourcemanager.googleapis.com/organizations/1234",
+		}))
+	})
+
+	It("roots a project parent at the project", func() {
+		scope := scopeFor("projects/gcp-proj-1", "1234")
+		Expect(scope.Root).To(Equal(v1.ConfigExternalKey{
+			Type:       v1.GCPProject,
+			ExternalID: "gcp-proj-1",
+		}))
+	})
+})
+
+var _ = Describe("resolveOrganization", func() {
+	assetsUnderOrg := []*assetpb.Asset{
+		{Name: "//storage.googleapis.com/b", Ancestors: []string{"projects/123", "organizations/9999"}},
+	}
+
+	It("prefers the configured organization", func() {
+		hierarchy := resourceHierarchy{OrganizationID: "5555"}
+		Expect(resolveOrganization(v1.GCP{Organization: "1234"}, hierarchy, assetsUnderOrg)).To(Equal("1234"))
+	})
+
+	It("falls back to the hierarchy when none is configured", func() {
+		hierarchy := resourceHierarchy{OrganizationID: "5555"}
+		Expect(resolveOrganization(v1.GCP{Project: "gcp-proj-1"}, hierarchy, assetsUnderOrg)).To(Equal("5555"))
+	})
+
+	It("falls back to asset ancestry when the hierarchy is unavailable", func() {
+		Expect(resolveOrganization(v1.GCP{Project: "gcp-proj-1"}, resourceHierarchy{}, assetsUnderOrg)).To(Equal("9999"))
+	})
+
+	It("returns empty when the project belongs to no organization", func() {
+		assets := []*assetpb.Asset{
+			{Name: "//storage.googleapis.com/b", Ancestors: []string{"projects/123"}},
+		}
+		Expect(resolveOrganization(v1.GCP{Project: "gcp-proj-1"}, resourceHierarchy{}, assets)).To(BeEmpty())
+	})
+})
+
+var _ = Describe("fetchResourceManagerHierarchy salvage", func() {
+	It("keeps the organization id discovered before an unreadable node", func() {
+		// The walk records organizations/1234 from the parent chain before it
+		// tries to read the organization resource, so a scrape service account
+		// without organization read access still tenants by organization.
+		hierarchy := resourceHierarchy{OrganizationID: "1234"}
+		Expect(scopeFor("projects/gcp-proj-1", hierarchy.OrganizationID).Tenant).To(Equal("1234"))
+	})
+})
+
+var _ = Describe("newRoleConfig", func() {
+	orgScope := iamScope{
+		Tenant: "1234",
+		Root: v1.ConfigExternalKey{
+			Type:       "GCP::ResourceManager::Organization",
+			ExternalID: "//cloudresourcemanager.googleapis.com/organizations/1234",
+		},
+	}
+
+	It("parents a project custom role to its own project", func() {
+		role := newRoleConfig("projects/gcp-proj-7/roles/customViewer", orgScope)
+		Expect(role.Parents).To(ConsistOf(v1.ConfigExternalKey{
+			Type:       v1.GCPProject,
+			ExternalID: "gcp-proj-7",
+		}))
+		Expect(role.Config).To(HaveKeyWithValue("project", "gcp-proj-7"))
+	})
+
+	It("parents an organization custom role to its own organization", func() {
+		role := newRoleConfig("organizations/9999/roles/auditor", orgScope)
+		Expect(role.Parents).To(ConsistOf(v1.ConfigExternalKey{
+			Type:       "GCP::ResourceManager::Organization",
+			ExternalID: "//cloudresourcemanager.googleapis.com/organizations/9999",
+		}))
+		Expect(role.Config).To(HaveKeyWithValue("organization", "9999"))
+	})
+
+	It("parents a predefined role to the scrape root", func() {
+		role := newRoleConfig("roles/storage.admin", orgScope)
+		Expect(role.Parents).To(ConsistOf(orgScope.Root))
+	})
+
+	It("never emits an empty parent external id when org-scoped", func() {
+		for _, id := range []string{"roles/viewer", "organizations/1234/roles/x", "projects/p/roles/y"} {
+			role := newRoleConfig(id, orgScope)
+			for _, parent := range role.Parents {
+				Expect(parent.ExternalID).ToNot(BeEmpty(), "role %s produced a dangling parent", id)
+			}
+		}
+	})
+})
+
+var _ = Describe("buildIAMAccess tenant", func() {
+	It("stamps the organization tenant on every external identity", func() {
+		scope := iamScope{
+			Tenant:  "1234",
+			Project: "gcp-proj-1",
+			Root:    v1.ConfigExternalKey{Type: v1.GCPProject, ExternalID: "gcp-proj-1"},
+		}
+
+		res := buildIAMAccess([]*assetpb.Asset{
+			iamPolicyAsset("//storage.googleapis.com/projects/_/buckets/b", "storage.googleapis.com/Bucket",
+				&iampb.Binding{Role: "roles/viewer", Members: []string{
+					"user:alice@example.com",
+					"serviceAccount:sa@gcp-proj-1.iam.gserviceaccount.com",
+					"group:admins@example.com",
+				}},
+			),
+		}, scope)
+
+		Expect(res.Users).ToNot(BeEmpty())
+		for _, user := range res.Users {
+			Expect(user.Tenant).To(Equal("1234"))
+		}
+		Expect(res.Groups).ToNot(BeEmpty())
+		for _, group := range res.Groups {
+			Expect(group.Tenant).To(Equal("1234"))
+		}
+		Expect(res.Roles).ToNot(BeEmpty())
+		for _, role := range res.Roles {
+			Expect(role.Tenant).To(Equal("1234"))
+		}
+	})
+})

--- a/scrapers/gcp/iam_scope_test.go
+++ b/scrapers/gcp/iam_scope_test.go
@@ -58,13 +58,10 @@ var _ = Describe("resolveOrganization", func() {
 	})
 })
 
-var _ = Describe("fetchResourceManagerHierarchy salvage", func() {
-	It("keeps the organization id discovered before an unreadable node", func() {
-		// The walk records organizations/1234 from the parent chain before it
-		// tries to read the organization resource, so a scrape service account
-		// without organization read access still tenants by organization.
-		hierarchy := resourceHierarchy{OrganizationID: "1234"}
-		Expect(scopeFor("projects/gcp-proj-1", hierarchy.OrganizationID).Tenant).To(Equal("1234"))
+var _ = Describe("fetchResourceManagerHierarchy", func() {
+	It("rejects unsupported roots before creating an API client", func() {
+		_, err := fetchResourceManagerHierarchy(&GCPContext{}, v1.GCP{}, "folders/1234")
+		Expect(err).To(MatchError(`unsupported GCP resource hierarchy root "folders/1234"`))
 	})
 })
 
@@ -116,6 +113,7 @@ var _ = Describe("coalesceIAMRoleConfigs", func() {
 			Relationship:      "IAMBinding",
 		})
 		roleB := newRoleConfig("roles/viewer", scope)
+		roleB.Config.(map[string]any)["title"] = "Viewer"
 		roleB.RelationshipResults = append(roleB.RelationshipResults, v1.RelationshipResult{
 			ConfigExternalID:  v1.ExternalID{ConfigType: v1.IAMRole, ExternalID: "roles/viewer"},
 			RelatedExternalID: v1.ExternalID{ConfigType: v1.GCSBucket, ExternalID: "bucket-b"},
@@ -127,6 +125,8 @@ var _ = Describe("coalesceIAMRoleConfigs", func() {
 		Expect(results).To(HaveLen(1))
 		Expect(results[0].Parents).To(ConsistOf(scope.Root))
 		Expect(results[0].RelationshipResults).To(HaveLen(2))
+		Expect(results[0].Config).To(HaveKeyWithValue("title", "Viewer"))
+		Expect(roleA.Config).ToNot(HaveKey("title"), "coalescing must not mutate its input maps")
 	})
 
 	It("leaves unrelated and error results untouched", func() {

--- a/scrapers/gcp/iam_test.go
+++ b/scrapers/gcp/iam_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/samber/lo"
 	cloudidentity "google.golang.org/api/cloudidentity/v1"
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v3"
+	expr "google.golang.org/genproto/googleapis/type/expr"
 
 	v1 "github.com/flanksource/config-db/api/v1"
 )
@@ -243,9 +244,88 @@ var _ = Describe("buildIAMAccess", func() {
 			},
 		))
 	})
+
+	It("omits conditional bindings from effective access", func() {
+		result := buildIAMAccess([]*assetpb.Asset{
+			iamPolicyAsset("//storage.googleapis.com/projects/_/buckets/conditional", "storage.googleapis.com/Bucket",
+				&iampb.Binding{
+					Role:      "roles/storage.objectViewer",
+					Members:   []string{"user:alice@example.com", "group:admins@example.com"},
+					Condition: &expr.Expr{Expression: "request.time < timestamp('2030-01-01T00:00:00Z')"},
+				},
+			),
+		}, projectIAMScope("my-project"))
+
+		gomega.Expect(result.SkippedConditionalBindings).To(gomega.Equal(1))
+		gomega.Expect(result.RoleConfigs).To(gomega.HaveLen(1), "the role definition remains discoverable")
+		gomega.Expect(result.Roles).To(gomega.HaveLen(1))
+		gomega.Expect(result.RoleConfigs[0].RelationshipResults).To(gomega.BeEmpty())
+		gomega.Expect(result.Access).To(gomega.BeEmpty())
+		gomega.Expect(result.Users).To(gomega.BeEmpty())
+		gomega.Expect(result.Groups).To(gomega.BeEmpty())
+		gomega.Expect(result.GroupEmails).To(gomega.BeEmpty())
+	})
+
+	It("still emits an unconditional sibling after skipping the same conditional tuple", func() {
+		conditional := &iampb.Binding{
+			Role:      "roles/viewer",
+			Members:   []string{"user:alice@example.com"},
+			Condition: &expr.Expr{Expression: "resource.name.startsWith('projects/prefix')"},
+		}
+		unconditional := &iampb.Binding{
+			Role:    "roles/viewer",
+			Members: []string{"user:alice@example.com"},
+		}
+
+		result := buildIAMAccess([]*assetpb.Asset{
+			iamPolicyAsset("//storage.googleapis.com/projects/_/buckets/mixed", "storage.googleapis.com/Bucket",
+				conditional, unconditional,
+			),
+		}, projectIAMScope("my-project"))
+
+		gomega.Expect(result.SkippedConditionalBindings).To(gomega.Equal(1))
+		gomega.Expect(result.Access).To(gomega.HaveLen(1))
+		gomega.Expect(result.Users).To(gomega.HaveLen(1))
+		gomega.Expect(result.RoleConfigs).To(gomega.HaveLen(1))
+		gomega.Expect(result.RoleConfigs[0].RelationshipResults).To(gomega.HaveLen(1))
+	})
 })
 
 var _ = Describe("fetch IAM policies", func() {
+	It("reports omitted conditional bindings as a bounded warning", func() {
+		ctx := &GCPContext{ScrapeContext: api.NewScrapeContext(dutyCtx.New())}
+		iamPolicy, err := (Scraper{}).fetchIAMPolicies(ctx, v1.GCP{Project: "app-prod"}, "projects/app-prod", iamPolicyFetchers{
+			listAssets: func(*GCPContext, v1.GCP, string) ([]*assetpb.Asset, error) {
+				return []*assetpb.Asset{iamPolicyAsset(
+					"//storage.googleapis.com/projects/_/buckets/conditional",
+					"storage.googleapis.com/Bucket",
+					&iampb.Binding{
+						Role:      "roles/viewer",
+						Members:   []string{"user:alice@example.com"},
+						Condition: &expr.Expr{Title: "temporary", Expression: "request.time < timestamp('2030-01-01T00:00:00Z')"},
+					},
+				)}, nil
+			},
+			fetchHierarchy: func(*GCPContext, v1.GCP, string) (resourceHierarchy, error) {
+				return resourceHierarchy{Project: &cloudresourcemanager.Project{Name: "projects/123", ProjectId: "app-prod"}}, nil
+			},
+			enrichRoles: func(*GCPContext, []v1.ScrapeResult) {},
+		})
+
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		var warnings []v1.Warning
+		var accesses []v1.ExternalConfigAccess
+		for _, result := range iamPolicy.Results {
+			warnings = append(warnings, result.Warnings...)
+			accesses = append(accesses, result.ConfigAccess...)
+		}
+		gomega.Expect(accesses).To(gomega.BeEmpty())
+		gomega.Expect(warnings).To(gomega.ConsistOf(v1.Warning{
+			Error: "conditional GCP IAM bindings cannot be modeled and were omitted from effective access",
+			Count: 1,
+		}))
+	})
+
 	DescribeTable("preserves asset policies when hierarchy discovery is unavailable",
 		func(project *cloudresourcemanager.Project, hierarchyErr error) {
 			const (
@@ -374,6 +454,38 @@ var _ = Describe("buildResourceManagerHierarchy", func() {
 			principal, "roles/resourcemanager.organizationAdmin",
 		)).ToNot(gomega.BeNil())
 	})
+
+	It("preserves IAM conditions while converting Resource Manager policies", func() {
+		policy := resourceManagerIAMPolicy(&cloudresourcemanager.Policy{
+			Version: 3,
+			Bindings: []*cloudresourcemanager.Binding{{
+				Role:    "roles/viewer",
+				Members: []string{"user:alice@example.com"},
+				Condition: &cloudresourcemanager.Expr{
+					Title:       "temporary",
+					Description: "expires at the end of the migration",
+					Expression:  "request.time < timestamp('2030-01-01T00:00:00Z')",
+					Location:    "policy.yaml:12",
+				},
+			}},
+		})
+
+		gomega.Expect(policy.Version).To(gomega.Equal(int32(3)))
+		gomega.Expect(policy.Bindings).To(gomega.HaveLen(1))
+		gomega.Expect(policy.Bindings[0].Condition).ToNot(gomega.BeNil())
+		gomega.Expect(policy.Bindings[0].Condition.Title).To(gomega.Equal("temporary"))
+		gomega.Expect(policy.Bindings[0].Condition.Description).To(gomega.Equal("expires at the end of the migration"))
+		gomega.Expect(policy.Bindings[0].Condition.Expression).To(gomega.Equal("request.time < timestamp('2030-01-01T00:00:00Z')"))
+		gomega.Expect(policy.Bindings[0].Condition.Location).To(gomega.Equal("policy.yaml:12"))
+
+		access := buildIAMAccess([]*assetpb.Asset{{
+			Name:      "//cloudresourcemanager.googleapis.com/organizations/1234",
+			AssetType: organizationAssetType,
+			IamPolicy: policy,
+		}}, scopeFor("organizations/1234", "1234"))
+		gomega.Expect(access.SkippedConditionalBindings).To(gomega.Equal(1))
+		gomega.Expect(access.Access).To(gomega.BeEmpty())
+	})
 })
 
 func TestBuildIAMAccess(t *testing.T) {
@@ -422,7 +534,11 @@ func TestBuildIAMAccess(t *testing.T) {
 		g.Expect(rc).ToNot(gomega.BeNil(), "missing role config for %s", role)
 		g.Expect(rc.Config).ToNot(gomega.BeNil(), "role config %s must carry a config body", role)
 		g.Expect(rc.Aliases).To(gomega.ContainElement(role))
-		g.Expect(rc.Parents).To(gomega.ContainElement(v1.ConfigExternalKey{Type: v1.GCPProject, ExternalID: project}))
+	}
+	for _, role := range []string{roleOwner, roleStorage, roleCustom} {
+		g.Expect(findRoleConfig(res.RoleConfigs, role).Parents).To(gomega.ContainElement(
+			v1.ConfigExternalKey{Type: v1.GCPProject, ExternalID: project},
+		))
 	}
 
 	// storage.admin is bound on the project and the bucket -> 2 deduped edges.

--- a/scrapers/gcp/iam_test.go
+++ b/scrapers/gcp/iam_test.go
@@ -11,6 +11,7 @@ import (
 	dutyCtx "github.com/flanksource/duty/context"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/samber/lo"
 	cloudidentity "google.golang.org/api/cloudidentity/v1"
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v3"
 
@@ -159,6 +160,12 @@ func TestTraverseGroupNestedFetchError(t *testing.T) {
 	g.Expect(err).To(gomega.HaveOccurred())
 }
 
+// projectIAMScope is the scope of a project-rooted scrape with no reachable
+// organization, which is what most of these tests exercise.
+func projectIAMScope(project string) iamScope {
+	return scopeFor(v1.ProjectPrefix+project, "")
+}
+
 func iamPolicyAsset(name, assetType string, bindings ...*iampb.Binding) *assetpb.Asset {
 	return &assetpb.Asset{
 		Name:      name,
@@ -218,7 +225,7 @@ var _ = Describe("buildIAMAccess", func() {
 					"serviceAccount:" + principal,
 				}},
 			),
-		}, project)
+		}, projectIAMScope(project))
 
 		source := iamPolicySource
 		gomega.Expect(result.Access).To(gomega.ConsistOf(
@@ -249,25 +256,38 @@ var _ = Describe("fetch IAM policies", func() {
 			)
 
 			ctx := &GCPContext{ScrapeContext: api.NewScrapeContext(dutyCtx.New())}
-			results, groups, err := (Scraper{}).fetchIAMPolicies(ctx, v1.GCP{Project: projectID}, iamPolicyFetchers{
-				listAssets: func(*GCPContext, v1.GCP) ([]*assetpb.Asset, error) {
+			iamPolicy, err := (Scraper{}).fetchIAMPolicies(ctx, v1.GCP{Project: projectID}, v1.ProjectPrefix+projectID, iamPolicyFetchers{
+				listAssets: func(*GCPContext, v1.GCP, string) ([]*assetpb.Asset, error) {
 					return []*assetpb.Asset{iamPolicyAsset(
 						bucketID,
 						"storage.googleapis.com/Bucket",
 						&iampb.Binding{Role: role, Members: []string{"user:" + principal}},
 					)}, nil
 				},
-				fetchHierarchy: func(*GCPContext, v1.GCP) (*cloudresourcemanager.Project, []resourceManagerNode, error) {
-					return project, nil, hierarchyErr
+				fetchHierarchy: func(*GCPContext, v1.GCP, string) (resourceHierarchy, error) {
+					return resourceHierarchy{Project: project}, hierarchyErr
 				},
 				enrichRoles: func(*GCPContext, []v1.ScrapeResult) {},
 			})
 
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Expect(groups).To(gomega.BeEmpty())
-			gomega.Expect(results).To(gomega.HaveLen(2))
+			gomega.Expect(iamPolicy.GroupEmails).To(gomega.BeEmpty())
+			// No organization is reachable here, so the tenant stays the project.
+			gomega.Expect(iamPolicy.Scope.Tenant).To(gomega.Equal(projectID))
+
+			// An unreadable hierarchy is surfaced as a scraper error, not just a log
+			// line, because it silently costs the organization and folder configs.
+			hierarchyErrors := lo.Filter(iamPolicy.Results, func(r v1.ScrapeResult, _ int) bool {
+				return r.Error != nil
+			})
+			gomega.Expect(hierarchyErrors).To(gomega.HaveLen(1))
+			gomega.Expect(hierarchyErrors[0].Error.Error()).To(gomega.ContainSubstring("resource hierarchy"))
+
 			source := iamPolicySource
-			gomega.Expect(results[1].ConfigAccess).To(gomega.Equal([]v1.ExternalConfigAccess{{
+			accesses := lo.FlatMap(iamPolicy.Results, func(r v1.ScrapeResult, _ int) []v1.ExternalConfigAccess {
+				return r.ConfigAccess
+			})
+			gomega.Expect(accesses).To(gomega.Equal([]v1.ExternalConfigAccess{{
 				ConfigExternalID:    v1.ExternalID{ConfigType: v1.GCSBucket, ExternalID: bucketID},
 				ExternalUserAliases: []string{principal},
 				ExternalRoleAliases: []string{role},
@@ -344,7 +364,7 @@ var _ = Describe("buildResourceManagerHierarchy", func() {
 		gomega.Expect(configs[1].Aliases).To(gomega.Equal([]string{organizationExternalID}))
 		gomega.Expect(configs[1].Children).To(gomega.BeEmpty())
 
-		access := buildIAMAccess(policies, projectID)
+		access := buildIAMAccess(policies, projectIAMScope(projectID))
 		gomega.Expect(accessKeyed(access.Access,
 			v1.ExternalID{ConfigType: "GCP::ResourceManager::Folder", ExternalID: folderExternalID},
 			principal, "roles/resourcemanager.folderViewer",
@@ -393,7 +413,7 @@ func TestBuildIAMAccess(t *testing.T) {
 		),
 	}
 
-	res := buildIAMAccess(assets, project)
+	res := buildIAMAccess(assets, projectIAMScope(project))
 
 	// One GCP::IAMRole config item per distinct bound role.
 	g.Expect(res.RoleConfigs).To(gomega.HaveLen(3), "expected one config item per distinct role")

--- a/scrapers/gcp/iam_test.go
+++ b/scrapers/gcp/iam_test.go
@@ -534,9 +534,7 @@ func TestBuildIAMAccess(t *testing.T) {
 		g.Expect(rc).ToNot(gomega.BeNil(), "missing role config for %s", role)
 		g.Expect(rc.Config).ToNot(gomega.BeNil(), "role config %s must carry a config body", role)
 		g.Expect(rc.Aliases).To(gomega.ContainElement(role))
-	}
-	for _, role := range []string{roleOwner, roleStorage, roleCustom} {
-		g.Expect(findRoleConfig(res.RoleConfigs, role).Parents).To(gomega.ContainElement(
+		g.Expect(rc.Parents).To(gomega.ContainElement(
 			v1.ConfigExternalKey{Type: v1.GCPProject, ExternalID: project},
 		))
 	}

--- a/scrapers/gcp/security_center.go
+++ b/scrapers/gcp/security_center.go
@@ -117,7 +117,9 @@ func parseFinding(finding *securitycenterpb.ListFindingsResponse_ListFindingsRes
 	return &analysis
 }
 
-func (gcp Scraper) ListFindings(ctx *GCPContext, config v1.GCP) (v1.ScrapeResults, error) {
+// ListFindings reads Security Center findings for parent, which is either a
+// single project or a whole organization.
+func (gcp Scraper) ListFindings(ctx *GCPContext, parent string) (v1.ScrapeResults, error) {
 	var results v1.ScrapeResults
 	client, err := securitycenter.NewClient(ctx, ctx.ClientOpts...)
 	if err != nil {
@@ -130,7 +132,7 @@ func (gcp Scraper) ListFindings(ctx *GCPContext, config v1.GCP) (v1.ScrapeResult
 	}()
 
 	req := &securitycenterpb.ListFindingsRequest{
-		Parent:   fmt.Sprintf("projects/%s/sources/-", config.Project),
+		Parent:   fmt.Sprintf("%s/sources/-", parent),
 		PageSize: 1000,
 	}
 

--- a/scrapers/gcp/targets.go
+++ b/scrapers/gcp/targets.go
@@ -1,0 +1,112 @@
+// Resolves a GCP scraper config into the Cloud Asset Inventory roots to scrape,
+// narrowing an organization to the configured projects that actually belong to it.
+package gcp
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	asset "cloud.google.com/go/asset/apiv1"
+	"cloud.google.com/go/asset/apiv1/assetpb"
+	"google.golang.org/api/iterator"
+
+	v1 "github.com/flanksource/config-db/api/v1"
+)
+
+// resolveParents returns the asset-inventory roots to list from. An organization
+// with no configured projects is listed in one pass; configured projects are
+// listed one at a time so only what was asked for is fetched.
+func resolveParents(ctx *GCPContext, config v1.GCP) ([]string, error) {
+	configured := config.ConfiguredProjects()
+
+	if !config.IsOrgScoped() {
+		return qualifyProjects(configured), nil
+	}
+
+	organization := v1.OrganizationPrefix + config.OrganizationID()
+	if len(configured) == 0 {
+		return []string{organization}, nil
+	}
+
+	organizationProjects, err := listOrganizationProjects(ctx, organization)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list projects in %s: %w", organization, err)
+	}
+
+	return qualifyProjects(intersectProjects(organizationProjects, configured, ctx.Warnf)), nil
+}
+
+// intersectProjects keeps the configured projects that belong to the
+// organization, warning about each one that does not so a typo or a project
+// moved out of the organization is visible rather than silently scraped as
+// nothing.
+func intersectProjects(organizationProjects, configured []string, warn func(format string, args ...any)) []string {
+	var projects []string
+	for _, project := range configured {
+		if slices.Contains(organizationProjects, project) {
+			projects = append(projects, project)
+			continue
+		}
+		warn("gcp: skipping project %s, it does not belong to the configured organization", project)
+	}
+	return projects
+}
+
+func qualifyProjects(projects []string) []string {
+	parents := make([]string, 0, len(projects))
+	for _, project := range projects {
+		parents = append(parents, v1.ProjectPrefix+project)
+	}
+	return parents
+}
+
+// projectFromParent returns the project id an asset-inventory root refers to,
+// empty for an organization root.
+func projectFromParent(parent string) string {
+	id, ok := strings.CutPrefix(parent, v1.ProjectPrefix)
+	if !ok {
+		return ""
+	}
+	return id
+}
+
+// listOrganizationProjects returns the ids of every project beneath the
+// organization, read from the asset inventory so no extra API surface is needed.
+func listOrganizationProjects(ctx *GCPContext, organization string) ([]string, error) {
+	assetClient, err := asset.NewClient(ctx, ctx.ClientOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating asset client: %w", err)
+	}
+	defer func() {
+		if err := assetClient.Close(); err != nil {
+			ctx.Warnf("gcp: failed to close asset client: %v", err)
+		}
+	}()
+
+	req := &assetpb.ListAssetsRequest{
+		Parent:      organization,
+		ContentType: assetpb.ContentType_RESOURCE,
+		AssetTypes:  []string{projectAssetType},
+		PageSize:    1000,
+	}
+
+	resolver := newProjectResolver("")
+	var projects []string
+	it := assetClient.ListAssets(ctx, req)
+	for {
+		a, err := it.Next()
+		if err == iterator.Done {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("error listing projects: %w", err)
+		}
+
+		resolver.record(a)
+		if id := resolver.resolve(a.Ancestors); id != "" {
+			projects = append(projects, id)
+		}
+	}
+
+	return projects, nil
+}

--- a/scrapers/gcp/targets_test.go
+++ b/scrapers/gcp/targets_test.go
@@ -1,0 +1,65 @@
+package gcp
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("intersectProjects", func() {
+	It("keeps only the configured projects that belong to the organization", func() {
+		var warnings []string
+		warn := func(format string, args ...any) { warnings = append(warnings, format) }
+
+		projects := intersectProjects(
+			[]string{"gcp-proj-1", "gcp-proj-2", "gcp-proj-3"},
+			[]string{"gcp-proj-2", "gcp-proj-9"},
+			warn,
+		)
+
+		Expect(projects).To(Equal([]string{"gcp-proj-2"}))
+		Expect(warnings).To(HaveLen(1), "expected a warning for the project outside the organization")
+	})
+
+	It("returns nothing when no configured project belongs to the organization", func() {
+		projects := intersectProjects(
+			[]string{"gcp-proj-1"},
+			[]string{"gcp-proj-9"},
+			func(string, ...any) {},
+		)
+
+		Expect(projects).To(BeEmpty())
+	})
+
+	It("keeps every configured project when all belong to the organization", func() {
+		var warnings int
+		projects := intersectProjects(
+			[]string{"gcp-proj-1", "gcp-proj-2"},
+			[]string{"gcp-proj-1", "gcp-proj-2"},
+			func(string, ...any) { warnings++ },
+		)
+
+		Expect(projects).To(Equal([]string{"gcp-proj-1", "gcp-proj-2"}))
+		Expect(warnings).To(BeZero())
+	})
+})
+
+var _ = Describe("qualifyProjects", func() {
+	It("prefixes each project id", func() {
+		Expect(qualifyProjects([]string{"gcp-proj-1", "gcp-proj-2"})).To(Equal(
+			[]string{"projects/gcp-proj-1", "projects/gcp-proj-2"}))
+	})
+
+	It("returns an empty list for no projects", func() {
+		Expect(qualifyProjects(nil)).To(BeEmpty())
+	})
+})
+
+var _ = Describe("projectFromParent", func() {
+	It("extracts the project id from a project root", func() {
+		Expect(projectFromParent("projects/gcp-proj-1")).To(Equal("gcp-proj-1"))
+	})
+
+	It("returns empty for an organization root", func() {
+		Expect(projectFromParent("organizations/1234567890")).To(BeEmpty())
+	})
+})

--- a/scrapers/gcp/targets_test.go
+++ b/scrapers/gcp/targets_test.go
@@ -54,6 +54,18 @@ var _ = Describe("qualifyProjects", func() {
 	})
 })
 
+var _ = Describe("securityCenterParents", func() {
+	It("keeps narrowed organization project roots", func() {
+		parents := []string{"projects/gcp-proj-1", "projects/gcp-proj-2"}
+		Expect(securityCenterParents(parents)).To(Equal(parents))
+	})
+
+	It("keeps an unrestricted organization root", func() {
+		parents := []string{"organizations/1234567890"}
+		Expect(securityCenterParents(parents)).To(Equal(parents))
+	})
+})
+
 var _ = Describe("projectFromParent", func() {
 	It("extracts the project id from a project root", func() {
 		Expect(projectFromParent("projects/gcp-proj-1")).To(Equal("gcp-proj-1"))

--- a/scrapers/gcp/targets_test.go
+++ b/scrapers/gcp/targets_test.go
@@ -54,18 +54,6 @@ var _ = Describe("qualifyProjects", func() {
 	})
 })
 
-var _ = Describe("securityCenterParents", func() {
-	It("keeps narrowed organization project roots", func() {
-		parents := []string{"projects/gcp-proj-1", "projects/gcp-proj-2"}
-		Expect(securityCenterParents(parents)).To(Equal(parents))
-	})
-
-	It("keeps an unrestricted organization root", func() {
-		parents := []string{"organizations/1234567890"}
-		Expect(securityCenterParents(parents)).To(Equal(parents))
-	})
-})
-
 var _ = Describe("projectFromParent", func() {
 	It("extracts the project id from a project root", func() {
 		Expect(projectFromParent("projects/gcp-proj-1")).To(Equal("gcp-proj-1"))


### PR DESCRIPTION
Fixes: #2341 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization-scoped and multi-project GCP scraping.
  * Added flexible project configuration, including single-project aliases and project filtering.
  * Added organization and project hierarchy detection for more accurate resource ownership.
  * Improved audit-log attribution to affected projects and support for organization-level datasets.
  * Added broader IAM, Security Center, Cloud SQL backup, and asset coverage across configured scopes.

* **Bug Fixes**
  * Improved handling of project ancestry, aliases, conditional IAM bindings, and out-of-scope audit-log entries.
  * Preserved successful results when individual project operations fail.

* **Documentation**
  * Updated configuration schemas and examples with scope, filtering, and audit-log guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->