### PR TITLE
fix: cost attribution

### DIFF
--- a/db/external_costs.go
+++ b/db/external_costs.go
@@ -395,7 +395,7 @@ func findConfigMatches(db *gorm.DB, lookup v1.ExternalID, defaultScraperID *uuid
 			return cached, nil
 		}
 	}
-	q := db.Table("config_items").Select("id").Where("deleted_at IS NULL").Where("? = ANY(external_id)", externalID)
+	q := db.Table("config_items").Select("id, deleted_at IS NULL AS live").Where("? = ANY(external_id)", externalID)
 	if lookup.ConfigType != "" {
 		q = q.Where("type = ?", lookup.ConfigType)
 	}
@@ -418,9 +418,27 @@ func findConfigMatches(db *gorm.DB, lookup v1.ExternalID, defaultScraperID *uuid
 		// the resource itself happens to carry.
 		q = q.Where("COALESCE(tags ->> ?, labels ->> ?) = ?", k, k, lookup.Labels[k])
 	}
-	var ids []uuid.UUID
-	if err := q.Order("id ASC").Limit(3).Pluck("id", &ids).Error; err != nil {
+	// Soft-deleted resources are candidates too. Deleting a VM does not un-bill the days it
+	// ran, and the only alternative target is the account root — which reports a resource
+	// the catalog knows perfectly well as one it never discovered.
+	//
+	// Live resources are ordered first so a resource torn down and rebuilt under the same
+	// name resolves to the one that still exists, rather than reading as an ambiguous pair.
+	var matches []struct {
+		ID   uuid.UUID
+		Live bool
+	}
+	if err := q.Order("(deleted_at IS NULL) DESC, id ASC").Limit(3).Scan(&matches).Error; err != nil {
 		return nil, err
+	}
+	// Only the most alive tier decides: a deleted resource never makes a live match
+	// ambiguous, and never disambiguates one either.
+	var ids []uuid.UUID
+	for _, match := range matches {
+		if match.Live != matches[0].Live {
+			break
+		}
+		ids = append(ids, match.ID)
 	}
 	if memo != nil {
 		memo[key] = ids

--- a/db/external_costs_test.go
+++ b/db/external_costs_test.go
@@ -317,6 +317,67 @@ var _ = Describe("cost target resolution", func() {
 		Expect(c.ConfigID).To(Equal(&root))
 	})
 
+	It("attributes a charge to a resource the catalog has soft deleted", func() {
+		// Deleting a VM does not un-bill the days it ran. The resource is still the best
+		// answer to what the charge was for, and the alternative is the account root —
+		// which reports the resource as one the catalog never discovered.
+		typeName := "Test::DeletedCost"
+		id := uuid.New()
+		Expect(DefaultContext.DB().Exec(`INSERT INTO config_items (id, scraper_id, type, config_class, external_id, deleted_at, created_at, updated_at) VALUES (?, ?, ?, ?, ARRAY[?]::text[], now(), now(), now())`,
+			id, scraperID, typeName, typeName, "i-retired").Error).To(Succeed())
+		root := uuid.New()
+		Expect(DefaultContext.DB().Exec(`INSERT INTO config_items (id, scraper_id, type, config_class, external_id, created_at, updated_at) VALUES (?, ?, 'Test::Account', 'Test', ARRAY[?]::text[], now(), now())`, root, scraperID, "deleted-root").Error).To(Succeed())
+		DeferCleanup(func() { DefaultContext.DB().Exec("DELETE FROM config_items WHERE id IN ?", []uuid.UUID{id, root}) })
+
+		c := cost("2026-08-03T01:00:00Z", "2026-08-03T02:00:00Z", "1")
+		c.ConfigID = nil
+		c.ResourceID = "i-retired"
+		c.ConfigExternalID = v1.ExternalID{ConfigType: typeName}
+		c.RootConfigID = v1.ExternalID{ExternalID: "deleted-root", ConfigType: "Test::Account"}
+		Expect(resolveCostTarget(ctx, &c, &scraperID, make(configLookups))).To(Succeed())
+		Expect(c.ConfigID).To(Equal(&id))
+	})
+
+	It("prefers a live resource over a soft-deleted one sharing its external id", func() {
+		// A resource torn down and rebuilt under the same name leaves both rows behind.
+		// Counting them as an ambiguous pair would send the charge to the root; the live
+		// one is what the charge is for.
+		typeName := "Test::RecreatedCost"
+		deleted, live := uuid.New(), uuid.New()
+		Expect(DefaultContext.DB().Exec(`INSERT INTO config_items (id, scraper_id, type, config_class, external_id, deleted_at, created_at, updated_at) VALUES (?, ?, ?, ?, ARRAY[?]::text[], now(), now(), now())`,
+			deleted, scraperID, typeName, typeName, "i-recreated").Error).To(Succeed())
+		Expect(DefaultContext.DB().Exec(`INSERT INTO config_items (id, scraper_id, type, config_class, external_id, created_at, updated_at) VALUES (?, ?, ?, ?, ARRAY[?]::text[], now(), now())`,
+			live, scraperID, typeName, typeName, "i-recreated").Error).To(Succeed())
+		DeferCleanup(func() { DefaultContext.DB().Exec("DELETE FROM config_items WHERE id IN ?", []uuid.UUID{deleted, live}) })
+
+		c := cost("2026-08-03T01:00:00Z", "2026-08-03T02:00:00Z", "1")
+		c.ConfigID = nil
+		c.ResourceID = "i-recreated"
+		c.ConfigExternalID = v1.ExternalID{ConfigType: typeName}
+		Expect(resolveCostTarget(ctx, &c, &scraperID, make(configLookups))).To(Succeed())
+		Expect(c.ConfigID).To(Equal(&live))
+	})
+
+	It("falls back to the root when only soft-deleted resources match ambiguously", func() {
+		typeName := "Test::AmbiguousDeletedCost"
+		ids := []uuid.UUID{uuid.New(), uuid.New()}
+		for _, id := range ids {
+			Expect(DefaultContext.DB().Exec(`INSERT INTO config_items (id, scraper_id, type, config_class, external_id, deleted_at, created_at, updated_at) VALUES (?, ?, ?, ?, ARRAY[?]::text[], now(), now(), now())`,
+				id, scraperID, typeName, typeName, "i-ambiguous-deleted").Error).To(Succeed())
+		}
+		root := uuid.New()
+		Expect(DefaultContext.DB().Exec(`INSERT INTO config_items (id, scraper_id, type, config_class, external_id, created_at, updated_at) VALUES (?, ?, 'Test::Account', 'Test', ARRAY[?]::text[], now(), now())`, root, scraperID, "ambiguous-deleted-root").Error).To(Succeed())
+		DeferCleanup(func() { DefaultContext.DB().Exec("DELETE FROM config_items WHERE id IN ?", append(ids, root)) })
+
+		c := cost("2026-08-03T01:00:00Z", "2026-08-03T02:00:00Z", "1")
+		c.ConfigID = nil
+		c.ResourceID = "i-ambiguous-deleted"
+		c.ConfigExternalID = v1.ExternalID{ConfigType: typeName}
+		c.RootConfigID = v1.ExternalID{ExternalID: "ambiguous-deleted-root", ConfigType: "Test::Account"}
+		Expect(resolveCostTarget(ctx, &c, &scraperID, make(configLookups))).To(Succeed())
+		Expect(c.ConfigID).To(Equal(&root))
+	})
+
 	It("errors when nothing resolves and the scraper supplied no root", func() {
 		c := cost("2026-08-03T01:00:00Z", "2026-08-03T02:00:00Z", "1")
 		c.ConfigID = nil

--- a/jobs/config_cost_attribution.go
+++ b/jobs/config_cost_attribution.go
@@ -1,0 +1,102 @@
+// Moves a charge onto the resource it names once the catalog has discovered that
+// resource, for the charge periods no provider will restate again.
+package jobs
+
+import (
+	"fmt"
+
+	"github.com/flanksource/duty/job"
+)
+
+// The cost tables carry the same attribution and are re-pointed by the same rule.
+// config_costs is the source of truth and is corrected first; config_cost_compact is
+// corrected directly rather than left to compaction, because it outlives the raw rows it
+// was built from and the oldest part of the series has no raw source left to rebuild from.
+var costAttributionTables = []string{"config_costs", "config_cost_compact"}
+
+// ReattributeConfigCosts re-points charges whose resource the catalog discovered late.
+//
+// Runs an hour ahead of ReconcileConfigCosts so the nightly rebuild carries the corrected
+// attribution from raw into the compacted series in the same night.
+var ReattributeConfigCosts = &job.Job{
+	Name: "ReattributeConfigCosts", Schedule: "0 2 * * *", Singleton: true,
+	JobHistory: true, Retention: job.RetentionBalanced,
+	Fn: func(ctx job.JobRuntime) error {
+		ctx.History.ResourceType = JobResourceType
+		for _, table := range costAttributionTables {
+			moved, err := reattributeCosts(ctx, table)
+			if err != nil {
+				return err
+			}
+			ctx.History.SuccessCount += moved
+		}
+		return nil
+	},
+}
+
+// reattributeCosts asks again, for every charge in one cost table, which config item its
+// external id names — and books the charge there.
+//
+// A charge is resolved once, at scrape time, and providers stop restating a billing period
+// within weeks of closing it. Whatever attribution a row held when its period went quiet is
+// therefore frozen. A resource discovered after its first charges landed keeps those early
+// charges booked against the account root for as long as they are retained: the resource
+// reports less spend than it incurred, and the same spend is listed as an undiscovered
+// resource the catalog is missing.
+//
+// The lookup mirrors resolveCostTarget. external_config_type, external_config_scraper_id
+// and external_config_labels are the scope the charge was originally resolved under, kept
+// on the row as provenance, so asking here asks exactly what ingest asked. A resource id
+// matching more than one config item is left where it is — never guess a resource.
+//
+// One case differs from ingest: a feed that supplies both an explicit config_id and a
+// resource_id naming a different resource has the resource_id honoured here, where ingest
+// honours the explicit id. The scrapers never emit both, and FOCUS defines ResourceId as
+// the resource the charge is for.
+func reattributeCosts(ctx job.JobRuntime, table string) (int, error) {
+	// The distinct identities number in the resources, the rows in the charge periods —
+	// several orders of magnitude apart. Materialising the identities is what turns a
+	// catalog probe per row into one per resource; inlined, the planner runs the lateral
+	// once for every row in the table.
+	query := fmt.Sprintf(`
+		WITH targets AS MATERIALIZED (
+			SELECT DISTINCT external_id, external_config_type, external_config_scraper_id,
+			       external_config_labels
+			FROM %[1]s
+			WHERE external_id IS NOT NULL
+		), resolved AS MATERIALIZED (
+			SELECT t.external_id, t.external_config_type, t.external_config_scraper_id,
+			       t.external_config_labels, m.id AS target
+			FROM targets t
+			JOIN LATERAL (
+				SELECT (array_agg(ci.id ORDER BY ci.id))[1] AS id, count(*) AS matches
+				FROM config_items ci
+				WHERE ci.external_id @> ARRAY[t.external_id]
+				  AND (t.external_config_type IS NULL OR ci.type = t.external_config_type)
+				  AND (t.external_config_scraper_id IS NULL
+				       OR t.external_config_scraper_id = 'all'
+				       OR ci.scraper_id::text = t.external_config_scraper_id)
+				  AND NOT EXISTS (
+					SELECT 1
+					FROM jsonb_each_text(COALESCE(t.external_config_labels, '{}'::jsonb)) AS scope(key, value)
+					WHERE COALESCE(ci.tags ->> scope.key, ci.labels ->> scope.key) IS DISTINCT FROM scope.value)
+				  AND (ci.deleted_at IS NULL OR NOT EXISTS (
+					SELECT 1 FROM config_items live
+					WHERE live.external_id @> ARRAY[t.external_id] AND live.deleted_at IS NULL))
+			) m ON m.matches = 1
+		)
+		UPDATE %[1]s c
+		SET config_id = r.target, updated_at = now()
+		FROM resolved r
+		WHERE r.external_id = c.external_id
+		  AND r.external_config_type IS NOT DISTINCT FROM c.external_config_type
+		  AND r.external_config_scraper_id IS NOT DISTINCT FROM c.external_config_scraper_id
+		  AND r.external_config_labels IS NOT DISTINCT FROM c.external_config_labels
+		  AND c.config_id <> r.target`, table)
+
+	result := ctx.DB().Exec(query)
+	if result.Error != nil {
+		return 0, fmt.Errorf("failed to reattribute %s: %w", table, result.Error)
+	}
+	return int(result.RowsAffected), nil
+}

--- a/jobs/config_cost_attribution_test.go
+++ b/jobs/config_cost_attribution_test.go
@@ -1,0 +1,127 @@
+// Covers the re-attribution pass: a charge frozen against the account root moves onto its
+// resource once the catalog has it, and an ambiguous or absent resource is left alone.
+package jobs
+
+import (
+	"time"
+
+	"github.com/flanksource/duty/job"
+	"github.com/flanksource/duty/models"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/shopspring/decimal"
+)
+
+var _ = Describe("config cost reattribution", func() {
+	var configIDs []uuid.UUID
+
+	// createConfig writes a catalog entry carrying externalID as an alias. A nil
+	// deletedAt leaves it live.
+	createConfig := func(configType, externalID string, deleted bool) uuid.UUID {
+		id := uuid.New()
+		configIDs = append(configIDs, id)
+		deletedAt := "NULL"
+		if deleted {
+			deletedAt = "now()"
+		}
+		Expect(DefaultContext.DB().Exec(`
+			INSERT INTO config_items (id, type, config_class, external_id, deleted_at, created_at, updated_at)
+			VALUES (?, ?, 'Test', ARRAY[?]::text[], `+deletedAt+`, now(), now())`,
+			id, configType, externalID).Error).To(Succeed())
+		return id
+	}
+
+	// bookedCost writes one charge into both cost tables, attributed to configID and
+	// naming externalID as the resource it was for.
+	bookedCost := func(configID uuid.UUID, externalID, fingerprint string) {
+		start := time.Now().UTC().Truncate(time.Hour).Add(-3 * time.Hour)
+		amount := decimal.RequireFromString("4.5")
+		raw := models.ConfigCost{
+			ID: uuid.New(), ConfigID: configID, SourceKey: "test:reattribute",
+			ExternalID:              &externalID,
+			ExternalConfigScraperID: ptr("all"),
+			PeriodStart:             start, PeriodEnd: start.Add(time.Hour),
+			Grain: models.ConfigCostLevel1, ChargeCategory: "Usage", BillingCurrency: "USD",
+			BilledCost: amount, EffectiveCost: amount, Fingerprint: fingerprint,
+		}
+		Expect(DefaultContext.DB().Create(&raw).Error).To(Succeed())
+		compact := models.ConfigCostCompact{ConfigCost: raw}
+		compact.ID = uuid.New()
+		Expect(DefaultContext.DB().Create(&compact).Error).To(Succeed())
+	}
+
+	targetsOf := func(fingerprint string) []uuid.UUID {
+		GinkgoHelper()
+		var targets []uuid.UUID
+		for _, table := range costAttributionTables {
+			var booked []uuid.UUID
+			Expect(DefaultContext.DB().Table(table).Where("fingerprint = ?", fingerprint).
+				Pluck("config_id", &booked).Error).To(Succeed())
+			Expect(booked).To(HaveLen(1), "one charge per table in %s", table)
+			targets = append(targets, booked[0])
+		}
+		return targets
+	}
+
+	AfterEach(func() {
+		if len(configIDs) > 0 {
+			// Both cost tables cascade from config_items.
+			Expect(DefaultContext.DB().Exec("DELETE FROM config_items WHERE id IN ?", configIDs).Error).To(Succeed())
+		}
+		configIDs = nil
+	})
+
+	It("moves a root-booked charge onto the resource the catalog now has", func() {
+		root := createConfig("Test::Account", "reattribute-root", false)
+		resource := createConfig("Test::Resource", "i-late-discovery", false)
+		bookedCost(root, "i-late-discovery", "reattribute-late")
+
+		Expect(ReattributeConfigCosts.Fn(job.New(DefaultContext))).To(Succeed())
+
+		Expect(targetsOf("reattribute-late")).To(Equal([]uuid.UUID{resource, resource}))
+	})
+
+	It("moves a charge onto a resource the catalog has soft deleted", func() {
+		root := createConfig("Test::Account", "reattribute-deleted-root", false)
+		resource := createConfig("Test::Resource", "i-retired-late", true)
+		bookedCost(root, "i-retired-late", "reattribute-retired")
+
+		Expect(ReattributeConfigCosts.Fn(job.New(DefaultContext))).To(Succeed())
+
+		Expect(targetsOf("reattribute-retired")).To(Equal([]uuid.UUID{resource, resource}))
+	})
+
+	It("leaves a charge naming a resource the catalog does not have", func() {
+		root := createConfig("Test::Account", "reattribute-absent-root", false)
+		bookedCost(root, "i-never-scraped", "reattribute-absent")
+
+		Expect(ReattributeConfigCosts.Fn(job.New(DefaultContext))).To(Succeed())
+
+		Expect(targetsOf("reattribute-absent")).To(Equal([]uuid.UUID{root, root}))
+	})
+
+	It("leaves a charge whose resource id matches more than one config item", func() {
+		root := createConfig("Test::Account", "reattribute-ambiguous-root", false)
+		createConfig("Test::Resource", "i-ambiguous-late", false)
+		createConfig("Test::OtherResource", "i-ambiguous-late", false)
+		bookedCost(root, "i-ambiguous-late", "reattribute-ambiguous")
+
+		Expect(ReattributeConfigCosts.Fn(job.New(DefaultContext))).To(Succeed())
+
+		Expect(targetsOf("reattribute-ambiguous")).To(Equal([]uuid.UUID{root, root}))
+	})
+
+	It("is idempotent", func() {
+		root := createConfig("Test::Account", "reattribute-idempotent-root", false)
+		resource := createConfig("Test::Resource", "i-idempotent", false)
+		bookedCost(root, "i-idempotent", "reattribute-idempotent")
+
+		Expect(ReattributeConfigCosts.Fn(job.New(DefaultContext))).To(Succeed())
+		Expect(ReattributeConfigCosts.Fn(job.New(DefaultContext))).To(Succeed())
+
+		Expect(targetsOf("reattribute-idempotent")).To(Equal([]uuid.UUID{resource, resource}))
+	})
+})
+
+func ptr(s string) *string { return &s }

--- a/jobs/config_costs.go
+++ b/jobs/config_costs.go
@@ -30,7 +30,7 @@ const (
 	defaultCompactRetention = "365d"
 )
 
-var configCostJobs = []*job.Job{RefreshConfigCostSummary, CompactConfigCosts, ReconcileConfigCosts}
+var configCostJobs = []*job.Job{RefreshConfigCostSummary, CompactConfigCosts, ReconcileConfigCosts, ReattributeConfigCosts}
 
 // RefreshConfigCostSummary keeps the trailing-window totals the `configs` view serves in
 // step with config_cost_compact. The windows end at the newest charge period present


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic correction of cost attribution when cataloged resources are discovered after charges are recorded.
  - Charges can now remain associated with the correct resource after it has been removed or soft-deleted.
  - Scheduled reconciliation updates applicable historical and summarized cost data.

- **Bug Fixes**
  - Prevented valid live resources from being overridden by deleted or ambiguous matches.
  - Charges remain at the account level when a unique resource match cannot be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->