### PR TITLE
fix: restore semantic deduplication for Kubernetes events

### DIFF
--- a/changes/fingerprint.go
+++ b/changes/fingerprint.go
@@ -82,10 +82,7 @@ func Fingerprint(change *models.ConfigChange) (string, error) {
 		return "", err
 	}
 
-	out := map[string]any{
-		"__change_type":        change.ChangeType,
-		"__external_change_id": lo.FromPtr(change.ExternalChangeID),
-	}
+	out := map[string]any{"__change_type": change.ChangeType}
 	for k, v := range flat {
 		if shouldIgnoreFingerprintPath(k) {
 			continue

--- a/changes/fingerprint_test.go
+++ b/changes/fingerprint_test.go
@@ -56,9 +56,15 @@ var _ = Describe("Change Fingerprints", func() {
 		Expect(fp1).To(Equal(fp2))
 	})
 
-	It("16 character long hex should be ignored", func() {
-		fp1, err1 := changes.Fingerprint(readChange("helm_upgrade_failed.json"))
-		fp2, err2 := changes.Fingerprint(readChange("helm_upgrade_failed_2.json"))
+	It("deduplicates equivalent Kubernetes events with distinct IDs", func() {
+		change1 := readChange("helm_upgrade_failed.json")
+		change2 := readChange("helm_upgrade_failed_2.json")
+		Expect(change1.ExternalChangeID).ToNot(BeNil())
+		Expect(change2.ExternalChangeID).ToNot(BeNil())
+		Expect(*change1.ExternalChangeID).ToNot(Equal(*change2.ExternalChangeID))
+
+		fp1, err1 := changes.Fingerprint(change1)
+		fp2, err2 := changes.Fingerprint(change2)
 		Expect(err1).ToNot(HaveOccurred())
 		Expect(err2).ToNot(HaveOccurred())
 		Expect(fp1).To(Equal(fp2))

--- a/changes/testdata/helm_upgrade_failed.json
+++ b/changes/testdata/helm_upgrade_failed.json
@@ -1,4 +1,6 @@
 {
+  "external_change_id": "852af766-4928-49d5-a2a6-a5668e3715e3",
+  "change_type": "UpgradeFailed",
   "details": {
     "reason": "UpgradeFailed",
     "source": {

--- a/changes/testdata/helm_upgrade_failed_2.json
+++ b/changes/testdata/helm_upgrade_failed_2.json
@@ -1,4 +1,6 @@
 {
+  "external_change_id": "552e28a9-54a4-4ba7-8dc2-a68924cbba60",
+  "change_type": "UpgradeFailed",
   "details": {
     "reason": "UpgradeFailed",
     "source": {


### PR DESCRIPTION
Recurring Kubernetes Events receive new UIDs, but `external_change_id` was included in the normalized change fingerprint. This caused semantically equivalent events to bypass fingerprint deduplication and create separate change rows.

Exclude source event identity from semantic fingerprints while retaining `external_change_id` for exact-event idempotency.

Reverts: https://github.com/flanksource/config-db/pull/1797/changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Equivalent Kubernetes events now produce consistent fingerprints even when their external change IDs differ.
  * Fingerprints continue to distinguish changes based on their type and processed event data.

* **Tests**
  * Updated fingerprint coverage to validate consistency across equivalent events.
  * Expanded Helm upgrade failure test data with event identifiers and change types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->