### PR TITLE
fix: handle invalid cache entries for config location

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -127,6 +127,28 @@ func (t *TempCache) Insert(item models.ConfigItem) {
 	t.notFound.Delete(strings.ToLower(item.ID))
 }
 
+// Delete removes a config and its aliases from the cache. It is used when the
+// database proves that a cached config ID no longer exists.
+func (t *TempCache) Delete(id string) {
+	id = strings.ToLower(id)
+	value, found := t.items.LoadAndDelete(id)
+	t.notFound.Store(id, struct{}{})
+	if !found {
+		return
+	}
+
+	item := value.(models.ConfigItem)
+	scraperID := lo.FromPtr(item.ScraperID).String()
+	if scraperID == uuid.Nil.String() {
+		scraperID = t.GetScraperID()
+	}
+	for _, extID := range item.ExternalID {
+		key := v1.ExternalID{ConfigType: item.Type, ExternalID: extID, ScraperID: scraperID}.Key()
+		// Do not remove an alias that has since been reassigned to another item.
+		t.aliases.CompareAndDelete(key, item.ID)
+	}
+}
+
 type CacheOption string
 
 var IgnoreNotFound CacheOption = "IgnoreNotFound"

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -130,6 +130,30 @@ var _ = Describe("TempCache", func() {
 		Expect(item.ExternalID).To(ContainElement(externalID))
 	})
 
+	It("removes a stale config and its aliases", func() {
+		id := uuid.NewString()
+		externalID := "cluster/pod/default/stale"
+		lookup := v1.ExternalID{
+			ConfigType: "Kubernetes::Pod",
+			ExternalID: externalID,
+		}
+		ctx.TempCache().Insert(models.ConfigItem{
+			ID:         id,
+			Type:       lookup.ConfigType,
+			ExternalID: []string{externalID},
+			ScraperID:  lo.ToPtr(scraperID),
+		})
+
+		ctx.TempCache().Delete(id)
+
+		item, err := ctx.TempCache().Get(ctx, id)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(item).To(BeNil())
+		lookup.ScraperID = ctx.ScraperID()
+		_, aliased := ctx.TempCache().aliases.Load(lookup.Key())
+		Expect(aliased).To(BeFalse())
+	})
+
 	It("returns not found for an uncached config ID without a database", func() {
 		id := uuid.NewString()
 

--- a/db/update.go
+++ b/db/update.go
@@ -568,56 +568,52 @@ func syncCRDChanges(ctx api.ScrapeContext, configs []*models.ConfigItem) error {
 	return nil
 }
 
-const configLocationDiagnosticLimit = 50
+const (
+	configLocationDiagnosticLimit = 50
+	configLocationLookupBatchSize = 1000
+)
 
-func saveConfigLocations(ctx api.ScrapeContext, locations []dutyModels.ConfigLocation) error {
+func saveConfigLocations(ctx api.ScrapeContext, locations []dutyModels.ConfigLocation) ([]dutyModels.ConfigLocation, error) {
 	if len(locations) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	uniqueLocations := lo.Uniq(locations)
-	err := ctx.DB().Transaction(func(tx *gorm.DB) error {
-		return tx.Clauses(clause.OnConflict{Columns: []clause.Column{{Name: "id"}, {Name: "location"}}, DoNothing: true}).
-			CreateInBatches(&uniqueLocations, 200).Error
-	})
-	if err == nil {
-		return nil
-	}
-
-	detailedErr := dutydb.ErrorDetails(err)
-	if !dutydb.IsForeignKeyError(err) {
-		return detailedErr
-	}
-
 	configIDs := lo.Uniq(lo.Map(uniqueLocations, func(location dutyModels.ConfigLocation, _ int) uuid.UUID {
 		return location.ID
 	}))
 	var existingIDs []uuid.UUID
-	if queryErr := ctx.DB().Table("config_items").Where("id IN ?", configIDs).Pluck("id", &existingIDs).Error; queryErr != nil {
-		return fmt.Errorf("%w; failed to diagnose config location foreign key violation: %v", detailedErr, queryErr)
+	for _, batch := range lo.Chunk(configIDs, configLocationLookupBatchSize) {
+		var batchIDs []uuid.UUID
+		if err := ctx.DB().Table("config_items").Where("id IN ?", batch).Pluck("id", &batchIDs).Error; err != nil {
+			return nil, dutydb.ErrorDetails(err)
+		}
+		existingIDs = append(existingIDs, batchIDs...)
 	}
 
 	existing := lo.SliceToMap(existingIDs, func(id uuid.UUID) (uuid.UUID, struct{}) {
 		return id, struct{}{}
 	})
-	missing := lo.Filter(uniqueLocations, func(location dutyModels.ConfigLocation, _ int) bool {
+	valid, missing := lo.FilterReject(uniqueLocations, func(location dutyModels.ConfigLocation, _ int) bool {
 		_, found := existing[location.ID]
-		return !found
+		return found
 	})
-	if len(missing) == 0 {
-		return detailedErr
+
+	if len(valid) == 0 {
+		return missing, nil
 	}
 
-	displayed := missing
-	if len(displayed) > configLocationDiagnosticLimit {
-		displayed = displayed[:configLocationDiagnosticLimit]
-	}
-	rows, marshalErr := json.Marshal(displayed)
-	if marshalErr != nil {
-		return fmt.Errorf("%w; %d config location row(s) reference missing config_items; failed to marshal offending rows: %v", detailedErr, len(missing), marshalErr)
+	// Use a savepoint so an insert error does not abort a transaction supplied
+	// by the caller. Missing config items are filtered above because locations
+	// are derived metadata and must not prevent the configs themselves saving.
+	if err := ctx.DB().Transaction(func(tx *gorm.DB) error {
+		return tx.Clauses(clause.OnConflict{Columns: []clause.Column{{Name: "id"}, {Name: "location"}}, DoNothing: true}).
+			CreateInBatches(&valid, 200).Error
+	}); err != nil {
+		return missing, dutydb.ErrorDetails(err)
 	}
 
-	return fmt.Errorf("%w; %d config location row(s) reference missing config_items; offending_rows=%s; displayed=%d", detailedErr, len(missing), rows, len(displayed))
+	return missing, nil
 }
 
 func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSummary, error) {
@@ -655,8 +651,31 @@ func saveResults(ctx api.ScrapeContext, results []v1.ScrapeResult) (v1.ScrapeSum
 		ctx.TempCache().Insert(*config)
 	}
 
-	if err := saveConfigLocations(ctx, extractResult.locations); err != nil {
+	missingLocations, err := saveConfigLocations(ctx, extractResult.locations)
+	if err != nil {
 		return summary, ctx.Oops().Wrapf(err, "failed to save config locations")
+	}
+	if len(missingLocations) > 0 {
+		for _, id := range lo.Uniq(lo.Map(missingLocations, func(location dutyModels.ConfigLocation, _ int) uuid.UUID {
+			return location.ID
+		})) {
+			ctx.TempCache().Delete(id.String())
+		}
+
+		displayed := missingLocations
+		if len(displayed) > configLocationDiagnosticLimit {
+			displayed = displayed[:configLocationDiagnosticLimit]
+		}
+		summary.AddScrapeWarning(v1.Warning{
+			Error:  "skipping config location because its config item does not exist",
+			Output: displayed,
+			Count:  len(missingLocations),
+		})
+		if rows, marshalErr := json.Marshal(displayed); marshalErr == nil {
+			ctx.Logger.Warnf("skipped %d config location row(s) referencing missing config_items: rows=%s displayed=%d", len(missingLocations), rows, len(displayed))
+		} else {
+			ctx.Logger.Warnf("skipped %d config location row(s) referencing missing config_items", len(missingLocations))
+		}
 	}
 
 	entityResult, synced, err := syncExternalEntities(ctx, extractResult, scraperID)

--- a/db/update_locations_test.go
+++ b/db/update_locations_test.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/flanksource/config-db/api"
@@ -128,21 +127,25 @@ var _ = Describe("saving config locations", func() {
 		Expect(configCount).To(Equal(int64(1)))
 	})
 
-	It("reports the offending ID and location for a foreign key failure", func() {
+	It("skips locations whose config item does not exist", func() {
 		missingID := uuid.New()
 		location := "kubernetes://cluster/default/pod/" + uuid.NewString()
 
-		err := saveConfigLocations(api.NewScrapeContext(DefaultContext), []dutymodels.ConfigLocation{{
+		missing, err := saveConfigLocations(api.NewScrapeContext(DefaultContext), []dutymodels.ConfigLocation{{
 			ID:       missingID,
 			Location: location,
 		}})
-		Expect(err).To(HaveOccurred())
-		Expect(strings.Contains(err.Error(), missingID.String())).To(BeTrue(), err.Error())
-		Expect(strings.Contains(err.Error(), location)).To(BeTrue(), err.Error())
-		Expect(strings.Contains(err.Error(), "offending_rows=")).To(BeTrue(), err.Error())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(missing).To(Equal([]dutymodels.ConfigLocation{{ID: missingID, Location: location}}))
+
+		var locationCount int64
+		Expect(DefaultContext.DB().Model(&dutymodels.ConfigLocation{}).
+			Where("id = ? AND location = ?", missingID, location).
+			Count(&locationCount).Error).ToNot(HaveOccurred())
+		Expect(locationCount).To(BeZero())
 	})
 
-	It("can diagnose a foreign key failure without aborting a caller transaction", func() {
+	It("can skip a missing config location inside a caller transaction", func() {
 		missingID := uuid.New()
 		location := "kubernetes://cluster/default/pod/" + uuid.NewString()
 		tx := DefaultContext.DB().Begin()
@@ -152,11 +155,43 @@ var _ = Describe("saving config locations", func() {
 		})
 		ctx := api.NewScrapeContext(DefaultContext.WithDB(tx, DefaultContext.Pool()))
 
-		err := saveConfigLocations(ctx, []dutymodels.ConfigLocation{{ID: missingID, Location: location}})
-		Expect(err).To(HaveOccurred())
-		Expect(strings.Contains(err.Error(), missingID.String())).To(BeTrue(), err.Error())
-		Expect(strings.Contains(err.Error(), location)).To(BeTrue(), err.Error())
+		missing, err := saveConfigLocations(ctx, []dutymodels.ConfigLocation{{ID: missingID, Location: location}})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(missing).To(HaveLen(1))
 		Expect(tx.Exec("SELECT 1").Error).ToNot(HaveOccurred())
+	})
+
+	It("warns instead of failing when a cached config is missing from the database", func() {
+		missingID := uuid.New()
+		scraperID := uuid.New()
+		location := "kubernetes://cluster/default/pod/" + uuid.NewString()
+		ctx := api.NewScrapeContext(DefaultContext).WithScrapeConfig(&v1.ScrapeConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "stale-cache-config-location-integration-test",
+				Namespace: "default",
+				UID:       k8stypes.UID(scraperID.String()),
+			},
+		})
+		ctx.TempCache().Insert(models.ConfigItem{
+			ID:         missingID.String(),
+			ScraperID:  &scraperID,
+			Type:       "Kubernetes::Pod",
+			ExternalID: []string{missingID.String()},
+		})
+
+		summary, err := SaveResults(ctx, []v1.ScrapeResult{{
+			ID:        missingID.String(),
+			Type:      "Kubernetes::Pod",
+			Locations: []string{location},
+		}})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(summary.Warnings).To(HaveLen(1))
+		Expect(summary.Warnings[0].Error).To(Equal("skipping config location because its config item does not exist"))
+		Expect(summary.Warnings[0].Count).To(Equal(1))
+
+		cached, err := ctx.TempCache().Get(ctx, missingID.String())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cached).To(BeNil())
 	})
 
 	It("skips repeated locations for an unknown metadata-only config", func() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of deleted or missing configuration items during updates.
  * Invalid configuration locations are now skipped without causing update failures.
  * Prevented stale aliases from lingering after a configuration is removed.
  * Added bounded warnings when scrape locations reference unavailable configurations.
  * Preserved transaction safety when filtering invalid locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->