### PR TITLE
fix(kubernetes): skip invalid involved objects from Event

### DIFF
--- a/utils/kube/fetcher.go
+++ b/utils/kube/fetcher.go
@@ -55,11 +55,10 @@ func FetchInvolvedObjects(ctx api.ScrapeContext, iObjs []v1.InvolvedObject) ([]*
 	}
 
 	for _, iObj := range iObjs {
-		gv, _ := schema.ParseGroupVersion(iObj.APIVersion)
-		gvk := schema.GroupVersionKind{
-			Group:   gv.Group,
-			Version: gv.Version,
-			Kind:    iObj.Kind,
+		gvk, err := involvedObjectGVK(iObj)
+		if err != nil {
+			ctx.Logger.V(3).Infof("skipping invalid involved object: %v", err)
+			continue
 		}
 
 		client, err := k8s.GetClientByGroupVersionKind(ctx, gvk.Group, gvk.Version, gvk.Kind)
@@ -98,6 +97,28 @@ func FetchInvolvedObjects(ctx api.ScrapeContext, iObjs []v1.InvolvedObject) ([]*
 	}
 
 	return output, nil
+}
+
+func involvedObjectGVK(iObj v1.InvolvedObject) (schema.GroupVersionKind, error) {
+	if strings.TrimSpace(iObj.APIVersion) == "" {
+		return schema.GroupVersionKind{}, fmt.Errorf("missing apiVersion for %q", iObj.Name)
+	}
+	if strings.TrimSpace(iObj.Kind) == "" {
+		return schema.GroupVersionKind{}, fmt.Errorf("missing kind for %q", iObj.Name)
+	}
+	if strings.TrimSpace(iObj.Name) == "" {
+		return schema.GroupVersionKind{}, fmt.Errorf("missing name for kind %q", iObj.Kind)
+	}
+
+	gv, err := schema.ParseGroupVersion(iObj.APIVersion)
+	if err != nil {
+		return schema.GroupVersionKind{}, fmt.Errorf("invalid apiVersion %q for %s/%s: %w", iObj.APIVersion, iObj.Kind, iObj.Name, err)
+	}
+	if gv.Version == "" {
+		return schema.GroupVersionKind{}, fmt.Errorf("apiVersion %q has no version for %s/%s", iObj.APIVersion, iObj.Kind, iObj.Name)
+	}
+
+	return gv.WithKind(iObj.Kind), nil
 }
 
 func fetchObject(ctx api.ScrapeContext, client dynamic.NamespaceableResourceInterface, iObj v1.InvolvedObject) (*unstructured.Unstructured, error) {

--- a/utils/kube/fetcher_test.go
+++ b/utils/kube/fetcher_test.go
@@ -1,0 +1,76 @@
+package kube
+
+import (
+	"testing"
+
+	v1 "github.com/flanksource/config-db/api/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestInvolvedObjectGVK(t *testing.T) {
+	tests := []struct {
+		name    string
+		object  v1.InvolvedObject
+		want    schema.GroupVersionKind
+		wantErr bool
+	}{
+		{
+			name:   "core resource",
+			object: v1.InvolvedObject{APIVersion: "v1", Kind: "Pod", Namespace: "default", Name: "nginx"},
+			want:   schema.GroupVersionKind{Version: "v1", Kind: "Pod"},
+		},
+		{
+			name:   "grouped resource",
+			object: v1.InvolvedObject{APIVersion: "apps/v1", Kind: "Deployment", Namespace: "default", Name: "nginx"},
+			want:   schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+		},
+		{
+			name:   "cluster scoped resource",
+			object: v1.InvolvedObject{APIVersion: "v1", Kind: "Node", Name: "worker-1"},
+			want:   schema.GroupVersionKind{Version: "v1", Kind: "Node"},
+		},
+		{
+			name:    "missing api version",
+			object:  v1.InvolvedObject{Kind: "Pod", Name: "nginx"},
+			wantErr: true,
+		},
+		{
+			name:    "api version without version",
+			object:  v1.InvolvedObject{APIVersion: "apps/", Kind: "Deployment", Name: "nginx"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid api version",
+			object:  v1.InvolvedObject{APIVersion: "apps/v1/extra", Kind: "Deployment", Name: "nginx"},
+			wantErr: true,
+		},
+		{
+			name:    "missing kind",
+			object:  v1.InvolvedObject{APIVersion: "v1", Name: "nginx"},
+			wantErr: true,
+		},
+		{
+			name:    "missing name",
+			object:  v1.InvolvedObject{APIVersion: "v1", Kind: "Pod"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := involvedObjectGVK(tt.object)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("involvedObjectGVK() error = nil, want an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("involvedObjectGVK() unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("involvedObjectGVK() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation when identifying related Kubernetes resources.
  - Invalid or incomplete resource metadata is now safely skipped instead of causing processing issues.
  - Added clearer handling for malformed API versions and missing resource versions.

- **Tests**
  - Added coverage for core, grouped, and cluster-scoped resources.
  - Added validation tests for incomplete and invalid metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->