### PR TITLE
perf(ci): consolidate resource generation and untagged vet

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,12 +21,14 @@ jobs:
 
       - name: Generate resources
         run: make resources
-      - name: Verify generated CRDs are committed
+      - name: Verify generated resources and formatting are committed
         run: |
-          if [ -n "$(git status --porcelain -- chart/crds)" ]; then
-            git status --short -- chart/crds
-            echo "::error::Generated CRDs are out of date. Run 'make manifests' and commit the changes."
+          if [ -n "$(git status --porcelain -- '*.go' chart/crds config/schemas)" ]; then
+            git status --short -- '*.go' chart/crds config/schemas
+            echo "::error::Generated resources or Go formatting are out of date. Run 'make resources' and commit the changes."
             exit 1
           fi
+      - name: Vet
+        run: make vet
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ name: Test
 permissions:
   contents: read
 
+# Lint verifies generation, formatting and untagged vet. These suites use the
+# committed generated files so each variant need not repeat that preparation.
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -39,7 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: make envtest
       - name: Test
-        run: make test
+        run: make gotest
 
   test-playwright:
     runs-on: ubuntu-latest
@@ -160,7 +162,7 @@ jobs:
             postgrest
           GITHUB_TOKEN: ${{ github.token }}
       - name: Test
-        run: make test-prod
+        run: make envtest gotest-prod
 
   clickhouse-e2e:
     runs-on: ubuntu-latest
@@ -212,7 +214,7 @@ jobs:
       - name: Setup
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: make manifests generate fmt vet envtest
+        run: make envtest
       - name: Test
         run: make test-fast
 


### PR DESCRIPTION
Full, production and slim CI jobs repeated generation, formatting and the same untagged vet pass; slim preparation alone took 9m45s in the sampled run.

- Keep generation and explicit full vet in the existing Lint job; verify committed Go formatting, generated Go, JSON schemas and CRDs.
- Use existing suite leaf targets with envtest provisioning retained; local Makefile entry points remain unchanged.
- Keep Lint required when merging: committed generated output is now the shared contract, without adding an artifact dependency to every job.