### PR TITLE
fix: resolve relationship external IDs

### DIFF
--- a/db/config.go
+++ b/db/config.go
@@ -56,14 +56,41 @@ func FindConfigIDsByRelationshipSelector(ctx context.Context, selector duty.Rela
 		return nil, nil
 	}
 
-	return query.FindConfigIDsByResourceSelector(ctx, 0, selector.ToResourceSelector())
+	// duty treats relationship external IDs as generic property field selectors,
+	// but config external IDs are stored in their own normalized array column.
+	externalID := v1.NormalizeExternalID(selector.ExternalID)
+	selector.ExternalID = ""
+
+	if selector.IsEmpty() {
+		if externalID == "" {
+			return nil, nil
+		}
+		var ids []uuid.UUID
+		err := ctx.DB().Model(&dutyModels.ConfigItem{}).
+			Where("? = ANY(external_id)", externalID).
+			Pluck("id", &ids).Error
+		return ids, err
+	}
+
+	ids, err := query.FindConfigIDsByResourceSelector(ctx, 0, selector.ToResourceSelector())
+	if err != nil || externalID == "" || len(ids) == 0 {
+		return ids, err
+	}
+
+	var filtered []uuid.UUID
+	err = ctx.DB().Model(&dutyModels.ConfigItem{}).
+		Where("id IN ?", ids).
+		Where("? = ANY(external_id)", externalID).
+		Pluck("id", &filtered).Error
+	return filtered, err
 }
 
 func FindConfigsByRelationshipSelector(ctx context.Context, selector duty.RelationshipSelector) ([]dutyModels.ConfigItem, error) {
-	if selector.IsEmpty() {
-		return nil, nil
+	ids, err := FindConfigIDsByRelationshipSelector(ctx, selector)
+	if err != nil || len(ids) == 0 {
+		return nil, err
 	}
-	return query.FindConfigsByResourceSelector(ctx, 0, selector.ToResourceSelector())
+	return query.GetConfigsByIDs(ctx, ids)
 }
 
 // FindConfigIDsByNamespaceNameClass returns the uuid of config items which matches the given type, name & namespace

--- a/db/config_test.go
+++ b/db/config_test.go
@@ -1,0 +1,46 @@
+package db
+
+import (
+	v1 "github.com/flanksource/config-db/api/v1"
+	"github.com/flanksource/duty"
+	dutymodels "github.com/flanksource/duty/models"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+)
+
+var _ = Describe("FindConfigsByRelationshipSelector", func() {
+	It("resolves normalized external IDs without dropping the other selector fields", func() {
+		id := uuid.New()
+		configType := "CNPG::Cluster"
+		externalID := "Kubernetes/production/Cluster/database/Orders"
+		item := dutymodels.ConfigItem{
+			ID:          id,
+			ConfigClass: configType,
+			ExternalID:  pq.StringArray{v1.NormalizeExternalID(externalID)},
+			Type:        lo.ToPtr(configType),
+			Name:        lo.ToPtr("Orders"),
+		}
+		Expect(DefaultContext.DB().Create(&item).Error).To(Succeed())
+		DeferCleanup(func() {
+			Expect(DefaultContext.DB().Delete(&dutymodels.ConfigItem{}, id).Error).To(Succeed())
+		})
+
+		configs, err := FindConfigsByRelationshipSelector(DefaultContext, duty.RelationshipSelector{
+			ExternalID: externalID,
+			Type:       configType,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(configs).To(HaveLen(1))
+		Expect(configs[0].ID).To(Equal(id))
+
+		configs, err = FindConfigsByRelationshipSelector(DefaultContext, duty.RelationshipSelector{
+			ExternalID: externalID,
+			Type:       "CNPG::Backup",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(configs).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
## Summary

- normalize `RelationshipSelector.ExternalID` and query the dedicated `config_items.external_id` array
- retain all other relationship selector constraints before filtering by external ID
- add regression coverage for matching and mismatched selector types

## Tests

- `go test ./db -run '^TestDB$' -count=1 -ginkgo.focus 'FindConfigsByRelationshipSelector'`\n- `go test ./db -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relationship selector matching for configurations using external IDs.
  * Selectors combining external IDs with other criteria now return only matching configurations.
  * Selectors with unmatched external IDs correctly return no results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->