### PR TITLE
perf(build): exclude Go compiler scratch from Docker cache layers

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -59,7 +59,10 @@ COPY ./ ./
 
 COPY --from=rust-builder /app/external/diffgen/target/release ./external/diffgen/target/release
 
-RUN if [ "$BUILDARCH" != "$TARGETARCH" ]; then \
+## Keep compiler scratch out of mode=max layer exports. GHA does not persist
+## this mount across fresh builders; dependency layers remain cacheable.
+RUN --mount=type=cache,id=config-db-go-${TARGETARCH},target=/root/.cache/go-build \
+    if [ "$BUILDARCH" != "$TARGETARCH" ]; then \
     case "$TARGETARCH" in \
     amd64) export CC=x86_64-linux-gnu-gcc ;; \
     arm64) export CC=aarch64-linux-gnu-gcc ;; \


### PR DESCRIPTION
The sampled release amd64 image spent 14m47s exporting GHA cache, longer than its Go compilation. Compiler scratch was included in the intermediate build layer.

- Mount `/root/.cache/go-build` as an architecture-scoped BuildKit cache so compiler scratch is excluded from exported layers.
- Retain `mode=max`, dependency layers, both platforms and existing image contents; no registry or infrastructure changes.
- GHA does not export cache-mount contents. This reduces cache footprint; it does not establish incremental Go compilation across fresh hosted builders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved production build caching to help reduce build times across target architectures.
  * Existing cross-compilation and build behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->