### PR TITLE
fix: regenerate scrape config CRD

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,14 @@ jobs:
         with:
           go-version: 1.26.x
 
-      - run: make resources
+      - name: Generate resources
+        run: make resources
+      - name: Verify generated CRDs are committed
+        run: |
+          if [ -n "$(git status --porcelain -- chart/crds)" ]; then
+            git status --short -- chart/crds
+            echo "::error::Generated CRDs are out of date. Run 'make manifests' and commit the changes."
+            exit 1
+          fi
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0

--- a/chart/crds/configs.flanksource.com_scrapeconfigs.yaml
+++ b/chart/crds/configs.flanksource.com_scrapeconfigs.yaml
@@ -5902,13 +5902,25 @@ spec:
               github:
                 items:
                   description: |-
-                    GitHub scraper creates GitHub::Repository config items and optionally
-                    attaches security alerts and OpenSSF scorecard results as analyses.
+                    GitHub scraper creates GitHub::Repository config items, optionally collects
+                    commits as changes, and attaches security alerts and OpenSSF scorecard results as analyses.
                   properties:
                     class:
                       description: A static value or JSONPath expression to use as
                         the class for the resource.
                       type: string
+                    commits:
+                      description: Commits configures commit metadata collection from
+                        each repository's default branch
+                      properties:
+                        enabled:
+                          description: Enabled enables commit collection.
+                          type: boolean
+                        maxAge:
+                          description: MaxAge limits commits to this age. Defaults
+                            to 30d.
+                          type: string
+                      type: object
                     connection:
                       description: ConnectionName, if provided, will be used to populate
                         personalAccessToken


### PR DESCRIPTION
## Summary
- regenerate the ScrapeConfig CRD so `github.commits.enabled` and `github.commits.maxAge` are published
- fail the lint workflow when `make resources` changes or creates files under `chart/crds`

## Validation
- `make resources`
- generated CRD guard passes with a clean `chart/crds` tree
- `actionlint .github/workflows/lint.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub scraper configurations can now optionally collect commit information.
  * Commit collection supports enabling or disabling the feature and setting a maximum age, defaulting to 30 days.

* **Bug Fixes**
  * Added validation to detect outdated or uncommitted generated resource definitions before changes are merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->