### PR TITLE
Distinguish conflicting Kubernetes kinds

### DIFF
--- a/scrapers/kubernetes/events.go
+++ b/scrapers/kubernetes/events.go
@@ -90,7 +90,7 @@ func getChangeFromEvent(event v1.KubernetesEvent, severityKeywords v1.SeverityKe
 		Details:          getDetailsFromEvent(event),
 		ExternalChangeID: event.GetUID(),
 		ExternalID:       string(event.InvolvedObject.UID),
-		ConfigType:       ConfigTypePrefix + event.InvolvedObject.Kind,
+		ConfigType:       getConfigType(event.InvolvedObject.APIVersion, event.InvolvedObject.Kind),
 		Severity:         severity,
 		Source:           getSourceFromEvent(event),
 		Summary:          event.Message,

--- a/scrapers/kubernetes/kubernetes.go
+++ b/scrapers/kubernetes/kubernetes.go
@@ -44,16 +44,27 @@ const (
 var ResourceIDMapPerCluster PerClusterResourceIDMap
 
 func GetConfigType(obj *unstructured.Unstructured) string {
-	apiVersion := obj.GetAPIVersion()
+	return getConfigType(obj.GetAPIVersion(), obj.GetKind())
+}
+
+func getConfigType(apiVersion, kind string) string {
+	apiGroup, _, _ := strings.Cut(apiVersion, "/")
+	switch apiGroup + "/" + kind {
+	case "longhorn.io/Node":
+		return ConfigTypePrefix + "LonghornNode"
+	case "postgresql.cnpg.io/Cluster":
+		return ConfigTypePrefix + "CNPGCluster"
+	}
+
 	if strings.Contains(apiVersion, ".upbound.io") || strings.Contains(apiVersion, ".crossplane.io") {
-		return "Crossplane::" + obj.GetKind()
+		return "Crossplane::" + kind
 	}
 
 	if strings.HasSuffix(apiVersion, ".flanksource.com/v1") {
-		return api.MissionControlConfigTypePrefix + obj.GetKind()
+		return api.MissionControlConfigTypePrefix + kind
 	}
 
-	return ConfigTypePrefix + obj.GetKind()
+	return ConfigTypePrefix + kind
 }
 
 type KubernetesScraper struct{}
@@ -649,7 +660,7 @@ func getKubernetesParent(ctx *KubernetesContext, obj *unstructured.Unstructured)
 			}}, allParents...)
 		} else {
 			allParents = append([]v1.ConfigExternalKey{{
-				Type:       ConfigTypePrefix + ref.Kind,
+				Type:       getConfigType(ref.APIVersion, ref.Kind),
 				ExternalID: string(ref.UID),
 			}}, allParents...)
 		}

--- a/scrapers/kubernetes/kubernetes_test.go
+++ b/scrapers/kubernetes/kubernetes_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestKubernetes(t *testing.T) {
@@ -18,6 +19,20 @@ var _ = Describe("extractAccountIDFromARN", func() {
 			Expect(extractAccountIDFromARN(input)).To(Equal(expected))
 		},
 		Entry("valid ARN", `- groups:\n  - system:masters\n  rolearn: arn:aws:iam::123456789012:role/kubernetes-admin\n  username: admin\n- groups:\n  - system:bootstrappers\n  - system:nodes\n  rolearn: arn:aws:iam::123456789012:role/eksctl-mission-control-demo-clust-NodeInstanceRole-VRLF7VBIVK3M\n  username: system:node:{{EC2PrivateDNSName}}\n`, "123456789012"),
+	)
+})
+
+var _ = Describe("GetConfigType", func() {
+	DescribeTable("distinguishes conflicting Kubernetes kinds",
+		func(apiVersion, kind, expected string) {
+			obj := &unstructured.Unstructured{}
+			obj.SetAPIVersion(apiVersion)
+			obj.SetKind(kind)
+			Expect(GetConfigType(obj)).To(Equal(expected))
+		},
+		Entry("core node", "v1", "Node", "Kubernetes::Node"),
+		Entry("Longhorn node", "longhorn.io/v1beta2", "Node", "Kubernetes::LonghornNode"),
+		Entry("CNPG cluster", "postgresql.cnpg.io/v1", "Cluster", "Kubernetes::CNPGCluster"),
 	)
 })
 


### PR DESCRIPTION
Resolves #1740 by assigning distinct config types to Longhorn nodes and CNPG clusters while preserving related events and owner links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration type detection for Kubernetes resources.
  * Added accurate handling for Longhorn Nodes and CNPG Clusters.
  * Preserved correct type mapping for Crossplane and Mission Control resources.
  * Improved event and owner-reference classification when resource kinds overlap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->