### PR TITLE
fix(external-cost): align cost re-attribution with ingest resolution

### DIFF
--- a/jobs/config_cost_attribution.go
+++ b/jobs/config_cost_attribution.go
@@ -4,8 +4,11 @@ package jobs
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/flanksource/duty/job"
+
+	v1 "github.com/flanksource/config-db/api/v1"
 )
 
 // The cost tables carry the same attribution and are re-pointed by the same rule.
@@ -34,6 +37,16 @@ var ReattributeConfigCosts = &job.Job{
 	},
 }
 
+// scraperLessTypes renders the config types findConfigMatches never scopes by scraper, as
+// a SQL array. Read from the resolver's own list so the two cannot drift apart.
+func scraperLessTypes() string {
+	quoted := make([]string, 0, len(v1.ScraperLessTypes))
+	for _, configType := range v1.ScraperLessTypes {
+		quoted = append(quoted, "'"+strings.ReplaceAll(configType, "'", "''")+"'")
+	}
+	return "ARRAY[" + strings.Join(quoted, ", ") + "]::text[]"
+}
+
 // reattributeCosts asks again, for every charge in one cost table, which config item its
 // external id names — and books the charge there.
 //
@@ -46,8 +59,18 @@ var ReattributeConfigCosts = &job.Job{
 //
 // The lookup mirrors resolveCostTarget. external_config_type, external_config_scraper_id
 // and external_config_labels are the scope the charge was originally resolved under, kept
-// on the row as provenance, so asking here asks exactly what ingest asked. A resource id
-// matching more than one config item is left where it is — never guess a resource.
+// on the row as provenance, so asking here asks exactly what ingest asked; a charge naming
+// no scraper is scoped to the one that emitted it, as findConfigMatches scopes it to the
+// scraper doing the scrape. A resource id matching more than one config item is left where
+// it is — never guess a resource.
+//
+// Candidates are ranked the way resolveCostTarget ranks them: a GCP resource name that
+// matches nothing falls back to its last segment, which is how the services that bill
+// under a numeric provider id reach the resource inventory stores under its name. The full
+// name always wins, so a short name cannot pull a charge onto another type. Within the
+// candidates of one precision, a live config item wins over a soft-deleted one — and both
+// tiers are drawn from the same scoped set, so an item the scope excludes neither claims a
+// charge nor blocks one.
 //
 // One case differs from ingest: a feed that supplies both an explicit config_id and a
 // resource_id naming a different resource has the resource_id honoured here, where ingest
@@ -61,28 +84,48 @@ func reattributeCosts(ctx job.JobRuntime, table string) (int, error) {
 	query := fmt.Sprintf(`
 		WITH targets AS MATERIALIZED (
 			SELECT DISTINCT external_id, external_config_type, external_config_scraper_id,
-			       external_config_labels
+			       external_config_labels, scraper_id
 			FROM %[1]s
 			WHERE external_id IS NOT NULL
+		), scoped AS MATERIALIZED (
+			SELECT t.*,
+			       CASE WHEN t.external_id LIKE '//%%'
+			             AND t.external_id LIKE '%%.googleapis.com/%%'
+			             AND regexp_replace(t.external_id, '^.*/', '') NOT IN ('', t.external_id)
+			            THEN regexp_replace(t.external_id, '^.*/', '')
+			       END AS basename,
+			       CASE WHEN COALESCE(t.external_config_scraper_id, t.scraper_id::text) = 'all'
+			             OR t.external_config_type = ANY (%[2]s)
+			            THEN NULL
+			            ELSE COALESCE(t.external_config_scraper_id, t.scraper_id::text)
+			       END AS scraper_scope
+			FROM targets t
 		), resolved AS MATERIALIZED (
 			SELECT t.external_id, t.external_config_type, t.external_config_scraper_id,
-			       t.external_config_labels, m.id AS target
-			FROM targets t
+			       t.external_config_labels, t.scraper_id, m.id AS target
+			FROM scoped t
 			JOIN LATERAL (
-				SELECT (array_agg(ci.id ORDER BY ci.id))[1] AS id, count(*) AS matches
-				FROM config_items ci
-				WHERE ci.external_id @> ARRAY[t.external_id]
-				  AND (t.external_config_type IS NULL OR ci.type = t.external_config_type)
-				  AND (t.external_config_scraper_id IS NULL
-				       OR t.external_config_scraper_id = 'all'
-				       OR ci.scraper_id::text = t.external_config_scraper_id)
-				  AND NOT EXISTS (
-					SELECT 1
-					FROM jsonb_each_text(COALESCE(t.external_config_labels, '{}'::jsonb)) AS scope(key, value)
-					WHERE COALESCE(ci.tags ->> scope.key, ci.labels ->> scope.key) IS DISTINCT FROM scope.value)
-				  AND (ci.deleted_at IS NULL OR NOT EXISTS (
-					SELECT 1 FROM config_items live
-					WHERE live.external_id @> ARRAY[t.external_id] AND live.deleted_at IS NULL))
+				SELECT (array_agg(c.id ORDER BY c.id))[1] AS id, count(*) AS matches
+				FROM (
+					SELECT r.id, r.live, r.specificity,
+					       min(r.specificity) OVER ()                         AS best,
+					       bool_or(r.live) OVER (PARTITION BY r.specificity)  AS any_live
+					FROM (
+						SELECT ci.id,
+						       (ci.deleted_at IS NULL) AS live,
+						       CASE WHEN ci.external_id @> ARRAY[t.external_id] THEN 0 ELSE 1 END AS specificity
+						FROM config_items ci
+						WHERE (ci.external_id @> ARRAY[t.external_id]
+						       OR (t.basename IS NOT NULL AND ci.external_id @> ARRAY[t.basename]))
+						  AND (t.external_config_type IS NULL OR ci.type = t.external_config_type)
+						  AND (t.scraper_scope IS NULL OR ci.scraper_id::text = t.scraper_scope)
+						  AND NOT EXISTS (
+							SELECT 1
+							FROM jsonb_each_text(COALESCE(t.external_config_labels, '{}'::jsonb)) AS scope(key, value)
+							WHERE COALESCE(ci.tags ->> scope.key, ci.labels ->> scope.key) IS DISTINCT FROM scope.value)
+					) r
+				) c
+				WHERE c.specificity = c.best AND c.live = c.any_live
 			) m ON m.matches = 1
 		)
 		UPDATE %[1]s c
@@ -92,7 +135,8 @@ func reattributeCosts(ctx job.JobRuntime, table string) (int, error) {
 		  AND r.external_config_type IS NOT DISTINCT FROM c.external_config_type
 		  AND r.external_config_scraper_id IS NOT DISTINCT FROM c.external_config_scraper_id
 		  AND r.external_config_labels IS NOT DISTINCT FROM c.external_config_labels
-		  AND c.config_id <> r.target`, table)
+		  AND r.scraper_id IS NOT DISTINCT FROM c.scraper_id
+		  AND c.config_id <> r.target`, table, scraperLessTypes())
 
 	result := ctx.DB().Exec(query)
 	if result.Error != nil {

--- a/jobs/config_cost_attribution_test.go
+++ b/jobs/config_cost_attribution_test.go
@@ -51,6 +51,44 @@ var _ = Describe("config cost reattribution", func() {
 		Expect(DefaultContext.DB().Create(&compact).Error).To(Succeed())
 	}
 
+	// createScraper registers a scraper the catalog entries and charges can belong to.
+	createScraper := func() uuid.UUID {
+		id := uuid.New()
+		Expect(DefaultContext.DB().Exec(`
+			INSERT INTO config_scrapers (id, name, namespace, spec, source)
+			VALUES (?, ?, 'default', '{}', 'ConfigFile')`, id, "reattribute-"+id.String()).Error).To(Succeed())
+		DeferCleanup(func() { DefaultContext.DB().Exec("DELETE FROM config_scrapers WHERE id = ?", id) })
+		return id
+	}
+
+	// createScrapedConfig is createConfig for an entry a particular scraper owns.
+	createScrapedConfig := func(scraperID uuid.UUID, configType, externalID string) uuid.UUID {
+		id := uuid.New()
+		configIDs = append(configIDs, id)
+		Expect(DefaultContext.DB().Exec(`
+			INSERT INTO config_items (id, scraper_id, type, config_class, external_id, created_at, updated_at)
+			VALUES (?, ?, ?, 'Test', ARRAY[?]::text[], now(), now())`,
+			id, scraperID, configType, externalID).Error).To(Succeed())
+		return id
+	}
+
+	// scopedCost writes one charge carrying the lookup scope it was originally resolved
+	// under, which is what the re-attribution pass has to reproduce.
+	scopedCost := func(configID uuid.UUID, externalID, fingerprint string, scope models.ConfigCost) {
+		start := time.Now().UTC().Truncate(time.Hour).Add(-3 * time.Hour)
+		amount := decimal.RequireFromString("4.5")
+		raw := scope
+		raw.ID, raw.ConfigID, raw.SourceKey = uuid.New(), configID, "test:reattribute"
+		raw.ExternalID = &externalID
+		raw.PeriodStart, raw.PeriodEnd = start, start.Add(time.Hour)
+		raw.Grain, raw.ChargeCategory, raw.BillingCurrency = models.ConfigCostLevel1, "Usage", "USD"
+		raw.BilledCost, raw.EffectiveCost, raw.Fingerprint = amount, amount, fingerprint
+		Expect(DefaultContext.DB().Create(&raw).Error).To(Succeed())
+		compact := models.ConfigCostCompact{ConfigCost: raw}
+		compact.ID = uuid.New()
+		Expect(DefaultContext.DB().Create(&compact).Error).To(Succeed())
+	}
+
 	targetsOf := func(fingerprint string) []uuid.UUID {
 		GinkgoHelper()
 		var targets []uuid.UUID
@@ -110,6 +148,77 @@ var _ = Describe("config cost reattribution", func() {
 		Expect(ReattributeConfigCosts.Fn(job.New(DefaultContext))).To(Succeed())
 
 		Expect(targetsOf("reattribute-ambiguous")).To(Equal([]uuid.UUID{root, root}))
+	})
+
+	It("attributes to a soft-deleted resource in scope over a live one outside it", func() {
+		// The live/deleted preference only ranks candidates that already passed the scope.
+		// A live item the scope excludes is not a candidate at all, so it cannot suppress
+		// the deleted one that does match — which is how findConfigMatches reads it.
+		root := createConfig("Test::Account", "scoped-deleted-root", false)
+		createConfig("Test::OtherType", "i-scope-split", false)
+		wanted := createConfig("Test::Resource", "i-scope-split", true)
+		scopedCost(root, "i-scope-split", "reattribute-scope-split", models.ConfigCost{
+			ExternalConfigType:      ptr("Test::Resource"),
+			ExternalConfigScraperID: ptr("all"),
+		})
+
+		Expect(ReattributeConfigCosts.Fn(job.New(DefaultContext))).To(Succeed())
+
+		Expect(targetsOf("reattribute-scope-split")).To(Equal([]uuid.UUID{wanted, wanted}))
+	})
+
+	It("falls back to a GCP resource basename when only its numeric id is aliased", func() {
+		// GCP bills some resources under a name whose last segment is a numeric provider
+		// id, while inventory stores that id as a standalone alias. resolveCostTarget
+		// tries the basename when the full name matches nothing.
+		root := createConfig("Test::Account", "basename-root", false)
+		resource := createConfig("Test::Resource", "987654321", false)
+		scopedCost(root, "//compute.googleapis.com/projects/210987654321/zones/us-central1-a/disks/987654321",
+			"reattribute-basename", models.ConfigCost{ExternalConfigScraperID: ptr("all")})
+
+		Expect(ReattributeConfigCosts.Fn(job.New(DefaultContext))).To(Succeed())
+
+		Expect(targetsOf("reattribute-basename")).To(Equal([]uuid.UUID{resource, resource}))
+	})
+
+	It("prefers the full resource name over a basename that matches something else", func() {
+		root := createConfig("Test::Account", "basename-collision-root", false)
+		full := "//container.googleapis.com/projects/demo/locations/europe-west1/clusters/prod"
+		wanted := createConfig("Test::Resource", full, false)
+		createConfig("Test::OtherResource", "prod", false)
+		scopedCost(root, full, "reattribute-basename-collision",
+			models.ConfigCost{ExternalConfigScraperID: ptr("all")})
+
+		Expect(ReattributeConfigCosts.Fn(job.New(DefaultContext))).To(Succeed())
+
+		Expect(targetsOf("reattribute-basename-collision")).To(Equal([]uuid.UUID{wanted, wanted}))
+	})
+
+	It("scopes to the emitting scraper when the charge names none", func() {
+		// With no scope on the charge, resolveCostTarget falls back to the scraper doing
+		// the scrape. Ignoring that here would attribute a charge to another scraper's
+		// resource that happens to share an id.
+		mine, theirs := createScraper(), createScraper()
+		root := createConfig("Test::Account", "scraper-scope-root", false)
+		scopedCost(root, "i-shared-across-scrapers", "reattribute-foreign-scraper",
+			models.ConfigCost{ScraperID: &mine})
+		createScrapedConfig(theirs, "Test::Resource", "i-shared-across-scrapers")
+
+		Expect(ReattributeConfigCosts.Fn(job.New(DefaultContext))).To(Succeed())
+
+		Expect(targetsOf("reattribute-foreign-scraper")).To(Equal([]uuid.UUID{root, root}))
+	})
+
+	It("attributes to a resource belonging to the emitting scraper", func() {
+		mine := createScraper()
+		root := createConfig("Test::Account", "scraper-own-root", false)
+		scopedCost(root, "i-own-scraper", "reattribute-own-scraper",
+			models.ConfigCost{ScraperID: &mine})
+		resource := createScrapedConfig(mine, "Test::Resource", "i-own-scraper")
+
+		Expect(ReattributeConfigCosts.Fn(job.New(DefaultContext))).To(Succeed())
+
+		Expect(targetsOf("reattribute-own-scraper")).To(Equal([]uuid.UUID{resource, resource}))
 	})
 
 	It("is idempotent", func() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cost attribution by restricting matches to the appropriate scraper scope.
  * Added support for matching GCP resources by basename when needed.
  * Prioritized full resource names over conflicting basename matches.
  * Improved selection between live and soft-deleted resources during attribution.
  * Ensured charges without an explicit scraper are attributed using the emitting scraper when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->