### PR TITLE
fix(chart): select ClickHouse image by registry

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -10,7 +10,7 @@ A Helm chart for config-db
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for pod scheduling |
 | clickhouse.enabled | bool | `false` | Enable ClickHouse for analytics |
-| clickhouse.image.name | string | `"flanksource/clickhouse-server"` | ClickHouse image name |
+| clickhouse.image.name | string | `""` | ClickHouse image name. Defaults to the upstream image on Docker Hub and the Flanksource mirror on other registries. |
 | clickhouse.image.tag | string | `"25.4"` | ClickHouse image tag |
 | clickhouse.properties | object | `{"keep_alive_timeout":"300","mark_cache_size":"67108864","max_concurrent_queries":"10","max_connections":"4","uncompressed_cache_size":"134217728"}` | ClickHouse server properties |
 | clickhouse.resources.limits.cpu | string | `"1"` |  |
@@ -92,4 +92,3 @@ A Helm chart for config-db
 | upstream.secretKeyRef.name | string | `"config-db-upstream"` | Name of the secret containing upstream credentials. Must contain: AGENT_NAME, UPSTREAM_USER, UPSTREAM_PASSWORD & UPSTREAM_HOST |
 | volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition. |
 | volumes | list | `[]` | Additional volumes on the output Deployment definition. |
-

--- a/chart/templates/clickhouse.yaml
+++ b/chart/templates/clickhouse.yaml
@@ -97,7 +97,13 @@ spec:
     spec:
       containers:
       - name: clickhouse
-        image: "{{ tpl .Values.global.imageRegistry . }}/{{ tpl .Values.clickhouse.image.name . }}:{{tpl .Values.clickhouse.image.tag . }}"
+        {{- $registry := tpl .Values.global.imageRegistry . }}
+        {{- $defaultImageName := "flanksource/clickhouse-server" }}
+        {{- if eq $registry "docker.io" }}
+          {{- $defaultImageName = "clickhouse/clickhouse-server" }}
+        {{- end }}
+        {{- $imageName := tpl (.Values.clickhouse.image.name | default $defaultImageName) . }}
+        image: "{{ $registry }}/{{ $imageName }}:{{ tpl .Values.clickhouse.image.tag . }}"
         ports:
         - containerPort: 8123
           name: http

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -17,8 +17,8 @@
         "image": {
           "properties": {
             "name": {
-              "default": "flanksource/clickhouse-server",
-              "description": "ClickHouse image name",
+              "default": "",
+              "description": "ClickHouse image name. Defaults to the upstream image on Docker Hub and the Flanksource mirror on other registries.",
               "required": [],
               "title": "name"
             },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -268,8 +268,8 @@ clickhouse:
     # @schema
     # required: false
     # @schema
-    # -- ClickHouse image name
-    name: flanksource/clickhouse-server
+    # -- ClickHouse image name. Defaults to the upstream image on Docker Hub and the Flanksource mirror on other registries.
+    name: ''
     # @schema
     # required: false
     # @schema


### PR DESCRIPTION
The chart always used the Flanksource ClickHouse repository, which does not exist on Docker Hub.

Select the upstream `clickhouse/clickhouse-server` image for `docker.io` while retaining the Flanksource mirror for other registries such as public ECR. Explicit `clickhouse.image.name` overrides remain unchanged.

Update the generated values documentation and schema to describe the registry-dependent default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - ClickHouse deployments now automatically select the appropriate upstream or Flanksource mirror image based on the configured registry.
  - Custom ClickHouse image names can be provided through templated configuration.
  - Image tags remain configurable as before.

- **Documentation**
  - Updated configuration guidance and schema descriptions to explain registry-dependent image selection and the new empty image-name default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->