### PR TITLE
fix: prevent config location foreign key violations

### DIFF
--- a/db/update.go
+++ b/db/update.go
@@ -568,6 +568,58 @@ func syncCRDChanges(ctx api.ScrapeContext, configs []*models.ConfigItem) error {
 	return nil
 }
 
+const configLocationDiagnosticLimit = 50
+
+func saveConfigLocations(ctx api.ScrapeContext, locations []dutyModels.ConfigLocation) error {
+	if len(locations) == 0 {
+		return nil
+	}
+
+	uniqueLocations := lo.Uniq(locations)
+	err := ctx.DB().Transaction(func(tx *gorm.DB) error {
+		return tx.Clauses(clause.OnConflict{Columns: []clause.Column{{Name: "id"}, {Name: "location"}}, DoNothing: true}).
+			CreateInBatches(&uniqueLocations, 200).Error
+	})
+	if err == nil {
+		return nil
+	}
+
+	detailedErr := dutydb.ErrorDetails(err)
+	if !dutydb.IsForeignKeyError(err) {
+		return detailedErr
+	}
+
+	configIDs := lo.Uniq(lo.Map(uniqueLocations, func(location dutyModels.ConfigLocation, _ int) uuid.UUID {
+		return location.ID
+	}))
+	var existingIDs []uuid.UUID
+	if queryErr := ctx.DB().Table("config_items").Where("id IN ?", configIDs).Pluck("id", &existingIDs).Error; queryErr != nil {
+		return fmt.Errorf("%w; failed to diagnose config location foreign key violation: %v", detailedErr, queryErr)
+	}
+
+	existing := lo.SliceToMap(existingIDs, func(id uuid.UUID) (uuid.UUID, struct{}) {
+		return id, struct{}{}
+	})
+	missing := lo.Filter(uniqueLocations, func(location dutyModels.ConfigLocation, _ int) bool {
+		_, found := existing[location.ID]
+		return !found
+	})
+	if len(missing) == 0 {
+		return detailedErr
+	}
+
+	displayed := missing
+	if len(displayed) > configLocationDiagnosticLimit {
+		displayed = displayed[:configLocationDiagnosticLimit]
+	}
+	rows, marshalErr := json.Marshal(displayed)
+	if marshalErr != nil {
+		return fmt.Errorf("%w; %d config location row(s) reference missing config_items; failed to marshal offending rows: %v", detailedErr, len(missing), marshalErr)
+	}
+
+	return fmt.Errorf("%w; %d config location row(s) reference missing config_items; offending_rows=%s; displayed=%d", detailedErr, len(missing), rows, len(displayed))
+}
+
 func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSummary, error) {
 	var summary = v1.NewScrapeSummary()
 
@@ -603,12 +655,8 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 		ctx.TempCache().Insert(*config)
 	}
 
-	if len(extractResult.locations) > 0 {
-		uniqueLocations := lo.Uniq(extractResult.locations)
-		if err := ctx.DB().Clauses(clause.OnConflict{Columns: []clause.Column{{Name: "id"}, {Name: "location"}}, DoNothing: true}).
-			CreateInBatches(&uniqueLocations, 200).Error; err != nil {
-			return summary, ctx.Oops().Wrapf(err, "failed to save config locations")
-		}
+	if err := saveConfigLocations(ctx, extractResult.locations); err != nil {
+		return summary, ctx.Oops().Wrapf(err, "failed to save config locations")
 	}
 
 	entityResult, synced, err := syncExternalEntities(ctx, extractResult, scraperID)
@@ -1726,26 +1774,29 @@ func extractConfigsAndChangesFromResults(ctx api.ScrapeContext, results []v1.Scr
 				return nil, fmt.Errorf("config item %s has no external id", ci)
 			}
 
-			for _, extID := range ci.ExternalID {
-				parentTypeToConfigMap[configExternalKey{externalID: extID, parentType: ci.Type}] = ci.ID
+			existing, err := ctx.TempCache().Get(ctx, ci.ID)
+			if err != nil {
+				return nil, fmt.Errorf("unable to lookup existing config(%s): %w", ci, err)
 			}
 
-			existing := &models.ConfigItem{}
-			if ci.ID != "" {
-				if existing, err = ctx.TempCache().Get(ctx, ci.ID); err != nil {
-					return nil, fmt.Errorf("unable to lookup existing config(%s): %w", ci, err)
-				}
-			} else {
-				// We don't have a UUID for the config yet, so we need to look it up by external ID.
+			// The primary external ID can change while a stable alias continues to
+			// identify the same config. NewConfigItemFromResult always generates an
+			// ID, so an alias lookup must still be attempted after an exact-ID miss.
+			if existing == nil || existing.ID == "" {
 				for _, extID := range ci.ExternalID {
 					ext := v1.ExternalID{ConfigType: ci.Type, ExternalID: extID}
 					if c, err := ctx.TempCache().Find(ctx, ext); err != nil {
 						return nil, fmt.Errorf("unable to lookup external id(%s): %w", ext, err)
 					} else if c != nil && c.ID != "" {
 						existing = c
+						ci.ID = c.ID
 						break
 					}
 				}
+			}
+
+			for _, extID := range ci.ExternalID {
+				parentTypeToConfigMap[configExternalKey{externalID: extID, parentType: ci.Type}] = ci.ID
 			}
 
 			allConfigs = append(allConfigs, ci)
@@ -1765,23 +1816,34 @@ func extractConfigsAndChangesFromResults(ctx api.ScrapeContext, results []v1.Scr
 				}
 			}
 
-			for _, l := range result.Locations {
-				extractResult.locations = append(extractResult.locations, dutyModels.ConfigLocation{
-					ID:       uuid.MustParse(ci.ID),
-					Location: l,
+			if result.Config == nil && (existing == nil || existing.ID == "") && len(result.Locations) > 0 {
+				extractResult.warnings = append(extractResult.warnings, v1.Warning{
+					Error:  fmt.Sprintf("skipping locations for unknown config type=%s external_id=%s", result.Type, result.ID),
+					Result: result,
 				})
-			}
-
-			cacheItem := *ci
-			if cacheItem.CreatedAt.IsZero() {
-				if existing != nil && existing.ID != "" && !existing.CreatedAt.IsZero() {
-					cacheItem.CreatedAt = existing.CreatedAt
-				} else {
-					cacheItem.CreatedAt = time.Now().UTC()
+			} else {
+				for _, l := range result.Locations {
+					extractResult.locations = append(extractResult.locations, dutyModels.ConfigLocation{
+						ID:       uuid.MustParse(ci.ID),
+						Location: l,
+					})
 				}
 			}
 
-			ctx.TempCache().Insert(cacheItem)
+			// Metadata-only results for unknown configs are not persisted, so caching
+			// them would create phantom config IDs that later rows could reference.
+			if result.Config != nil {
+				cacheItem := *ci
+				if cacheItem.CreatedAt.IsZero() {
+					if existing != nil && existing.ID != "" && !existing.CreatedAt.IsZero() {
+						cacheItem.CreatedAt = existing.CreatedAt
+					} else {
+						cacheItem.CreatedAt = time.Now().UTC()
+					}
+				}
+
+				ctx.TempCache().Insert(cacheItem)
+			}
 		}
 
 		if chResult, err := extractChanges(ctx, result, ci); err != nil {

--- a/db/update_locations_test.go
+++ b/db/update_locations_test.go
@@ -1,0 +1,215 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/flanksource/config-db/api"
+	v1 "github.com/flanksource/config-db/api/v1"
+	"github.com/flanksource/config-db/db/models"
+	dutycontext "github.com/flanksource/duty/context"
+	dutymodels "github.com/flanksource/duty/models"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+func newLocationTestContext(t *testing.T) api.ScrapeContext {
+	t.Helper()
+
+	scraperID := uuid.New()
+	return api.NewScrapeContext(dutycontext.NewContext(context.Background())).WithScrapeConfig(&v1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "config-location-test",
+			Namespace: "default",
+			UID:       k8stypes.UID(scraperID.String()),
+		},
+	})
+}
+
+func TestExtractConfigLocationsUsesCanonicalAliasID(t *testing.T) {
+	ctx := newLocationTestContext(t)
+	existingID := uuid.New()
+	scraperID := ctx.ScrapeConfig().GetPersistedID()
+	ctx.TempCache().Insert(models.ConfigItem{
+		ID:         existingID.String(),
+		ScraperID:  scraperID,
+		Type:       "Kubernetes::Pod",
+		ExternalID: []string{"provider/old-id", "cluster/pod/default/example"},
+	})
+
+	extracted, err := extractConfigsAndChangesFromResults(ctx, []v1.ScrapeResult{{
+		ID:        "provider/new-id",
+		Aliases:   []string{"cluster/pod/default/example"},
+		Type:      "Kubernetes::Pod",
+		Name:      "example",
+		Config:    map[string]any{"metadata": map[string]any{"name": "example"}},
+		Locations: []string{"kubernetes://cluster/default/pod/example"},
+	}})
+	if err != nil {
+		t.Fatalf("extract results: %v", err)
+	}
+
+	if len(extracted.newConfigs) != 0 {
+		t.Fatalf("expected alias match to update the existing config, got %d new configs", len(extracted.newConfigs))
+	}
+	if len(extracted.configsToUpdate) != 1 {
+		t.Fatalf("expected one config update, got %d", len(extracted.configsToUpdate))
+	}
+	if got := extracted.configsToUpdate[0].New.ID; got != existingID.String() {
+		t.Fatalf("config ID = %s, want canonical ID %s", got, existingID)
+	}
+	if len(extracted.locations) != 1 {
+		t.Fatalf("expected one config location, got %d", len(extracted.locations))
+	}
+	if got := extracted.locations[0].ID; got != existingID {
+		t.Fatalf("location config ID = %s, want canonical ID %s", got, existingID)
+	}
+}
+
+var _ = Describe("saving config locations", func() {
+	It("uses the existing config ID resolved through a stable alias", func() {
+		scraperID := uuid.New()
+		existingID := uuid.New()
+		configJSON := `{}`
+		location := "kubernetes://cluster/default/pod/example"
+		scrapeConfig := &v1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{
+			Name:      "config-location-integration-test",
+			Namespace: "default",
+			UID:       k8stypes.UID(scraperID.String()),
+		}}
+
+		Expect(DefaultContext.DB().Create(&dutymodels.ConfigScraper{
+			ID:        scraperID,
+			Name:      "config-location-integration-test",
+			Namespace: "default",
+			Spec:      "{}",
+			Source:    dutymodels.SourceConfigFile,
+		}).Error).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			Expect(DefaultContext.DB().Delete(&dutymodels.ConfigScraper{}, "id = ?", scraperID).Error).ToNot(HaveOccurred())
+		})
+
+		Expect(DefaultContext.DB().Create(&models.ConfigItem{
+			ID:         existingID.String(),
+			ScraperID:  &scraperID,
+			Type:       "Kubernetes::Pod",
+			ExternalID: []string{"provider/old-id", "cluster/pod/default/example"},
+			Config:     &configJSON,
+		}).Error).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			Expect(DefaultContext.DB().Exec("DELETE FROM config_items WHERE id = ?", existingID).Error).ToNot(HaveOccurred())
+		})
+
+		ctx, err := api.NewScrapeContext(DefaultContext).WithScrapeConfig(scrapeConfig).InitTempCache()
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = SaveResults(ctx, []v1.ScrapeResult{{
+			ID:        "provider/new-id",
+			Aliases:   []string{"cluster/pod/default/example"},
+			Type:      "Kubernetes::Pod",
+			Name:      "example",
+			Config:    map[string]any{"metadata": map[string]any{"name": "example"}},
+			Locations: []string{location},
+		}})
+		Expect(err).ToNot(HaveOccurred())
+
+		var saved dutymodels.ConfigLocation
+		Expect(DefaultContext.DB().Where("location = ?", location).First(&saved).Error).ToNot(HaveOccurred())
+		Expect(saved.ID).To(Equal(existingID))
+
+		var configCount int64
+		Expect(DefaultContext.DB().Model(&models.ConfigItem{}).
+			Where("scraper_id = ? AND type = ?", scraperID, "Kubernetes::Pod").
+			Count(&configCount).Error).ToNot(HaveOccurred())
+		Expect(configCount).To(Equal(int64(1)))
+	})
+
+	It("reports the offending ID and location for a foreign key failure", func() {
+		missingID := uuid.New()
+		location := "kubernetes://cluster/default/pod/" + uuid.NewString()
+
+		err := saveConfigLocations(api.NewScrapeContext(DefaultContext), []dutymodels.ConfigLocation{{
+			ID:       missingID,
+			Location: location,
+		}})
+		Expect(err).To(HaveOccurred())
+		Expect(strings.Contains(err.Error(), missingID.String())).To(BeTrue(), err.Error())
+		Expect(strings.Contains(err.Error(), location)).To(BeTrue(), err.Error())
+		Expect(strings.Contains(err.Error(), "offending_rows=")).To(BeTrue(), err.Error())
+	})
+
+	It("can diagnose a foreign key failure without aborting a caller transaction", func() {
+		missingID := uuid.New()
+		location := "kubernetes://cluster/default/pod/" + uuid.NewString()
+		tx := DefaultContext.DB().Begin()
+		Expect(tx.Error).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			_ = tx.Rollback().Error
+		})
+		ctx := api.NewScrapeContext(DefaultContext.WithDB(tx, DefaultContext.Pool()))
+
+		err := saveConfigLocations(ctx, []dutymodels.ConfigLocation{{ID: missingID, Location: location}})
+		Expect(err).To(HaveOccurred())
+		Expect(strings.Contains(err.Error(), missingID.String())).To(BeTrue(), err.Error())
+		Expect(strings.Contains(err.Error(), location)).To(BeTrue(), err.Error())
+		Expect(tx.Exec("SELECT 1").Error).ToNot(HaveOccurred())
+	})
+
+	It("skips repeated locations for an unknown metadata-only config", func() {
+		missingID := "provider/missing-" + uuid.NewString()
+		location := "kubernetes://cluster/default/pod/" + uuid.NewString()
+		ctx := api.NewScrapeContext(DefaultContext).WithScrapeConfig(&v1.ScrapeConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "missing-config-location-integration-test",
+				Namespace: "default",
+				UID:       k8stypes.UID(uuid.NewString()),
+			},
+		})
+
+		summary, err := SaveResults(ctx, []v1.ScrapeResult{
+			{ID: missingID, Type: "Kubernetes::Pod", Locations: []string{location}},
+			{ID: missingID, Type: "Kubernetes::Pod", Locations: []string{location + "-again"}},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(summary.Warnings).To(HaveLen(1))
+		Expect(summary.Warnings[0].Count).To(Equal(2))
+
+		var locationCount int64
+		Expect(DefaultContext.DB().Model(&dutymodels.ConfigLocation{}).
+			Where("location IN ?", []string{location, location + "-again"}).
+			Count(&locationCount).Error).ToNot(HaveOccurred())
+		Expect(locationCount).To(BeZero())
+	})
+})
+
+func TestExtractConfigLocationsSkipsRepeatedUnknownMetadataOnlyConfig(t *testing.T) {
+	ctx := newLocationTestContext(t)
+	results := []v1.ScrapeResult{
+		{
+			ID:        "provider/missing-id",
+			Type:      "Kubernetes::Pod",
+			Locations: []string{"kubernetes://cluster/default/pod/missing"},
+		},
+		{
+			ID:        "provider/missing-id",
+			Type:      "Kubernetes::Pod",
+			Locations: []string{"kubernetes://cluster/default/pod/missing-again"},
+		},
+	}
+
+	extracted, err := extractConfigsAndChangesFromResults(ctx, results)
+	if err != nil {
+		t.Fatalf("extract results: %v", err)
+	}
+
+	if len(extracted.locations) != 0 {
+		t.Fatalf("expected unresolved locations to be skipped, got %d", len(extracted.locations))
+	}
+	if len(extracted.warnings) != len(results) {
+		t.Fatalf("expected %d warnings for skipped locations, got %d", len(results), len(extracted.warnings))
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration and location saving by preventing duplicate locations and preserving transactional consistency when errors occur.
  - Existing configurations are now correctly recognized through external ID aliases, even when generated IDs are present.
  - Unknown metadata-only configurations no longer create invalid locations.
  - Enhanced error reporting identifies missing configuration details and relevant affected records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->