### PR TITLE
fix: use Flanksource ClickHouse image repository

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -10,7 +10,7 @@ A Helm chart for config-db
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for pod scheduling |
 | clickhouse.enabled | bool | `false` | Enable ClickHouse for analytics |
-| clickhouse.image.name | string | `"clickhouse/clickhouse-server"` | ClickHouse image name |
+| clickhouse.image.name | string | `"flanksource/clickhouse-server"` | ClickHouse image name |
 | clickhouse.image.tag | string | `"25.4"` | ClickHouse image tag |
 | clickhouse.properties | object | `{"keep_alive_timeout":"300","mark_cache_size":"67108864","max_concurrent_queries":"10","max_connections":"4","uncompressed_cache_size":"134217728"}` | ClickHouse server properties |
 | clickhouse.resources.limits.cpu | string | `"1"` |  |

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -17,7 +17,7 @@
         "image": {
           "properties": {
             "name": {
-              "default": "clickhouse/clickhouse-server",
+              "default": "flanksource/clickhouse-server",
               "description": "ClickHouse image name",
               "required": [],
               "title": "name"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -269,7 +269,7 @@ clickhouse:
     # required: false
     # @schema
     # -- ClickHouse image name
-    name: clickhouse/clickhouse-server
+    name: flanksource/clickhouse-server
     # @schema
     # required: false
     # @schema


### PR DESCRIPTION
Mission Control supplies `public.ecr.aws` as the global image registry, causing the upstream `clickhouse/clickhouse-server` name to resolve under a nonexistent Public ECR alias.

Use `flanksource/clickhouse-server` as the repository name while continuing to respect `global.imageRegistry`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented default ClickHouse image repository to `flanksource/clickhouse-server`.

* **Configuration**
  * Updated the default deployment image repository to `flanksource/clickhouse-server`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->