### PR TITLE
chore(gcp): update cost-resource mapping

### DIFF
--- a/db/external_costs.go
+++ b/db/external_costs.go
@@ -428,6 +428,30 @@ func findConfigMatches(db *gorm.DB, lookup v1.ExternalID, defaultScraperID *uuid
 	return ids, nil
 }
 
+// costLookupCandidates returns lookup identities from most to least precise.
+//
+// GCP's billing export usually supplies the same full resource name Cloud Asset
+// Inventory stores. Some services instead end that name in a numeric provider id while
+// inventory stores the human-readable name and the numeric id as a separate alias. Try
+// the full name first so a short name cannot collide with another type, then retain the
+// numeric-id fallback for those services.
+func costLookupCandidates(lookup v1.ExternalID) []v1.ExternalID {
+	candidates := []v1.ExternalID{lookup}
+	name := strings.TrimSpace(lookup.ExternalID)
+	if !strings.HasPrefix(name, "//") || !strings.Contains(name, ".googleapis.com/") {
+		return candidates
+	}
+	if index := strings.LastIndex(name, "/"); index >= 0 && index < len(name)-1 {
+		basename := name[index+1:]
+		if v1.NormalizeExternalID(basename) != v1.NormalizeExternalID(name) {
+			fallback := lookup
+			fallback.ExternalID = basename
+			candidates = append(candidates, fallback)
+		}
+	}
+	return candidates
+}
+
 // resolveCostTarget picks the config item this cost is attributed to.
 //
 // Precedence: explicit UUID, then structured external identity, then resource id, then the
@@ -464,16 +488,21 @@ func resolveCostTarget(ctx api.ScrapeContext, cost *v1.ExternalCost, scraperID *
 	}
 
 	if lookup.ExternalID != "" {
-		ids, err := findConfigMatches(ctx.DB(), lookup, scraperID, memo)
-		if err != nil {
-			return fmt.Errorf("find config %s: %w", lookup.Pretty().ANSI(), err)
-		}
-		if len(ids) == 1 {
-			cost.ConfigID = &ids[0]
-			return nil
-		}
-		if len(ids) > 1 {
-			ctx.Logger.V(3).Infof("cost reference %s matched %d configs; attributing to the root", lookup.Pretty().ANSI(), len(ids))
+		for _, candidate := range costLookupCandidates(lookup) {
+			ids, err := findConfigMatches(ctx.DB(), candidate, scraperID, memo)
+			if err != nil {
+				return fmt.Errorf("find config %s: %w", candidate.Pretty().ANSI(), err)
+			}
+			if len(ids) == 1 {
+				cost.ConfigID = &ids[0]
+				return nil
+			}
+			if len(ids) > 1 {
+				// A less precise candidate cannot disambiguate an already ambiguous exact
+				// identity, so stop here rather than letting the basename guess.
+				ctx.Logger.V(3).Infof("cost reference %s matched %d configs; attributing to the root", candidate.Pretty().ANSI(), len(ids))
+				return resolveCostRoot(ctx, cost, scraperID, memo)
+			}
 		}
 	}
 

--- a/db/external_costs_test.go
+++ b/db/external_costs_test.go
@@ -215,6 +215,51 @@ var _ = Describe("cost target resolution", func() {
 		Expect(c.ConfigID).To(Equal(&id))
 	})
 
+	It("prefers a full GCP resource name over its colliding basename", func() {
+		projectName := "workload-prod-eu-02"
+		fullName := "//container.googleapis.com/projects/workload-prod-eu-02/locations/europe-west1/clusters/workload-prod-eu-02"
+		clusterID, projectID := uuid.New(), uuid.New()
+
+		Expect(DefaultContext.DB().Exec(`INSERT INTO config_items (id, scraper_id, type, config_class, external_id, tags, created_at, updated_at) VALUES (?, ?, ?, ?, ARRAY[?]::text[], ?, now(), now())`,
+			clusterID, scraperID, v1.GCPGKECluster, "GCP", fullName, `{"project":"workload-prod-eu-02"}`).Error).To(Succeed())
+		Expect(DefaultContext.DB().Exec(`INSERT INTO config_items (id, scraper_id, type, config_class, external_id, tags, created_at, updated_at) VALUES (?, ?, ?, ?, ARRAY[?]::text[], ?, now(), now())`,
+			projectID, scraperID, v1.GCPProject, "GCP", projectName, `{"project":"workload-prod-eu-02"}`).Error).To(Succeed())
+		DeferCleanup(func() {
+			DefaultContext.DB().Exec("DELETE FROM config_items WHERE id IN ?", []uuid.UUID{clusterID, projectID})
+		})
+
+		c := cost("2026-08-03T01:00:00Z", "2026-08-03T02:00:00Z", "1")
+		c.ConfigID = nil
+		c.ResourceID = fullName
+		c.ConfigExternalID = v1.ExternalID{
+			ExternalID: fullName,
+			Labels:     map[string]string{"project": projectName},
+		}
+		c.RootConfigID = v1.ExternalID{ExternalID: projectName, ConfigType: v1.GCPProject}
+
+		Expect(resolveCostTarget(ctx, &c, &scraperID, make(configLookups))).To(Succeed())
+		Expect(c.ConfigID).To(Equal(&clusterID))
+	})
+
+	It("falls back to a GCP resource basename when only its numeric id is aliased", func() {
+		fullName := "//compute.googleapis.com/projects/210987654321/zones/us-central1-a/disks/987654321"
+		resourceID := uuid.New()
+		Expect(DefaultContext.DB().Exec(`INSERT INTO config_items (id, scraper_id, type, config_class, external_id, tags, created_at, updated_at) VALUES (?, ?, 'GCP::Disk', 'GCP', ARRAY['987654321']::text[], ?, now(), now())`,
+			resourceID, scraperID, `{"project":"demo"}`).Error).To(Succeed())
+		DeferCleanup(func() { DefaultContext.DB().Exec("DELETE FROM config_items WHERE id = ?", resourceID) })
+
+		c := cost("2026-08-03T01:00:00Z", "2026-08-03T02:00:00Z", "1")
+		c.ConfigID = nil
+		c.ResourceID = fullName
+		c.ConfigExternalID = v1.ExternalID{
+			ExternalID: fullName,
+			Labels:     map[string]string{"project": "demo"},
+		}
+
+		Expect(resolveCostTarget(ctx, &c, &scraperID, make(configLookups))).To(Succeed())
+		Expect(c.ConfigID).To(Equal(&resourceID))
+	})
+
 	It("falls back to the root when a scoped external id matches multiple configs", func() {
 		typeName := "Test::AmbiguousCost"
 		ids := []uuid.UUID{uuid.New(), uuid.New()}

--- a/scrapers/gcp/cost.go
+++ b/scrapers/gcp/cost.go
@@ -163,20 +163,19 @@ func chargeKind(costType string) (string, string) {
 	}
 }
 
-// resourceLookupID is what the charge is resolved against.
+// resourceLookupID is the most precise identifier the charge can be resolved against.
 //
-// The export writes a resource as //compute.googleapis.com/projects/<number>/zones/<zone>/
-// disk/<numeric id>, while asset inventory writes the same resource by project id, plural
-// kind and name. The one part both agree on is the trailing numeric id, which the asset
-// scrape stores as an alias. Matching on it is safe because the lookup is scoped to the
-// owning project, so a numeric id cannot reach a resource in another one.
+// Cloud Asset Inventory stores the full resource name as an alias, including an
+// additional project-number spelling when billing and inventory disagree on whether a
+// project is named by id or number. Prefer that full name here: using only its final
+// segment can collide with a different resource type in the same project (for example a
+// GKE cluster whose name is also its project id). The resolver retains a basename
+// fallback for services whose billing name ends in a numeric id while inventory names the
+// resource differently and stores that id as a separate alias.
 func (r costRow) resourceLookupID() string {
 	name := r.stableResourceID()
 	if strings.HasPrefix(name, "gcp:unallocated:") {
 		return ""
-	}
-	if index := strings.LastIndex(name, "/"); index >= 0 && index < len(name)-1 {
-		return name[index+1:]
 	}
 	return name
 }

--- a/scrapers/gcp/cost_test.go
+++ b/scrapers/gcp/cost_test.go
@@ -91,6 +91,7 @@ func TestCostRowToExternalCost(t *testing.T) {
 	// The global name is the same full resource name the asset scrape stores as an alias,
 	// which is what lets the charge resolve to the instance.
 	g.Expect(cost.ResourceID).To(gomega.Equal(row.ResourceGlobalName))
+	g.Expect(cost.ConfigExternalID.ExternalID).To(gomega.Equal(row.ResourceGlobalName))
 	g.Expect(cost.BilledCost.String()).To(gomega.Equal("1.5"))
 	g.Expect(cost.EffectiveCost.String()).To(gomega.Equal("1.2"))
 	g.Expect(cost.SubAccountID).To(gomega.Equal("demo"))
@@ -225,26 +226,19 @@ func TestOptionalCostsReachTheExternalCost(t *testing.T) {
 	g.Expect(cost.ContractedCost).To(gomega.BeNil())
 }
 
-// The export and asset inventory spell the same resource differently — project number vs
-// id, singular vs plural kind, numeric id vs name. The trailing segment is the one part
-// they agree on, and it is what the asset scrape stores as an alias.
+// The full global name is the primary lookup identity. The generic cost resolver only
+// falls back to its trailing segment when the exact name is absent from inventory.
 func TestResourceLookupID(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	// A compute disk as the billing export writes it.
-	g.Expect(costRow{
-		ResourceGlobalName: "//compute.googleapis.com/projects/345678901234/zones/europe-west1-c/disk/1342029463145423244",
-	}.resourceLookupID()).To(gomega.Equal("1342029463145423244"))
-
-	// An instance, whose zone is numeric too. Still the trailing segment.
-	g.Expect(costRow{
-		ResourceGlobalName: "//compute.googleapis.com/projects/345678901234/zones/2103/instances/1109397387100823948",
-	}.resourceLookupID()).To(gomega.Equal("1109397387100823948"))
-
-	// Services that name resources rather than numbering them work the same way.
-	g.Expect(costRow{
-		ResourceGlobalName: "//storage.googleapis.com/projects/demo/buckets/my-bucket",
-	}.resourceLookupID()).To(gomega.Equal("my-bucket"))
+	for _, globalName := range []string{
+		"//compute.googleapis.com/projects/345678901234/zones/europe-west1-c/disk/1342029463145423244",
+		"//compute.googleapis.com/projects/345678901234/zones/2103/instances/1109397387100823948",
+		"//storage.googleapis.com/projects/demo/buckets/my-bucket",
+		"//container.googleapis.com/projects/workload-prod-eu-02/locations/europe-west1/clusters/workload-prod-eu-02",
+	} {
+		g.Expect(costRow{ResourceGlobalName: globalName}.resourceLookupID()).To(gomega.Equal(globalName))
+	}
 
 	// Falls back to the service-local name when there is no global name.
 	g.Expect(costRow{ResourceName: "vm-1"}.resourceLookupID()).To(gomega.Equal("vm-1"))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Cloud cost matching by prioritizing full resource names, reducing incorrect matches when resource identifiers share similar final segments.
  * Added a fallback to the final resource-name segment when no exact full-name match is found.
  * Preserved root configuration handling for ambiguous exact matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->