### PR TITLE
fix(external-cost): update on conflict clause on config compact job

### DIFF
--- a/db/external_costs.go
+++ b/db/external_costs.go
@@ -143,9 +143,12 @@ func bucketCosts(costs []v1.ExternalCost, scraperID *uuid.UUID, levels CostLevel
 	// Mirrors the config_costs merge key exactly. Keying on anything the database does not
 	// treat as identity — the external id, for one — splits rows here that the database
 	// then rejects as two inserts onto one conflict key.
+	// config_id is deliberately absent. The fingerprint already carries the resource the
+	// charge is for, so which config item the charge resolved to is an attribution that
+	// moves between scrapes, not part of the charge's identity.
 	type key struct {
-		source, configID, fingerprint string
-		periodStart, periodEnd        time.Time
+		source, fingerprint    string
+		periodStart, periodEnd time.Time
 	}
 	merged := make(map[key]*dutyModels.ConfigCost, len(costs))
 	order := make([]key, 0, len(costs))
@@ -164,7 +167,7 @@ func bucketCosts(costs []v1.ExternalCost, scraperID *uuid.UUID, levels CostLevel
 		if externalID == "" {
 			externalID = v1.NormalizeExternalID(c.ConfigExternalID.ExternalID)
 		}
-		k := key{c.SourceKey, configID, c.Fingerprint(), start, end}
+		k := key{c.SourceKey, c.Fingerprint(), start, end}
 		if existing := merged[k]; existing != nil {
 			existing.BilledCost = existing.BilledCost.Add(*c.BilledCost)
 			existing.EffectiveCost = existing.EffectiveCost.Add(*c.EffectiveCost)
@@ -202,10 +205,7 @@ func bucketCosts(costs []v1.ExternalCost, scraperID *uuid.UUID, levels CostLevel
 		if order[i].source != order[j].source {
 			return order[i].source < order[j].source
 		}
-		if order[i].fingerprint != order[j].fingerprint {
-			return order[i].fingerprint < order[j].fingerprint
-		}
-		return order[i].configID < order[j].configID
+		return order[i].fingerprint < order[j].fingerprint
 	})
 	out := make([]dutyModels.ConfigCost, 0, len(order))
 	for _, k := range order {
@@ -308,8 +308,13 @@ func upsertConfigCosts(ctx api.ScrapeContext, costs []dutyModels.ConfigCost, scr
 
 	// Columns the scrape restates. Both the SET list and the guard below are built from
 	// this, so they cannot drift apart and start rewriting rows nothing changed.
+	//
+	// config_id is restated like any other column: a charge is re-resolved every scrape,
+	// and when the catalog discovers the resource it names the charge moves off the
+	// account root onto that resource. The newest resolution is the best one, and letting
+	// it overwrite is what keeps a retarget from leaving the old booking behind.
 	restated := []string{
-		"external_id", "external_config_type", "external_config_scraper_id",
+		"config_id", "external_id", "external_config_type", "external_config_scraper_id",
 		"external_config_labels", "charge_category", "charge_class", "service_name",
 		"service_category", "sku_id", "region_id", "billing_currency", "pricing_unit",
 		"billed_cost", "effective_cost", "list_cost", "contracted_cost",
@@ -333,7 +338,7 @@ func upsertConfigCosts(ctx api.ScrapeContext, costs []dutyModels.ConfigCost, scr
 	// rewritten, and because updated_at is indexed the rewrite cannot be a HOT update and
 	// touches every index on the table.
 	query := fmt.Sprintf(`INSERT INTO config_costs SELECT * FROM %s
-		ON CONFLICT (source_key, config_id, period_start, period_end, fingerprint)
+		ON CONFLICT (source_key, period_start, period_end, fingerprint)
 		DO UPDATE SET %s
 		WHERE (%s) IS DISTINCT FROM (%s)`,
 		table, strings.Join(assignments, ", "),

--- a/db/external_costs_test.go
+++ b/db/external_costs_test.go
@@ -629,3 +629,61 @@ var _ = Describe("bucketCosts", func() {
 })
 
 func decPtr(d decimal.Decimal) *decimal.Decimal { return &d }
+
+// A charge is re-resolved on every scrape, and the target moves as soon as the catalog
+// discovers the resource the charge names. The charge is still one charge, so the earlier
+// booking must move with it rather than survive alongside the new one.
+var _ = Describe("cost retargeting", func() {
+	var (
+		scraperID uuid.UUID
+		root      uuid.UUID
+		resource  uuid.UUID
+		ctx       api.ScrapeContext
+	)
+
+	BeforeEach(func() {
+		scraperID = uuid.New()
+		Expect(DefaultContext.DB().Exec(`INSERT INTO config_scrapers (id, name, namespace, spec, source) VALUES (?, ?, 'default', '{}', 'ConfigFile')`, scraperID, "cost-retarget-"+scraperID.String()).Error).To(Succeed())
+
+		root, resource = uuid.New(), uuid.New()
+		for _, item := range []struct {
+			id       uuid.UUID
+			itemType string
+		}{{root, "Test::Account"}, {resource, "Test::Instance"}} {
+			Expect(DefaultContext.DB().Exec(`INSERT INTO config_items (id, scraper_id, type, config_class, created_at, updated_at) VALUES (?, ?, ?, ?, now(), now())`,
+				item.id, scraperID, item.itemType, item.itemType).Error).To(Succeed())
+		}
+
+		DeferCleanup(func() {
+			DefaultContext.DB().Exec("DELETE FROM config_costs WHERE scraper_id = ?", scraperID)
+			DefaultContext.DB().Exec("DELETE FROM config_items WHERE id IN ?", []uuid.UUID{root, resource})
+			DefaultContext.DB().Exec("DELETE FROM config_scrapers WHERE id = ?", scraperID)
+		})
+
+		scrapeConfig := v1.ScrapeConfig{ObjectMeta: metav1.ObjectMeta{UID: k8stypes.UID(scraperID.String())}}
+		ctx = api.NewScrapeContext(DefaultContext).WithScrapeConfig(&scrapeConfig)
+	})
+
+	// The same charge, differing only in which config item it resolved to.
+	chargeFor := func(target uuid.UUID) []models.ConfigCost {
+		c := cost("2026-08-03T00:00:00Z", "2026-08-03T01:00:00Z", "5")
+		c.ConfigID = &target
+		c.SourceKey = "retarget-test"
+		return bucketCosts([]v1.ExternalCost{c}, &scraperID, defaultLevels)
+	}
+
+	It("moves the booking to the new target instead of storing it twice", func() {
+		_, err := upsertConfigCosts(ctx, chargeFor(root), &scraperID)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = upsertConfigCosts(ctx, chargeFor(resource), &scraperID)
+		Expect(err).ToNot(HaveOccurred())
+
+		var rows []models.ConfigCost
+		Expect(DefaultContext.DB().Where("scraper_id = ?", scraperID).Find(&rows).Error).To(Succeed())
+
+		Expect(rows).To(HaveLen(1), "the same charge must not be booked against two config items")
+		Expect(rows[0].ConfigID).To(Equal(resource), "the latest resolution wins")
+		Expect(rows[0].EffectiveCost.String()).To(Equal("5"), "retargeting must not change the amount")
+	})
+})

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/flanksource/clicky v1.21.55
 	github.com/flanksource/commons v1.56.0
 	github.com/flanksource/deps v1.0.40
-	github.com/flanksource/duty v1.0.1375
+	github.com/flanksource/duty v1.0.1376
 	github.com/flanksource/gomplate/v3 v3.24.89
 	github.com/flanksource/is-healthy v1.0.90
 	github.com/flanksource/ketall v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -500,8 +500,8 @@ github.com/flanksource/commons v1.56.0 h1:/L1eWb3iLDM3UQEgd6vCTlG9Kbl6ssH6S0YR5f
 github.com/flanksource/commons v1.56.0/go.mod h1:gupTCRqGpgD8dd2ooE7bMDJxkfcVKvkPVuHg3cWkW+Q=
 github.com/flanksource/deps v1.0.40 h1:/GMifSp8vIpwqiupm15vi+FoeuTqsN0vuXEtBkKLU+I=
 github.com/flanksource/deps v1.0.40/go.mod h1:EvS1kCbri1Lj2qWUqS1+K0JxHjelwiXpL+lvDXn8h+U=
-github.com/flanksource/duty v1.0.1375 h1:0ZujWH8nMcqgONr7H10TXDWiRAkMr+zo4ItR/wUFxkM=
-github.com/flanksource/duty v1.0.1375/go.mod h1:mHaxJhcWkHqkIuo7elMQt7arIG/FOzjqmyLnYpmIjTM=
+github.com/flanksource/duty v1.0.1376 h1:ylpldAK3RUQrkJWHGyHGvrDY7OKlaouuESKoZBQgFfM=
+github.com/flanksource/duty v1.0.1376/go.mod h1:mHaxJhcWkHqkIuo7elMQt7arIG/FOzjqmyLnYpmIjTM=
 github.com/flanksource/gomplate/v3 v3.24.89 h1:yDuHmOQU2rf35vMELRgzMJ3q3H4pFdL+9p3HbDfIpyE=
 github.com/flanksource/gomplate/v3 v3.24.89/go.mod h1:tcjpBIaHboWVPUYt973dGLCWgTD1sOHdiFgA/AaPBPQ=
 github.com/flanksource/is-healthy v1.0.90 h1:YV4rmL9y1BOgg0FZsWF7FgMBiHyf1FS3oJG6mB8o4VY=

--- a/jobs/config_costs.go
+++ b/jobs/config_costs.go
@@ -33,9 +33,9 @@ const (
 var configCostJobs = []*job.Job{RefreshConfigCostSummary, CompactConfigCosts, ReconcileConfigCosts}
 
 // RefreshConfigCostSummary keeps the trailing-window totals the `configs` view serves in
-// step with config_cost_compact. The windows are relative to now(), so the summary goes
-// stale on its own even when nothing new is scraped — and cost_1h decays fastest, which is
-// what sets the cadence.
+// step with config_cost_compact. The windows end at the newest charge period present
+// rather than at now(), so the totals move when new spend lands rather than decaying on
+// their own — and the cadence tracks how quickly compaction makes that spend visible.
 var RefreshConfigCostSummary = &job.Job{
 	Name: "RefreshConfigCostSummary", Schedule: "@every 15m", Singleton: true,
 	JobHistory: true, Retention: job.RetentionBalanced,
@@ -172,10 +172,10 @@ func compactCosts(ctx job.JobRuntime, full bool) error {
 // runs — selecting exactly that set means the two can never disagree.
 func pendingBuckets(bucketSeconds int64, window, levelUp time.Duration) string {
 	return fmt.Sprintf(`
-		SELECT DISTINCT config_id, source_key, fingerprint, cost_bucket(period_start, %[1]d) AS bucket
+		SELECT DISTINCT source_key, fingerprint, cost_bucket(period_start, %[1]d) AS bucket
 		FROM config_costs WHERE updated_at >= now() - make_interval(secs => %[2]f)
 		UNION
-		SELECT DISTINCT config_id, source_key, fingerprint, cost_bucket(period_start, %[1]d) AS bucket
+		SELECT DISTINCT source_key, fingerprint, cost_bucket(period_start, %[1]d) AS bucket
 		FROM config_cost_compact
 		WHERE grain = '%[3]s' AND period_end < now() - make_interval(secs => %[4]f)`,
 		bucketSeconds, window.Seconds(), models.ConfigCostLevel1, levelUp.Seconds())
@@ -191,7 +191,12 @@ const compactTargetColumns = `config_id, scraper_id, source_key, external_id, ex
 // Grouping by the full identity tuple means scraper_id and pricing_unit are exact rather
 // than an arbitrary MIN(): both are functionally determined by columns already in the
 // group — scraper_id by source_key, pricing_unit by fingerprint.
-const compactGroupBy = `c.config_id, c.scraper_id, c.source_key, c.external_id, c.external_config_type,
+//
+// config_id is not in the group. It is an attribution that moves when the catalog
+// discovers the resource a charge names, so grouping by it would split one bucket into a
+// row per target the charge has held, and those rows then collide on the merge key. The
+// bucket takes the most recently resolved target instead, matching the ingest rule.
+const compactGroupBy = `c.scraper_id, c.source_key, c.external_id, c.external_config_type,
 		         c.external_config_scraper_id, c.external_config_labels,
 		         c.charge_category, c.charge_class, c.service_name, c.service_category,
 		         c.sku_id, c.region_id, c.billing_currency, c.pricing_unit, c.fingerprint`
@@ -200,8 +205,9 @@ const compactGroupBy = `c.config_id, c.scraper_id, c.source_key, c.external_id, 
 // billing periods for weeks, so a bucket already written here can change afterwards. The
 // conflict clause SETs the recomputed total instead of adding to it; adding would
 // double-count every restatement.
-const compactOnConflict = `ON CONFLICT (source_key, config_id, period_start, period_end, fingerprint)
+const compactOnConflict = `ON CONFLICT (source_key, period_start, period_end, fingerprint)
 		DO UPDATE SET grain            = excluded.grain,
+		              config_id        = excluded.config_id,
 		              external_id      = excluded.external_id,
 		              billed_cost      = excluded.billed_cost,
 		              effective_cost   = excluded.effective_cost,
@@ -214,7 +220,8 @@ const compactOnConflict = `ON CONFLICT (source_key, config_id, period_start, per
 // compactAggregates is the SELECT list shared by both access paths. Callers supply the
 // expressions for period_start and period_end, which is where the two differ.
 func compactAggregates(bucketStart, bucketEnd string) string {
-	return fmt.Sprintf(`c.config_id, c.scraper_id, c.source_key, c.external_id, c.external_config_type,
+	return fmt.Sprintf(`(array_agg(c.config_id ORDER BY c.updated_at DESC))[1],
+			c.scraper_id, c.source_key, c.external_id, c.external_config_type,
 			c.external_config_scraper_id, c.external_config_labels,
 			%s, %s, ?::text,
 			c.charge_category, c.charge_class, c.service_name, c.service_category, c.sku_id, c.region_id,
@@ -238,7 +245,7 @@ func compactIncremental(ctx job.JobRuntime, grain string, width, window, levelUp
 		SELECT %s
 		FROM pending p
 		JOIN config_costs c
-		  ON c.source_key = p.source_key AND c.config_id = p.config_id
+		  ON c.source_key = p.source_key
 		 AND c.fingerprint = p.fingerprint
 		 AND c.period_start >= p.bucket
 		 AND c.period_start <  p.bucket + make_interval(secs => %d)
@@ -312,7 +319,8 @@ func rollToCoarsestLevel(ctx job.JobRuntime, levels db.CostLevels, threshold tim
 			pricing_quantity, pricing_unit, focus, fingerprint
 		)
 		SELECT
-			config_id, scraper_id, source_key, external_id, external_config_type,
+			(array_agg(config_id ORDER BY updated_at DESC))[1],
+			scraper_id, source_key, external_id, external_config_type,
 			external_config_scraper_id, external_config_labels,
 			cost_bucket(period_start, %[1]d), cost_bucket(period_start, %[1]d) + make_interval(secs => %[1]d), ?::text,
 			charge_category, charge_class, service_name, service_category, sku_id, region_id,
@@ -322,12 +330,13 @@ func rollToCoarsestLevel(ctx job.JobRuntime, levels db.CostLevels, threshold tim
 			(array_agg(focus ORDER BY period_start))[1], fingerprint
 		FROM config_cost_compact
 		WHERE grain = ? AND period_end < now() - make_interval(secs => ?)
-		GROUP BY config_id, scraper_id, source_key, external_id, external_config_type,
+		GROUP BY scraper_id, source_key, external_id, external_config_type,
 		         external_config_scraper_id, external_config_labels, 8, 9,
 		         charge_category, charge_class, service_name, service_category, sku_id,
 		         region_id, billing_currency, pricing_unit, fingerprint
-		ON CONFLICT (source_key, config_id, period_start, period_end, fingerprint)
-		DO UPDATE SET billed_cost      = config_cost_compact.billed_cost + excluded.billed_cost,
+		ON CONFLICT (source_key, period_start, period_end, fingerprint)
+		DO UPDATE SET config_id        = excluded.config_id,
+		              billed_cost      = config_cost_compact.billed_cost + excluded.billed_cost,
 		              effective_cost   = config_cost_compact.effective_cost + excluded.effective_cost,
 		              list_cost        = COALESCE(config_cost_compact.list_cost, 0) + COALESCE(excluded.list_cost, 0),
 		              contracted_cost  = COALESCE(config_cost_compact.contracted_cost, 0) + COALESCE(excluded.contracted_cost, 0),

--- a/jobs/config_costs_test.go
+++ b/jobs/config_costs_test.go
@@ -95,6 +95,33 @@ var _ = Describe("config cost compaction", func() {
 		Expect(row.EffectiveCost.String()).To(Equal("6"))
 	})
 
+	It("collapses a bucket whose charge changed target part-way through", func() {
+		// A charge is re-resolved every scrape, so a bucket can span the moment its target
+		// moved off the account root onto the resource the catalog has just discovered.
+		// Grouping by config_id would split that bucket into one row per target, and the
+		// two then collide on the merge key. The bucket takes the newest target instead.
+		root := createConfig("compact-retarget-root")
+		resource := createConfig("compact-retarget-resource")
+		day := time.Now().UTC().Truncate(24*time.Hour).AddDate(0, 0, -5)
+
+		for h := 0; h < 2; h++ {
+			start := day.Add(time.Duration(h) * time.Hour)
+			rawCost(root, "test:retarget", "retarget", "1", start, start.Add(time.Hour), models.ConfigCostLevel1)
+		}
+		for h := 2; h < 4; h++ {
+			start := day.Add(time.Duration(h) * time.Hour)
+			rawCost(resource, "test:retarget", "retarget", "1", start, start.Add(time.Hour), models.ConfigCostLevel1)
+		}
+
+		Expect(CompactConfigCosts.Fn(job.New(DefaultContext))).To(Succeed())
+
+		var rows []models.ConfigCostCompact
+		Expect(DefaultContext.DB().Where("source_key = ?", "test:retarget").Find(&rows).Error).To(Succeed())
+		Expect(rows).To(HaveLen(1), "one charge in one bucket must compact to one row")
+		Expect(rows[0].ConfigID).To(Equal(resource), "the most recently resolved target wins")
+		Expect(rows[0].EffectiveCost.String()).To(Equal("4"), "no spend may be lost or duplicated")
+	})
+
 	It("replaces a restated bucket rather than adding to it", func() {
 		// config_costs keeps its rows, and providers restate open billing periods for
 		// weeks. Re-running compaction on a restated bucket must recompute the total, not


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected external cost attribution when a charge is re-resolved to a different resource.
  * Existing charges now move to their latest resolved target without creating duplicates or changing the recorded amount.
  * Cost compaction now preserves a single consolidated charge when attribution changes within a billing period.
  * Updated cost summaries to end at the newest charge period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->